### PR TITLE
 Release downstream packages with memgraph-toolbox 0.1.11

### DIFF
--- a/.github/workflows/release-langchain-memgraph.yaml
+++ b/.github/workflows/release-langchain-memgraph.yaml
@@ -23,5 +23,5 @@ jobs:
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          uv build
-          uv publish
+          uv build --out-dir dist
+          uv publish dist/*

--- a/.github/workflows/release-lightrag-memgraph.yaml
+++ b/.github/workflows/release-lightrag-memgraph.yaml
@@ -24,4 +24,4 @@ jobs:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           uv build --out-dir dist
-          uv publish
+          uv publish dist/*

--- a/.github/workflows/release-mcp-memgraph.yaml
+++ b/.github/workflows/release-mcp-memgraph.yaml
@@ -30,8 +30,8 @@ jobs:
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          uv build
-          uv publish
+          uv build --out-dir dist
+          uv publish dist/*
 
       - name: Extract version
         id: version

--- a/.github/workflows/release-structured2graph.yaml
+++ b/.github/workflows/release-structured2graph.yaml
@@ -1,4 +1,4 @@
-name: Release unstructured2graph
+name: Release structured2graph
 
 on:
   workflow_dispatch:
@@ -18,8 +18,8 @@ jobs:
       - name: Install uv
         run: python -m pip install uv
 
-      - name: Build and release unstructured2graph
-        working-directory: unstructured2graph
+      - name: Build and release structured2graph
+        working-directory: agents/sql2graph
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |

--- a/.github/workflows/release-toolbox.yaml
+++ b/.github/workflows/release-toolbox.yaml
@@ -23,5 +23,5 @@ jobs:
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          uv build
-          uv publish
+          uv build --out-dir dist
+          uv publish dist/*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,6 @@ on:
       - "integrations/mcp-memgraph/**"
       - "integrations/langchain-memgraph/**"
       - "integrations/lightrag-memgraph/**"
-      - "agents/sql2graph/**"
       - "unstructured2graph/**"
       - "context-graph/skills-graph/**"
       - "context-graph/agent-context-graph/**"
@@ -19,7 +18,6 @@ on:
       - "integrations/mcp-memgraph/**"
       - "integrations/langchain-memgraph/**"
       - "integrations/lightrag-memgraph/**"
-      - "agents/sql2graph/**"
       - "unstructured2graph/**"
       - "context-graph/skills-graph/**"
       - "context-graph/agent-context-graph/**"
@@ -32,7 +30,6 @@ jobs:
       mcp-memgraph: ${{ steps.filter.outputs.mcp-memgraph }}
       langchain-memgraph: ${{ steps.filter.outputs.langchain-memgraph }}
       lightrag-memgraph: ${{ steps.filter.outputs.lightrag-memgraph }}
-      structured2graph: ${{ steps.filter.outputs.structured2graph }}
       unstructured2graph: ${{ steps.filter.outputs.unstructured2graph }}
       agent-context-graph: ${{ steps.filter.outputs.agent-context-graph }}
       skills-graph: ${{ steps.filter.outputs.skills-graph }}
@@ -55,9 +52,6 @@ jobs:
               - 'memgraph-toolbox/**'
             lightrag-memgraph:
               - 'integrations/lightrag-memgraph/**'
-              - 'memgraph-toolbox/**'
-            structured2graph:
-              - 'agents/sql2graph/**'
               - 'memgraph-toolbox/**'
             unstructured2graph:
               - 'unstructured2graph/**'
@@ -220,32 +214,6 @@ jobs:
           uv venv
           uv pip install -e .[test]
           .venv/bin/python -m pytest .
-
-  test-structured2graph:
-    needs: changes
-    if: ${{ needs.changes.outputs.structured2graph == 'true' }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.12", "3.13"]
-    defaults:
-      run:
-        working-directory: agents/sql2graph
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        run: python -m pip install uv
-        working-directory: .
-
-      - name: Install dependencies and run tests
-        run: uv run --group dev pytest .
 
   test-agent-context-graph:
     needs: changes

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,7 @@ on:
       - "integrations/mcp-memgraph/**"
       - "integrations/langchain-memgraph/**"
       - "integrations/lightrag-memgraph/**"
+      - "agents/sql2graph/**"
       - "unstructured2graph/**"
       - "context-graph/skills-graph/**"
       - "context-graph/agent-context-graph/**"
@@ -18,6 +19,7 @@ on:
       - "integrations/mcp-memgraph/**"
       - "integrations/langchain-memgraph/**"
       - "integrations/lightrag-memgraph/**"
+      - "agents/sql2graph/**"
       - "unstructured2graph/**"
       - "context-graph/skills-graph/**"
       - "context-graph/agent-context-graph/**"
@@ -30,6 +32,7 @@ jobs:
       mcp-memgraph: ${{ steps.filter.outputs.mcp-memgraph }}
       langchain-memgraph: ${{ steps.filter.outputs.langchain-memgraph }}
       lightrag-memgraph: ${{ steps.filter.outputs.lightrag-memgraph }}
+      structured2graph: ${{ steps.filter.outputs.structured2graph }}
       unstructured2graph: ${{ steps.filter.outputs.unstructured2graph }}
       agent-context-graph: ${{ steps.filter.outputs.agent-context-graph }}
       skills-graph: ${{ steps.filter.outputs.skills-graph }}
@@ -52,6 +55,9 @@ jobs:
               - 'memgraph-toolbox/**'
             lightrag-memgraph:
               - 'integrations/lightrag-memgraph/**'
+              - 'memgraph-toolbox/**'
+            structured2graph:
+              - 'agents/sql2graph/**'
               - 'memgraph-toolbox/**'
             unstructured2graph:
               - 'unstructured2graph/**'
@@ -213,6 +219,35 @@ jobs:
         run: |
           uv venv
           uv pip install -e .[test]
+          .venv/bin/python -m pytest .
+
+  test-structured2graph:
+    needs: changes
+    if: ${{ needs.changes.outputs.structured2graph == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12", "3.13"]
+    defaults:
+      run:
+        working-directory: agents/sql2graph
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: python -m pip install uv
+        working-directory: .
+
+      - name: Install dependencies and run tests
+        run: |
+          uv venv
+          uv pip install -e . --group dev
           .venv/bin/python -m pytest .
 
   test-agent-context-graph:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -245,10 +245,7 @@ jobs:
         working-directory: .
 
       - name: Install dependencies and run tests
-        run: |
-          uv venv
-          uv pip install -e . --group dev
-          .venv/bin/python -m pytest .
+        run: uv run --group dev pytest .
 
   test-agent-context-graph:
     needs: changes

--- a/agents/sql2graph/Dockerfile
+++ b/agents/sql2graph/Dockerfile
@@ -11,7 +11,7 @@ ENV EDITOR=vi
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Install the released package from PyPI
-RUN uv pip install --system structured2graph==0.2.1
+RUN uv pip install --system structured2graph==0.2.2
 
 # Copy .env.example as reference; users supply real values at runtime
 # via: docker run -it --env-file .env memgraph/structured2graph

--- a/agents/sql2graph/pyproject.toml
+++ b/agents/sql2graph/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "sqlalchemy>=2.0.0",
     "pymysql>=1.1.0",
-    "memgraph-toolbox>=0.1.10",
+    "memgraph-toolbox>=0.1.11",
 ]
 
 [project.urls]

--- a/agents/sql2graph/pyproject.toml
+++ b/agents/sql2graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "structured2graph"
-version = "0.2.1"
+version = "0.2.2"
 description = "Database migration agent from structured data (e.g. SQL) to graph."
 readme = "README.md"
 license = "MIT"

--- a/agents/sql2graph/uv.lock
+++ b/agents/sql2graph/uv.lock
@@ -728,16 +728,16 @@ wheels = [
 
 [[package]]
 name = "memgraph-toolbox"
-version = "0.1.10"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "neo4j" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/26/220e0e29a2b54b1a1293265f34122f26cfd72e742049416ec0f1f1b8e56b/memgraph_toolbox-0.1.10.tar.gz", hash = "sha256:02a92d41e5b3c46ad86dbfef21acfcf7a5ae385e6a99718a1eb5803414cef177", size = 190161 }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/6d/9b144a2dcf594903fc041cab66b9782a67d7377940af8d6dcebb6aa5295e/memgraph_toolbox-0.1.11.tar.gz", hash = "sha256:ffe974f52235b93c65bb0459deaf718d4d6f53dd3f1eb119b00b6619d6e94933", size = 203781 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/e4/0f0b9aec35948afba78672bb6064f5e0d52b17c6ba09b98b1e2be7895a0a/memgraph_toolbox-0.1.10-py3-none-any.whl", hash = "sha256:76c1c902853a1dcc7c64bfbc58c2eae55898bbc0ef168508348e1d1b500e7b25", size = 32026 },
+    { url = "https://files.pythonhosted.org/packages/ef/d4/ff3a7e8353478b00741e7f22b8e12b24d373a7d77a20f8b001b81b575a58/memgraph_toolbox-0.1.11-py3-none-any.whl", hash = "sha256:34e7b81e297aa7985e00f76c1a24fbbb0134d4dd4a309a56fe31ea538bbaf508", size = 32753 },
 ]
 
 [[package]]
@@ -1690,7 +1690,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=2.0.0" },
     { name = "langchain-openai", specifier = ">=0.2.0" },
     { name = "langgraph", specifier = ">=1.0.10" },
-    { name = "memgraph-toolbox", specifier = ">=0.1.10" },
+    { name = "memgraph-toolbox", specifier = ">=0.1.11" },
     { name = "mysql-connector-python", specifier = ">=9.0.0" },
     { name = "neo4j", specifier = ">=5.28.1" },
     { name = "openai", specifier = ">=1.0.0" },

--- a/agents/sql2graph/uv.lock
+++ b/agents/sql2graph/uv.lock
@@ -1655,7 +1655,7 @@ wheels = [
 
 [[package]]
 name = "structured2graph"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/context-graph/agent-context-graph/pyproject.toml
+++ b/context-graph/agent-context-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-context-graph"
-version = "0.1.0"
+version = "0.1.1"
 description = "Connect agent SDKs to context-graph components (actions-graph, skills-graph, etc.)"
 readme = "README.md"
 license = { text = "MIT" }
@@ -12,7 +12,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "memgraph-toolbox",
+    "memgraph-toolbox>=0.1.11",
 ]
 
 [project.scripts]

--- a/context-graph/skills-graph/pyproject.toml
+++ b/context-graph/skills-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skills-graph"
-version = "0.1.0"
+version = "0.1.1"
 description = "Persist, retrieve and evolve AI skills in Memgraph"
 readme = "README.md"
 license = { text = "MIT" }
@@ -12,12 +12,12 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "memgraph-toolbox",
+    "memgraph-toolbox>=0.1.11",
 ]
 
 [project.optional-dependencies]
 agent-context-graph = [
-    "agent-context-graph",
+    "agent-context-graph>=0.1.1",
 ]
 test = [
     "pytest>=9.0.3",

--- a/integrations/langchain-memgraph/pyproject.toml
+++ b/integrations/langchain-memgraph/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "langchain-core>=1.2.28",
     "langchain-classic>=1.0.0",
     "neo4j>=5.28.1",
-    "memgraph-toolbox>=0.1.10",
+    "memgraph-toolbox>=0.1.11",
     "langchain>=1.0.0",
 ]
 

--- a/integrations/langchain-memgraph/pyproject.toml
+++ b/integrations/langchain-memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-memgraph"
-version = "0.1.13"
+version = "0.1.14"
 description = "An integration package connecting Memgraph and LangChain"
 authors = [{ name = "Ante Javor", email = "ante.javor@memgraph.com" }]
 readme = "README.md"

--- a/integrations/langchain-memgraph/uv.lock
+++ b/integrations/langchain-memgraph/uv.lock
@@ -918,7 +918,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'test'", specifier = ">=1.1.0" },
     { name = "langchain-tests", marker = "extra == 'test'", specifier = ">=0.3.0" },
     { name = "langgraph", marker = "extra == 'test'", specifier = ">=1.1.0" },
-    { name = "memgraph-toolbox", specifier = ">=0.1.10" },
+    { name = "memgraph-toolbox", specifier = ">=0.1.11" },
     { name = "neo4j", specifier = ">=5.28.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.26.0" },
@@ -1088,16 +1088,16 @@ wheels = [
 
 [[package]]
 name = "memgraph-toolbox"
-version = "0.1.10"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "neo4j" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/26/220e0e29a2b54b1a1293265f34122f26cfd72e742049416ec0f1f1b8e56b/memgraph_toolbox-0.1.10.tar.gz", hash = "sha256:02a92d41e5b3c46ad86dbfef21acfcf7a5ae385e6a99718a1eb5803414cef177", size = 190161 }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/6d/9b144a2dcf594903fc041cab66b9782a67d7377940af8d6dcebb6aa5295e/memgraph_toolbox-0.1.11.tar.gz", hash = "sha256:ffe974f52235b93c65bb0459deaf718d4d6f53dd3f1eb119b00b6619d6e94933", size = 203781 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/e4/0f0b9aec35948afba78672bb6064f5e0d52b17c6ba09b98b1e2be7895a0a/memgraph_toolbox-0.1.10-py3-none-any.whl", hash = "sha256:76c1c902853a1dcc7c64bfbc58c2eae55898bbc0ef168508348e1d1b500e7b25", size = 32026 },
+    { url = "https://files.pythonhosted.org/packages/ef/d4/ff3a7e8353478b00741e7f22b8e12b24d373a7d77a20f8b001b81b575a58/memgraph_toolbox-0.1.11-py3-none-any.whl", hash = "sha256:34e7b81e297aa7985e00f76c1a24fbbb0134d4dd4a309a56fe31ea538bbaf508", size = 32753 },
 ]
 
 [[package]]

--- a/integrations/langchain-memgraph/uv.lock
+++ b/integrations/langchain-memgraph/uv.lock
@@ -884,7 +884,7 @@ wheels = [
 
 [[package]]
 name = "langchain-memgraph"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "langchain" },

--- a/integrations/lightrag-memgraph/pyproject.toml
+++ b/integrations/lightrag-memgraph/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "lightrag-hku>=1.4.14",
-    "memgraph-toolbox>=0.1.10",
+    "memgraph-toolbox>=0.1.11",
     "numpy>=1.22.0",
     "anthropic>=0.40.0",
     "openai>=1.0.0",

--- a/integrations/lightrag-memgraph/pyproject.toml
+++ b/integrations/lightrag-memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lightrag-memgraph"
-version = "0.1.5"
+version = "0.1.6"
 description = "LightRAG integration with Memgraph"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/mcp-memgraph/pyproject.toml
+++ b/integrations/mcp-memgraph/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "httpx>=0.28.1",
   "mcp[cli]>=1.23.0",
   "neo4j>=5.28.1",
-  "memgraph-toolbox>=0.1.10",
+  "memgraph-toolbox>=0.1.11",
   "fastmcp>=3.2.0",
 ]
 

--- a/integrations/mcp-memgraph/pyproject.toml
+++ b/integrations/mcp-memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-memgraph"
-version = "0.1.11"
+version = "0.1.12"
 description = "MCP integration and utilities for Memgraph MCP server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/mcp-memgraph/uv.lock
+++ b/integrations/mcp-memgraph/uv.lock
@@ -865,7 +865,7 @@ cli = [
 
 [[package]]
 name = "mcp-memgraph"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/integrations/mcp-memgraph/uv.lock
+++ b/integrations/mcp-memgraph/uv.lock
@@ -891,7 +891,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'test'", specifier = ">=1.23.0" },
-    { name = "memgraph-toolbox", specifier = ">=0.1.10" },
+    { name = "memgraph-toolbox", specifier = ">=0.1.11" },
     { name = "neo4j", specifier = ">=5.28.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.20.3" },
@@ -910,16 +910,16 @@ wheels = [
 
 [[package]]
 name = "memgraph-toolbox"
-version = "0.1.10"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "neo4j" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/26/220e0e29a2b54b1a1293265f34122f26cfd72e742049416ec0f1f1b8e56b/memgraph_toolbox-0.1.10.tar.gz", hash = "sha256:02a92d41e5b3c46ad86dbfef21acfcf7a5ae385e6a99718a1eb5803414cef177", size = 190161 }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/6d/9b144a2dcf594903fc041cab66b9782a67d7377940af8d6dcebb6aa5295e/memgraph_toolbox-0.1.11.tar.gz", hash = "sha256:ffe974f52235b93c65bb0459deaf718d4d6f53dd3f1eb119b00b6619d6e94933", size = 203781 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/e4/0f0b9aec35948afba78672bb6064f5e0d52b17c6ba09b98b1e2be7895a0a/memgraph_toolbox-0.1.10-py3-none-any.whl", hash = "sha256:76c1c902853a1dcc7c64bfbc58c2eae55898bbc0ef168508348e1d1b500e7b25", size = 32026 },
+    { url = "https://files.pythonhosted.org/packages/ef/d4/ff3a7e8353478b00741e7f22b8e12b24d373a7d77a20f8b001b81b575a58/memgraph_toolbox-0.1.11-py3-none-any.whl", hash = "sha256:34e7b81e297aa7985e00f76c1a24fbbb0134d4dd4a309a56fe31ea538bbaf508", size = 32753 },
 ]
 
 [[package]]

--- a/memgraph-toolbox/pyproject.toml
+++ b/memgraph-toolbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memgraph-toolbox"
-version = "0.1.10"
+version = "0.1.11"
 description = "Memgraph toolbox library for Memgraph AI tools and utilities"
 readme = "README.md"
 authors = [

--- a/memgraph-toolbox/uv.lock
+++ b/memgraph-toolbox/uv.lock
@@ -1220,7 +1220,7 @@ wheels = [
 
 [[package]]
 name = "memgraph-toolbox"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 dependencies = [
-    "memgraph-toolbox",
+    "memgraph-toolbox>=0.1.11",
     "mcp[cli]>=1.23.0",
     "neo4j>=5.28.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memgraph-ai"
-version = "0.1.8"
+version = "0.1.9"
 description = "Memgraph AI Toolkit"
 readme = "README.md"
 license = { text = "MIT" }

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "unstructured>=0.18.18",
     "lightrag-memgraph>=0.1.5",
-    "memgraph-toolbox>=0.1.10",
+    "memgraph-toolbox>=0.1.11",
 ]
 [project.optional-dependencies]
 all-docs = [

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unstructured2graph"
-version = "0.1.4"
+version = "0.1.5"
 description = "Convert unstructured documents into knowledge graphs"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "unstructured>=0.18.18",
-    "lightrag-memgraph>=0.1.5",
+    "lightrag-memgraph>=0.1.6",
     "memgraph-toolbox>=0.1.11",
 ]
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "agent-context-graph"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "context-graph/agent-context-graph" }
 dependencies = [
     { name = "memgraph-toolbox" },
@@ -3060,7 +3060,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'test'", specifier = ">=1.1.0" },
     { name = "langchain-tests", marker = "extra == 'test'", specifier = ">=0.3.0" },
     { name = "langgraph", marker = "extra == 'test'", specifier = ">=1.1.0" },
-    { name = "memgraph-toolbox", specifier = ">=0.1.10" },
+    { name = "memgraph-toolbox", specifier = ">=0.1.11" },
     { name = "neo4j", specifier = ">=5.28.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.26.0" },
@@ -3863,7 +3863,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'test'", specifier = ">=1.23.0" },
-    { name = "memgraph-toolbox", specifier = ">=0.1.10" },
+    { name = "memgraph-toolbox", specifier = ">=0.1.11" },
     { name = "neo4j", specifier = ">=5.28.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.20.3" },
@@ -3899,7 +3899,7 @@ requires-dist = [
 
 [[package]]
 name = "memgraph-toolbox"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "memgraph-toolbox" }
 dependencies = [
     { name = "neo4j" },
@@ -8324,7 +8324,7 @@ wheels = [
 
 [[package]]
 name = "skills-graph"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "context-graph/skills-graph" }
 dependencies = [
     { name = "memgraph-toolbox" },
@@ -8622,7 +8622,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=2.0.0" },
     { name = "langchain-openai", specifier = ">=0.2.0" },
     { name = "langgraph", specifier = ">=1.0.10" },
-    { name = "memgraph-toolbox", specifier = ">=0.1.10" },
+    { name = "memgraph-toolbox", specifier = ">=0.1.11" },
     { name = "mysql-connector-python", specifier = ">=9.0.0" },
     { name = "neo4j", specifier = ">=5.28.1" },
     { name = "openai", specifier = ">=1.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3026,7 +3026,7 @@ wheels = [
 
 [[package]]
 name = "langchain-memgraph"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "integrations/langchain-memgraph" }
 dependencies = [
     { name = "langchain" },
@@ -3238,7 +3238,7 @@ wheels = [
 
 [[package]]
 name = "lightrag-memgraph"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "integrations/lightrag-memgraph" }
 dependencies = [
     { name = "anthropic" },
@@ -3837,7 +3837,7 @@ cli = [
 
 [[package]]
 name = "mcp-memgraph"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "integrations/mcp-memgraph" }
 dependencies = [
     { name = "fastmcp" },
@@ -8587,7 +8587,7 @@ wheels = [
 
 [[package]]
 name = "structured2graph"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "agents/sql2graph" }
 dependencies = [
     { name = "anthropic" },
@@ -9751,7 +9751,7 @@ wheels = [
 
 [[package]]
 name = "unstructured2graph"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "unstructured2graph" }
 dependencies = [
     { name = "lightrag-memgraph" },


### PR DESCRIPTION
Updates downstream packages to consume memgraph-toolbox 0.1.11 and prepares their next package releases.

Changes:

Bumps versions for MCP, LangChain, LightRAG, structured2graph, and unstructured2graph packages.
Refreshes affected uv.lock files.
Fixes release workflows to build into explicit dist/ directories before publishing.
Adds a structured2graph release workflow.
Removes structured2graph from integration CI testing for now.