### PR TITLE
Fix component naming for PyPi

### DIFF
--- a/.github/workflows/release-sessions-graph.yaml
+++ b/.github/workflows/release-sessions-graph.yaml
@@ -1,0 +1,26 @@
+name: Release sessions-graph
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.11.0
+
+      - name: Install uv
+        run: python -m pip install uv
+
+      - name: Build and release sessions-graph
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          uv build --package sessions-graph
+          uv publish dist/*

--- a/context-graph/sessions-graph/README.md
+++ b/context-graph/sessions-graph/README.md
@@ -1,27 +1,27 @@
-# Memory Graph
+# Sessions Graph
 
-Memory Graph is the [Context Graph](../CONTEXT-MAP.md) component for cross-session recall. It stores free-form text assertions — called **Memories** — written explicitly by agents, and makes them searchable in future sessions.
+Sessions Graph is the [Context Graph](../CONTEXT-MAP.md) component for session context and cross-session recall. It is the **authority on `(:Session)` nodes** in the Context Graph family. It stores free-form text assertions — called **Memories** — written explicitly by agents, and makes them searchable in future sessions.
 
 Requires **Memgraph ≥ 3.6** (text search is stable from that release).
 
 ## Installation
 
 ```bash
-pip install memory-graph
+pip install sessions-graph
 ```
 
 To use with Agent Context Graph:
 
 ```bash
-pip install memory-graph[agent-context-graph]
+pip install sessions-graph[agent-context-graph]
 ```
 
 ## Quick start
 
 ```python
-from memory_graph import MemoryGraph
+from sessions_graph import SessionsGraph
 
-graph = MemoryGraph()   # connects via MEMGRAPH_HOST / MEMGRAPH_PORT env vars
+graph = SessionsGraph()   # connects via MEMGRAPH_HOST / MEMGRAPH_PORT env vars
 graph.setup()           # creates constraints and the text index (run once)
 
 # Write a memory
@@ -44,18 +44,18 @@ graph.delete_memory(mem.memory_id)
 
 ## Integration with Agent Context Graph
 
-Wire the `MemoryGraphConnector` into an `AgentLink` to get automatic session provenance — the connector tracks the active `session_id` and `user_id` from `SessionStartEvent` so you can reference them when saving memories.
+Wire the `SessionsGraphConnector` into an `AgentLink` to get automatic session provenance — the connector tracks the active `session_id` and `user_id` from `SessionStartEvent` so you can reference them when saving memories.
 
 ```python
-from memory_graph import MemoryGraph
-from memory_graph.connector import MemoryGraphConnector
+from sessions_graph import SessionsGraph
+from sessions_graph.connector import SessionsGraphConnector
 from agent_context_graph import AgentLink
 from agent_context_graph.adapters.claude import ClaudeAdapter
 
-graph = MemoryGraph()
+graph = SessionsGraph()
 graph.setup()
 
-connector = MemoryGraphConnector(graph)
+connector = SessionsGraphConnector(graph)
 link = AgentLink()
 link.add_connector(connector)
 
@@ -81,12 +81,12 @@ graph.save_memory(
                               ▲
               [:PRODUCED_MEMORY]
                               │
-                      (:Session {session_id})   ← provenance, created on demand
+                      (:Session {session_id})   ← shared idempotent coordination point
 ```
 
 ## Text search
 
-Memory Graph uses [Memgraph text search](https://memgraph.com/docs/querying/text-search) (powered by Tantivy) for `search_memories`. The text index is created on `setup()`:
+Sessions Graph uses [Memgraph text search](https://memgraph.com/docs/querying/text-search) (powered by Tantivy) for `search_memories`. The text index is created on `setup()`:
 
 ```cypher
 CREATE TEXT INDEX memory_content_index ON :Memory(content);

--- a/context-graph/sessions-graph/pyproject.toml
+++ b/context-graph/sessions-graph/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "memory-graph"
+name = "sessions-graph"
 version = "0.1.0"
 description = "Cross-session memory store for agents, backed by Memgraph"
 readme = "README.md"

--- a/context-graph/sessions-graph/src/sessions_graph/__init__.py
+++ b/context-graph/sessions-graph/src/sessions_graph/__init__.py
@@ -1,10 +1,10 @@
-"""Memory Graph: Cross-session memory store for agents, backed by Memgraph.
+"""Sessions Graph: Cross-session memory store for agents, backed by Memgraph.
 
 Quick start::
 
-    from memory_graph import MemoryGraph, Memory
+    from sessions_graph import SessionsGraph, Memory
 
-    graph = MemoryGraph()
+    graph = SessionsGraph()
     graph.setup()
 
     mem = graph.save_memory(user_id="alice", content="Prefers Python over TypeScript")
@@ -12,15 +12,15 @@ Quick start::
 
 Integration with Agent Context Graph::
 
-    from memory_graph import MemoryGraph
-    from memory_graph.connector import MemoryGraphConnector
+    from sessions_graph import SessionsGraph
+    from sessions_graph.connector import SessionsGraphConnector
     from agent_context_graph import AgentLink
     from agent_context_graph.adapters.claude import ClaudeAdapter
 
-    graph = MemoryGraph()
+    graph = SessionsGraph()
     graph.setup()
 
-    connector = MemoryGraphConnector(graph)
+    connector = SessionsGraphConnector(graph)
     link = AgentLink()
     link.add_connector(connector)
     adapter = ClaudeAdapter(link, session_id="s-1", session_kwargs={"user_id": "alice"})
@@ -33,7 +33,7 @@ Integration with Agent Context Graph::
     )
 """
 
-from .core import MemoryGraph
+from .core import SessionsGraph
 from .models import Memory, MemoryValidationError
 
-__all__ = ["Memory", "MemoryGraph", "MemoryValidationError"]
+__all__ = ["Memory", "MemoryValidationError", "SessionsGraph"]

--- a/context-graph/sessions-graph/src/sessions_graph/connector.py
+++ b/context-graph/sessions-graph/src/sessions_graph/connector.py
@@ -1,26 +1,22 @@
-"""Agent Context Graph connector for MemoryGraph.
-
-The connector lives inside memory-graph because MemoryGraph owns the
-interpretation of session events for provenance — Agent Context Graph
-only routes normalized runtime events.
+"""Agent Context Graph connector for SessionsGraph.
 
 The connector is intentionally thin: it watches ``SessionStartEvent`` and
-``SessionEndEvent`` to ensure that ``(:User)`` and ``(:Session)`` nodes
-exist in the graph before any :meth:`MemoryGraph.save_memory` call tries to
-wire provenance relationships.  Memory writes themselves happen through the
-:class:`MemoryGraph` Python API directly, not through the event stream.
+``SessionEndEvent`` to MERGE ``(:User)`` and ``(:Session)`` nodes so that
+provenance relationships can be wired when memories are saved.  Memory writes
+themselves happen through the :class:`SessionsGraph` Python API directly,
+not through the event stream.
 
 Usage::
 
-    from memory_graph import MemoryGraph
-    from memory_graph.connector import MemoryGraphConnector
+    from sessions_graph import SessionsGraph
+    from sessions_graph.connector import SessionsGraphConnector
     from agent_context_graph import AgentLink
     from agent_context_graph.adapters.claude import ClaudeAdapter
 
-    graph = MemoryGraph()
+    graph = SessionsGraph()
     graph.setup()
 
-    connector = MemoryGraphConnector(graph)
+    connector = SessionsGraphConnector(graph)
 
     link = AgentLink()
     link.add_connector(connector)
@@ -42,28 +38,27 @@ from agent_context_graph.events import Event, EventType, SessionEndEvent, Sessio
 from agent_context_graph.protocols import GraphConnector
 
 if TYPE_CHECKING:
-    from .core import MemoryGraph
+    from .core import SessionsGraph
 
 
 _SUPPORTED_EVENTS = {EventType.SESSION_START, EventType.SESSION_END}
 
 
-class MemoryGraphConnector(GraphConnector):
-    """Receives Agent Context Graph session events and prepares Memory Graph provenance.
+class SessionsGraphConnector(GraphConnector):
+    """Receives Agent Context Graph session events for memory provenance.
 
     On ``SESSION_START``:
-      - MERGEs a ``(:User {user_id})`` node so ownership relationships can be created.
-      - MERGEs a ``(:Session {session_id})`` node so provenance relationships can be created.
-      - Tracks ``active_user_id`` and ``active_session_id`` for convenient API access.
+      - MERGEs ``(:User {user_id})`` and ``(:Session {session_id})`` nodes.
+      - Tracks ``active_user_id`` and ``active_session_id`` for use in API calls.
 
     On ``SESSION_END``:
       - Clears the tracked active session context.
 
     Args:
-        graph: An initialised :class:`MemoryGraph` instance.
+        graph: An initialised :class:`SessionsGraph` instance.
     """
 
-    def __init__(self, graph: MemoryGraph) -> None:
+    def __init__(self, graph: SessionsGraph) -> None:
         self._graph = graph
         self._active_user_id: str | None = None
         self._active_session_id: str | None = None

--- a/context-graph/sessions-graph/src/sessions_graph/core.py
+++ b/context-graph/sessions-graph/src/sessions_graph/core.py
@@ -1,11 +1,11 @@
-"""Core MemoryGraph class for storing and recalling agent memories in Memgraph.
+"""Core SessionsGraph class for storing and recalling agent memories in Memgraph.
 
 Graph schema
 ------------
 Nodes:
     (:User  {user_id})
     (:Memory {memory_id, user_id, content, created_at, session_id?})
-    (:Session {session_id})   — created on demand for provenance only
+    (:Session {session_id})
 
 Relationships:
     (:User)-[:HAS_MEMORY]->(:Memory)
@@ -24,7 +24,7 @@ from .models import Memory, validate_content, validate_memory_id, validate_user_
 _FULLTEXT_INDEX = "memory_content_index"
 
 
-class MemoryGraph:
+class SessionsGraph:
     """Store and recall agent memories in Memgraph.
 
     Provides:
@@ -36,7 +36,7 @@ class MemoryGraph:
     """
 
     def __init__(self, memgraph: Memgraph | None = None, **kwargs: Any) -> None:
-        """Initialise MemoryGraph.
+        """Initialise SessionsGraph.
 
         Args:
             memgraph: An existing Memgraph client instance.  When *None* a new

--- a/context-graph/sessions-graph/src/sessions_graph/models.py
+++ b/context-graph/sessions-graph/src/sessions_graph/models.py
@@ -1,4 +1,4 @@
-"""Data models for Memory Graph.
+"""Data models for Sessions Graph.
 
 Defines the core data structure for a Memory — a cross-session-durable
 free-form text assertion written explicitly by an agent.

--- a/context-graph/sessions-graph/tests/test_sessions_graph.py
+++ b/context-graph/sessions-graph/tests/test_sessions_graph.py
@@ -1,4 +1,4 @@
-"""Unit tests for Memory Graph models, core, and connector.
+"""Unit tests for Sessions Graph models, core, and connector.
 
 These tests use an in-memory stub for the Memgraph client so they run
 without a live database.
@@ -9,7 +9,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from memory_graph.models import Memory, MemoryValidationError
+from sessions_graph.models import Memory, MemoryValidationError
 
 # ---------------------------------------------------------------------------
 # models
@@ -54,14 +54,14 @@ def _stub_db(rows: list | None = None):
 
 
 def _graph(rows=None):
-    from memory_graph.core import MemoryGraph
+    from sessions_graph.core import SessionsGraph
 
-    g = MemoryGraph.__new__(MemoryGraph)
+    g = SessionsGraph.__new__(SessionsGraph)
     g._db = _stub_db(rows)
     return g
 
 
-class TestMemoryGraphCore:
+class TestSessionsGraphCore:
     def test_save_memory_runs_two_queries(self):
         g = _graph()
         mem = g.save_memory("alice", "Prefers dark mode")
@@ -123,22 +123,22 @@ class TestMemoryGraphCore:
 # ---------------------------------------------------------------------------
 
 
-class TestMemoryGraphConnector:
+class TestSessionsGraphConnector:
     def _make(self):
         pytest.importorskip("agent_context_graph", reason="agent-context-graph not installed")
-        from memory_graph.connector import MemoryGraphConnector
+        from sessions_graph.connector import SessionsGraphConnector
 
         from agent_context_graph.events import SessionEndEvent, SessionStartEvent
 
         db = MagicMock()
         db.query.return_value = []
 
-        from memory_graph.core import MemoryGraph
+        from sessions_graph.core import SessionsGraph
 
-        graph = MemoryGraph.__new__(MemoryGraph)
+        graph = SessionsGraph.__new__(SessionsGraph)
         graph._db = db
 
-        connector = MemoryGraphConnector(graph)
+        connector = SessionsGraphConnector(graph)
         return connector, graph, db, SessionStartEvent, SessionEndEvent
 
     def test_session_start_merges_user_and_session_nodes(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ members = [
     "context-graph/skills-graph",
     "context-graph/actions-graph",
     "context-graph/agent-context-graph",
-    "context-graph/memory-graph",
+    "context-graph/sessions-graph",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ members = [
     "mcp-memgraph",
     "memgraph-ai",
     "memgraph-toolbox",
-    "memory-graph",
+    "sessions-graph",
     "skills-graph",
     "structured2graph",
     "unstructured2graph",
@@ -3968,30 +3968,6 @@ requires-dist = [
     { name = "torch", marker = "extra == 'evaluations'", specifier = ">=2.8.0" },
 ]
 provides-extras = ["evaluations", "client", "test"]
-
-[[package]]
-name = "memory-graph"
-version = "0.1.0"
-source = { editable = "context-graph/memory-graph" }
-dependencies = [
-    { name = "memgraph-toolbox" },
-]
-
-[package.optional-dependencies]
-agent-context-graph = [
-    { name = "agent-context-graph" },
-]
-test = [
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "agent-context-graph", marker = "extra == 'agent-context-graph'", editable = "context-graph/agent-context-graph" },
-    { name = "memgraph-toolbox", editable = "memgraph-toolbox" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
-]
-provides-extras = ["agent-context-graph", "test"]
 
 [[package]]
 name = "ml-dtypes"
@@ -8350,6 +8326,30 @@ sdist = { url = "https://files.pythonhosted.org/packages/4c/72/43294fa4bdd75c516
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/44/4356cc64246ba7b2b920f7c97a85c3c52748e213e250b512ee8152eb559d/sentry_sdk-2.39.0-py2.py3-none-any.whl", hash = "sha256:ba655ca5e57b41569b18e2a5552cb3375209760a5d332cdd87c6c3f28f729602", size = 370851 },
 ]
+
+[[package]]
+name = "sessions-graph"
+version = "0.1.0"
+source = { editable = "context-graph/sessions-graph" }
+dependencies = [
+    { name = "memgraph-toolbox" },
+]
+
+[package.optional-dependencies]
+agent-context-graph = [
+    { name = "agent-context-graph" },
+]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-context-graph", marker = "extra == 'agent-context-graph'", editable = "context-graph/agent-context-graph" },
+    { name = "memgraph-toolbox", editable = "memgraph-toolbox" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
+]
+provides-extras = ["agent-context-graph", "test"]
 
 [[package]]
 name = "setuptools"


### PR DESCRIPTION
Rename the component to sessions-graph, since the memory-graph is taken. 