### PR TITLE
Support named databases

### DIFF
--- a/integrations/mcp-memgraph/README.md
+++ b/integrations/mcp-memgraph/README.md
@@ -154,6 +154,15 @@ docker run --rm \
   mcp-memgraph:latest
 ```
 
+### Docker environment variables
+
+- `MEMGRAPH_URL`: The Bolt URL of the Memgraph instance to connect to. Default: `bolt://host.docker.internal:7687`
+    - The default value allows you to connect to a Memgraph instance running on your host machine from within the Docker container.
+- `MEMGRAPH_USER`: The username for authentication. Default: `memgraph`
+- `MEMGRAPH_PASSWORD`: The password for authentication. Default: empty
+- `MEMGRAPH_DATABASE`: The database name to connect to. Default: `memgraph`
+- `MCP_TRANSPORT`: The transport protocol to use. Options: `http` (default), `stdio`
+
 ### Connecting from VS Code (HTTP server)
 
 If you are using VS Code MCP extension or similar, your configuration for an HTTP server would look like:

--- a/integrations/mcp-memgraph/README.md
+++ b/integrations/mcp-memgraph/README.md
@@ -154,7 +154,12 @@ docker run --rm \
   mcp-memgraph:latest
 ```
 
-### Docker environment variables
+
+## ⚙️ Configuration
+
+### Environment Variables
+
+The following environment variables can be used to configure the Memgraph MCP Server, whether running with Docker or directly (e.g., with `uv` or `python`).
 
 - `MEMGRAPH_URL`: The Bolt URL of the Memgraph instance to connect to. Default: `bolt://host.docker.internal:7687`
     - The default value allows you to connect to a Memgraph instance running on your host machine from within the Docker container.
@@ -162,6 +167,8 @@ docker run --rm \
 - `MEMGRAPH_PASSWORD`: The password for authentication. Default: empty
 - `MEMGRAPH_DATABASE`: The database name to connect to. Default: `memgraph`
 - `MCP_TRANSPORT`: The transport protocol to use. Options: `http` (default), `stdio`
+
+You can set these environment variables in your shell, in your Docker run command, or in your deployment environment. 
 
 ### Connecting from VS Code (HTTP server)
 

--- a/integrations/mcp-memgraph/src/mcp_memgraph/server.py
+++ b/integrations/mcp-memgraph/src/mcp_memgraph/server.py
@@ -34,7 +34,7 @@ db = Memgraph(
     url=MEMGRAPH_URL,
     username=MEMGRAPH_USER,
     password=MEMGRAPH_PASSWORD,
-    database=MEMGRAPH_DATABASE,
+    memgraph_config={"database": MEMGRAPH_DATABASE},
 )
 
 

--- a/integrations/mcp-memgraph/src/mcp_memgraph/server.py
+++ b/integrations/mcp-memgraph/src/mcp_memgraph/server.py
@@ -34,7 +34,7 @@ db = Memgraph(
     url=MEMGRAPH_URL,
     username=MEMGRAPH_USER,
     password=MEMGRAPH_PASSWORD,
-    memgraph_config={"database": MEMGRAPH_DATABASE},
+    database=MEMGRAPH_DATABASE,
 )
 
 

--- a/integrations/mcp-memgraph/src/mcp_memgraph/server.py
+++ b/integrations/mcp-memgraph/src/mcp_memgraph/server.py
@@ -25,14 +25,16 @@ mcp = FastMCP("mcp-memgraph", stateless_http=True)
 MEMGRAPH_URL = os.environ.get("MEMGRAPH_URL", "bolt://localhost:7687")
 MEMGRAPH_USER = os.environ.get("MEMGRAPH_USER", "")
 MEMGRAPH_PASSWORD = os.environ.get("MEMGRAPH_PASSWORD", "")
+MEMGRAPH_DATABASE = os.environ.get("MEMGRAPH_DATABASE", "memgraph")
 
