### PR TITLE
Fix naming of base toolbox. 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @antejavor @katarinasupe
+* @antejavor 

--- a/memgraph-toolbox/README.md
+++ b/memgraph-toolbox/README.md
@@ -33,13 +33,13 @@ Example:
 ```python
 from memgraph_toolbox.tools.trigger import ShowTriggersTool
 from memgraph_toolbox.api.memgraph import Memgraph
-from memgraph_toolbox.memgraph_toolkit import MemgraphToolkit
+from memgraph_toolbox.memgraph_toolbox import MemgraphToolbox
 
 # Connect to Memgraph
 db = Memgraph(url="bolt://localhost:7687", username="", password="")
 
 # Show available tools
-toolbox = MemgraphToolkit(db)
+toolbox = MemgraphToolbox(db)
 for tool in toolbox.get_all_tools():
     print(f"Tool Name: {tool.name}, Description: {tool.description}")
 

--- a/memgraph-toolbox/src/memgraph_toolbox/api/toolbox.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/api/toolbox.py
@@ -2,9 +2,9 @@ from typing import Dict, List
 from .tool import BaseTool
 
 
-class BaseToolkit:
+class BaseToolbox:
     """
-    A Toolkit for managing tools.
+    A Toolbox for managing tools.
     """
 
     def __init__(self):
@@ -15,11 +15,11 @@ class BaseToolkit:
         Add a new tool in the registry.
 
         Raises:
-            ValueError: If a tool with the same name is already toolkit.
+            ValueError: If a tool with the same name is already in toolbox.
         """
         if tool.name in self._tools:
             raise ValueError(
-                f"Tool with name '{tool.name}' is already present in toolkit."
+                f"Tool with name '{tool.name}' is already present in toolbox."
             )
         self._tools[tool.name] = tool
 

--- a/memgraph-toolbox/src/memgraph_toolbox/memgraph_toolbox.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/memgraph_toolbox.py
@@ -1,8 +1,5 @@
-from typing import Optional
-
-
 from .api.memgraph import Memgraph
-from .api.toolkit import BaseToolkit
+from .api.toolbox import BaseToolbox
 
 # Import all tool classes
 from .tools.betweenness_centrality import BetweennessCentralityTool
@@ -16,10 +13,10 @@ from .tools.storage import ShowStorageInfoTool
 from .tools.trigger import ShowTriggersTool
 
 
-class MemgraphToolkit(BaseToolkit):
+class MemgraphToolbox(BaseToolbox):
     """
     A toolbox that contains all available Memgraph tools.
-    This class extends the BaseToolkit to provide a convenient way to
+    This class extends the BaseToolbox to provide a convenient way to
     access all Memgraph-related tools.
     """
 

--- a/memgraph-toolbox/src/memgraph_toolbox/tests/test_toolbox.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/tests/test_toolbox.py
@@ -2,19 +2,19 @@ from typing import Any, Dict, List
 
 import pytest
 
-from ..api.toolkit import BaseToolkit
-from ..memgraph_toolkit import MemgraphToolkit
+from ..api.toolbox import BaseToolbox
+from ..memgraph_toolbox import MemgraphToolbox
 from ..api.tool import BaseTool
 from ..utils.logging import logger_init
 from ..api.memgraph import Memgraph
 
-logger = logger_init("test-toolkit")  # Set up logger for the test
+logger = logger_init("test-toolbox")  # Set up logger for the test
 
 
-def test_toolkit():
-    """Test the Toolkit class."""
+def test_base_toolbox():
+    """Test the Toolbox class."""
 
-    toolkit = BaseToolkit()
+    toolkit = BaseToolbox()
 
     class DummyTool(BaseTool):
         def __init__(self):
@@ -37,8 +37,8 @@ def test_toolkit():
         toolkit.add_tool(dummy_tool)
 
 
-def test_memgraph_toolkit():
-    """Test the Memgraph Toolkit."""
+def test_memgraph_toolbox():
+    """Test the Memgraph Toolbox."""
 
     url = "bolt://localhost:7687"
     user = ""
@@ -46,7 +46,7 @@ def test_memgraph_toolkit():
 
     memgraph_client = Memgraph(url=url, username=user, password=password)
 
-    toolkit = MemgraphToolkit(db=memgraph_client)
+    toolkit = MemgraphToolbox(db=memgraph_client)
 
     tools = toolkit.get_all_tools()
 


### PR DESCRIPTION
The name `toolkit` was introduced by accident. 