-logger.info(f"Connecting to Memgraph at {MEMGRAPH_URL} with user '{MEMGRAPH_USER}'")
+logger.info(f"Connecting to Memgraph db '{MEMGRAPH_DATABASE}' at {MEMGRAPH_URL} with user '{MEMGRAPH_USER}'")
 
 # Initialize Memgraph client
 db = Memgraph(
     url=MEMGRAPH_URL,
     username=MEMGRAPH_USER,
     password=MEMGRAPH_PASSWORD,
+    database=MEMGRAPH_DATABASE,
 )
 
 

--- a/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
@@ -13,8 +13,7 @@ class Memgraph:
         url: str = None,
         username: str = None,
         password: str = None,
-        *,
-        memgraph_config: Optional[Dict] = None,
+        database: str = None,
         driver_config: Optional[Dict] = None,
     ):
         """
@@ -30,7 +29,7 @@ class Memgraph:
             url: The Memgraph connection URL
             username: Username for authentication
             password: Password for authentication
-            memgraph_config: Optional dict for Memgraph-specific config (e.g., {"database": "mydb"})
+            database: The database name to connect to (default: "memgraph")
             driver_config: Additional Neo4j driver configuration
         """
 
@@ -43,11 +42,7 @@ class Memgraph:
             url, auth=(username, password), **(driver_config or {})
         )
 
-        # Determine database name: memgraph_config > env > default
-        if memgraph_config and "database" in memgraph_config:
-            self.database = memgraph_config["database"]
-        else:
-            self.database = os.environ.get("MEMGRAPH_DATABASE", "memgraph")
+        self.database = database or os.environ.get("MEMGRAPH_DATABASE", "memgraph")
 
         try:
             import neo4j

--- a/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
@@ -13,7 +13,8 @@ class Memgraph:
         url: str = None,
         username: str = None,
         password: str = None,
-        database: str = None,
+        *,
+        memgraph_config: Optional[Dict] = None,
         driver_config: Optional[Dict] = None,
     ):
         """
@@ -24,12 +25,13 @@ class Memgraph:
         - MEMGRAPH_USER (default: "")
         - MEMGRAPH_PASSWORD (default: "")
         - MEMGRAPH_DATABASE (default: "memgraph")
+        - memgraph_config: Optional dict for additional Memgraph-specific config (e.g., {"database": "mydb"})
 
         Args:
             url: The Memgraph connection URL
             username: Username for authentication
             password: Password for authentication
-            database: The database name to connect to (default: "memgraph")
+            memgraph_config: Optional dict for Memgraph-specific config (e.g., {"database": "mydb"})
             driver_config: Additional Neo4j driver configuration
         """
 
@@ -42,7 +44,11 @@ class Memgraph:
             url, auth=(username, password), **(driver_config or {})
         )
 
-        self.database = database or os.environ.get("MEMGRAPH_DATABASE", "memgraph")
+        # Determine database name: memgraph_config > env > default
+        if memgraph_config and "database" in memgraph_config:
+            self.database = memgraph_config["database"]
+        else:
+            self.database = os.environ.get("MEMGRAPH_DATABASE", "memgraph")
 
         try:
             import neo4j

--- a/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
@@ -25,7 +25,6 @@ class Memgraph:
         - MEMGRAPH_USER (default: "")
         - MEMGRAPH_PASSWORD (default: "")
         - MEMGRAPH_DATABASE (default: "memgraph")
-        - memgraph_config: Optional dict for additional Memgraph-specific config (e.g., {"database": "mydb"})
 
         Args:
             url: The Memgraph connection URL


### PR DESCRIPTION
This probably is a breaking change with the mid-signature adjustment to the Memgraph object from the toolkit. 

If that needs to be adjusted, let me know. It made more sense where I placed it than after the dictionary, but maybe it belongs in the dictionary as a parameter? Looking for guidance.