### PR TITLE
Implement persistent config for spawning process 

### DIFF
--- a/context-graph/agent-context-graph/pyproject.toml
+++ b/context-graph/agent-context-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-context-graph"
-version = "0.1.6"
+version = "0.1.7"
 description = "Connect agent SDKs to context-graph components (actions-graph, skills-graph, etc.)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
@@ -1,0 +1,266 @@
+"""Hook Configuration — persistent config for hook subprocesses.
+
+Agent runtimes (Claude Code, Codex) spawn hook commands as non-interactive
+subprocesses that do not inherit shell profile environment variables.  This
+module provides a config-file-only resolution path so hook subprocesses can
+reliably access identity and Memgraph connection settings.
+
+Resolution order (per ADR 0002):
+  CLI flag > config file > hardcoded default
+
+Environment variables are **not** consulted at hook runtime.  They are only
+used as a write-time input during ``bootstrap`` or ``config set``.
+
+Config file location: ``~/.config/context-graph/config.toml``
+"""
+
+from __future__ import annotations
+
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_CONFIG_DIR = Path.home() / ".config" / "context-graph"
+_CONFIG_FILE = _CONFIG_DIR / "config.toml"
+
+# Defaults matching memgraph-toolbox's MEMGRAPH_ENV_DEFAULTS.
+_MEMGRAPH_DEFAULTS = {
+    "url": "bolt://localhost:7687",
+    "user": "",
+    "password": "",
+    "database": "memgraph",
+}
+
+_sentinel = object()
+_cached_config: object = _sentinel
+
+
+@dataclass(frozen=True)
+class HookConfig:
+    """Parsed hook configuration from the config file."""
+
+    user_id: str | None = None
+    memgraph_url: str = _MEMGRAPH_DEFAULTS["url"]
+    memgraph_user: str = _MEMGRAPH_DEFAULTS["user"]
+    memgraph_password: str = _MEMGRAPH_DEFAULTS["password"]
+    memgraph_database: str = _MEMGRAPH_DEFAULTS["database"]
+
+
+def load_config() -> HookConfig:
+    """Load hook configuration from the config file.
+
+    Returns a HookConfig with defaults for any missing values.
+    Caches the result for the lifetime of the process.
+    """
+    global _cached_config
+    if _cached_config is not _sentinel:
+        return _cached_config  # type: ignore[return-value]
+
+    config = _read_config_file()
+    _cached_config = config
+    return config
+
+
+def resolve_user_id(payload: dict[str, Any]) -> str | None:
+    """Resolve user identity for hook subprocesses.
+
+    Resolution order:
+    1. ``user_id`` field in the hook payload (forward-compat).
+    2. Config file ``[identity] user_id``.
+    """
+    if uid := _string_or_none(payload.get("user_id")):
+        return uid
+    return load_config().user_id
+
+
+def resolve_memgraph_env(
+    *,
+    url: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    database: str | None = None,
+) -> dict[str, str]:
+    """Resolve Memgraph connection settings for hook subprocesses.
+
+    Resolution order per setting: explicit arg (CLI flag) > config file > default.
+    Returns a dict with keys matching memgraph-toolbox's env contract.
+    """
+    config = load_config()
+    return {
+        "MEMGRAPH_URL": url if url is not None else config.memgraph_url,
+        "MEMGRAPH_USER": user if user is not None else config.memgraph_user,
+        "MEMGRAPH_PASSWORD": password if password is not None else config.memgraph_password,
+        "MEMGRAPH_DATABASE": database if database is not None else config.memgraph_database,
+    }
+
+
+def write_config(
+    *,
+    user_id: str | None = None,
+    memgraph_url: str | None = None,
+    memgraph_user: str | None = None,
+    memgraph_password: str | None = None,
+    memgraph_database: str | None = None,
+) -> Path:
+    """Write or update the config file. Returns the path written to.
+
+    Only updates supplied values; preserves existing values for unspecified keys.
+    Creates the file with 0600 permissions if it does not exist.
+    """
+    global _cached_config
+
+    # Read existing config as base.
+    existing = _read_config_file()
+
+    final_user_id = user_id if user_id is not None else existing.user_id
+    final_url = memgraph_url if memgraph_url is not None else existing.memgraph_url
+    final_user = memgraph_user if memgraph_user is not None else existing.memgraph_user
+    final_password = memgraph_password if memgraph_password is not None else existing.memgraph_password
+    final_database = memgraph_database if memgraph_database is not None else existing.memgraph_database
+
+    content = _render_config(
+        user_id=final_user_id or "",
+        url=final_url,
+        user=final_user,
+        password=final_password,
+        database=final_database,
+    )
+
+    _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    _CONFIG_FILE.write_text(content, encoding="utf-8")
+    _CONFIG_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+
+    # Invalidate cache.
+    _cached_config = _sentinel
+    return _CONFIG_FILE
+
+
+def write_full_config(
+    *,
+    user_id: str = "",
+    memgraph_url: str = _MEMGRAPH_DEFAULTS["url"],
+    memgraph_user: str = _MEMGRAPH_DEFAULTS["user"],
+    memgraph_password: str = _MEMGRAPH_DEFAULTS["password"],
+    memgraph_database: str = _MEMGRAPH_DEFAULTS["database"],
+) -> Path:
+    """Write a complete config file with all sections (used by bootstrap).
+
+    Always overwrites the entire file.
+    """
+    global _cached_config
+
+    content = _render_config(
+        user_id=user_id,
+        url=memgraph_url,
+        user=memgraph_user,
+        password=memgraph_password,
+        database=memgraph_database,
+    )
+
+    _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    _CONFIG_FILE.write_text(content, encoding="utf-8")
+    _CONFIG_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+
+    _cached_config = _sentinel
+    return _CONFIG_FILE
+
+
+def config_file_path() -> Path:
+    """Return the config file path (for display purposes)."""
+    return _CONFIG_FILE
+
+
+def config_dir_path() -> Path:
+    """Return the config directory path."""
+    return _CONFIG_DIR
+
+
+# --- Internal helpers ---
+
+
+def _read_config_file() -> HookConfig:
+    """Parse the config file. Returns defaults if file is missing or malformed."""
+    if not _CONFIG_FILE.is_file():
+        return HookConfig()
+
+    try:
+        sections = _parse_toml(_CONFIG_FILE)
+    except Exception:
+        return HookConfig()
+
+    identity = sections.get("identity", {})
+    memgraph = sections.get("memgraph", {})
+
+    return HookConfig(
+        user_id=identity.get("user_id") or None,
+        memgraph_url=memgraph.get("url") or _MEMGRAPH_DEFAULTS["url"],
+        memgraph_user=memgraph.get("user", _MEMGRAPH_DEFAULTS["user"]),
+        memgraph_password=memgraph.get("password", _MEMGRAPH_DEFAULTS["password"]),
+        memgraph_database=memgraph.get("database") or _MEMGRAPH_DEFAULTS["database"],
+    )
+
+
+def _parse_toml(path: Path) -> dict[str, dict[str, str]]:
+    """Minimal TOML parser — handles [section] and key = "value" pairs.
+
+    Only supports string values (quoted or bare). Sufficient for our config shape.
+    """
+    sections: dict[str, dict[str, str]] = {}
+    current_section: str | None = None
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            current_section = stripped[1:-1].strip()
+            sections.setdefault(current_section, {})
+            continue
+        if current_section is not None and "=" in stripped:
+            key, _, value = stripped.partition("=")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            sections[current_section][key] = value
+
+    return sections
+
+
+def _render_config(
+    *,
+    user_id: str,
+    url: str,
+    user: str,
+    password: str,
+    database: str,
+) -> str:
+    """Render the full config file content."""
+    lines = [
+        "# Context Graph hook configuration",
+        "# Generated by: agent-context-graph config set / bootstrap",
+        f"# Location: {_CONFIG_FILE}",
+        "",
+        "[identity]",
+        f'user_id = "{user_id}"',
+        "",
+        "[memgraph]",
+        f'url = "{url}"',
+        f'user = "{user}"',
+        f'password = "{password}"',
+        f'database = "{database}"',
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value)
+    return s if s else None
+
+
+def _reset_cache() -> None:
+    """Reset the module cache (for testing)."""
+    global _cached_config
+    _cached_config = _sentinel

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/claude_code.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/claude_code.py
@@ -255,19 +255,26 @@ def load_payload(stream: Any | None = None) -> dict[str, Any]:
     return payload
 
 
-def create_link(connector_names: Iterable[str] = ()) -> AgentLink:
-    """Create an AgentLink with optional connectors named by CLI/config."""
+def create_link(connector_names: Iterable[str] = (), *, memgraph_env: dict[str, str] | None = None) -> AgentLink:
+    """Create an AgentLink with optional connectors named by CLI/config.
+
+    Args:
+        connector_names: Which graph connectors to attach.
+        memgraph_env: Resolved Memgraph connection dict (keys: MEMGRAPH_URL,
+            MEMGRAPH_USER, MEMGRAPH_PASSWORD, MEMGRAPH_DATABASE).  When None,
+            connectors fall back to their own default resolution.
+    """
     link = AgentLink()
     for connector_name in connector_names:
         normalized = connector_name.strip().replace("-", "_")
         if not normalized:
             continue
         if normalized == "skills_graph":
-            _add_skills_graph_connector(link)
+            _add_skills_graph_connector(link, memgraph_env)
         elif normalized == "actions_graph":
-            _add_actions_graph_connector(link)
+            _add_actions_graph_connector(link, memgraph_env)
         elif normalized == "sessions_graph":
-            _add_sessions_graph_connector(link)
+            _add_sessions_graph_connector(link, memgraph_env)
         else:
             msg = f"Unsupported connector: {connector_name}"
             raise ValueError(msg)
@@ -296,6 +303,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Override the session id from the Claude Code hook payload.",
     )
     parser.add_argument(
+        "--memgraph-url",
+        default=None,
+        help="Memgraph Bolt URL. Overrides config file value.",
+    )
+    parser.add_argument(
+        "--memgraph-user",
+        default=None,
+        help="Memgraph username. Overrides config file value.",
+    )
+    parser.add_argument(
+        "--memgraph-password",
+        default=None,
+        help="Memgraph password. Overrides config file value.",
+    )
+    parser.add_argument(
+        "--memgraph-database",
+        default=None,
+        help="Memgraph database. Overrides config file value.",
+    )
+    parser.add_argument(
         "--strict",
         action="store_true",
         help="Return a non-zero status if the hook payload cannot be recorded.",
@@ -306,10 +333,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     if connector_names is None:
         connector_names = _connectors_from_env()
 
+    # Resolve Memgraph connection: CLI flag > config file > default.
+    from agent_context_graph.adapters._identity import resolve_memgraph_env
+
+    memgraph_env = resolve_memgraph_env(
+        url=args.memgraph_url,
+        user=args.memgraph_user,
+        password=args.memgraph_password,
+        database=args.memgraph_database,
+    )
+
     payload: dict[str, Any] = {}
     try:
         payload = load_payload()
-        link = create_link(connector_names)
+        link = create_link(connector_names, memgraph_env=memgraph_env)
         adapter = ClaudeCodeHooksAdapter(link, session_id=args.session_id)
         adapter.handle_payload(payload)
         response = response_for_payload(payload)
@@ -325,7 +362,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 0
 
 
-def _add_skills_graph_connector(link: AgentLink) -> None:
+def _add_skills_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
     try:
         from skills_graph import SkillGraph
         from skills_graph.connector import SkillGraphConnector
@@ -333,11 +370,12 @@ def _add_skills_graph_connector(link: AgentLink) -> None:
         msg = "skills-graph is required for the skills-graph Claude Code connector"
         raise ImportError(msg) from exc
 
-    graph = SkillGraph()
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = SkillGraph(**kwargs)
     link.add_connector(SkillGraphConnector(graph))
 
 
-def _add_sessions_graph_connector(link: AgentLink) -> None:
+def _add_sessions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
     try:
         from sessions_graph import SessionsGraph
         from sessions_graph.connector import SessionsGraphConnector
@@ -345,11 +383,12 @@ def _add_sessions_graph_connector(link: AgentLink) -> None:
         msg = "sessions-graph is required for the sessions-graph Claude Code connector"
         raise ImportError(msg) from exc
 
-    graph = SessionsGraph()
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = SessionsGraph(**kwargs)
     link.add_connector(SessionsGraphConnector(graph))
 
 
-def _add_actions_graph_connector(link: AgentLink) -> None:
+def _add_actions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
     try:
         from actions_graph import ActionsGraph
         from actions_graph.connector import ActionsGraphConnector
@@ -357,8 +396,21 @@ def _add_actions_graph_connector(link: AgentLink) -> None:
         msg = "actions-graph is required for the actions-graph Claude Code connector"
         raise ImportError(msg) from exc
 
-    graph = ActionsGraph()
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = ActionsGraph(**kwargs)
     link.add_connector(ActionsGraphConnector(graph))
+
+
+def _memgraph_kwargs(memgraph_env: dict[str, str] | None) -> dict[str, str]:
+    """Convert resolved memgraph env dict to kwargs for graph component constructors."""
+    if memgraph_env is None:
+        return {}
+    return {
+        "url": memgraph_env["MEMGRAPH_URL"],
+        "username": memgraph_env["MEMGRAPH_USER"],
+        "password": memgraph_env["MEMGRAPH_PASSWORD"],
+        "database": memgraph_env["MEMGRAPH_DATABASE"],
+    }
 
 
 def _connectors_from_env() -> list[str]:
@@ -408,10 +460,11 @@ def _resolve_user_id(payload: dict[str, Any]) -> str | None:
     Resolution order:
     1. ``user_id`` field in the hook payload (forward-compat).
     2. ``AGENT_CONTEXT_GRAPH_USER_ID`` environment variable.
+    3. Config file at ``~/.config/agent-context-graph/config.toml``.
     """
-    if uid := _string_or_none(payload.get("user_id")):
-        return uid
-    return os.environ.get("AGENT_CONTEXT_GRAPH_USER_ID") or None
+    from agent_context_graph.adapters._identity import resolve_user_id
+
+    return resolve_user_id(payload)
 
 
 def _debug_log(message: str) -> None:

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/codex.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/codex.py
@@ -187,19 +187,26 @@ def load_payload(stream: Any | None = None) -> dict[str, Any]:
     return payload
 
 
-def create_link(connector_names: Iterable[str] = ()) -> AgentLink:
-    """Create an AgentLink with optional connectors named by CLI/config."""
+def create_link(connector_names: Iterable[str] = (), *, memgraph_env: dict[str, str] | None = None) -> AgentLink:
+    """Create an AgentLink with optional connectors named by CLI/config.
+
+    Args:
+        connector_names: Which graph connectors to attach.
+        memgraph_env: Resolved Memgraph connection dict (keys: MEMGRAPH_URL,
+            MEMGRAPH_USER, MEMGRAPH_PASSWORD, MEMGRAPH_DATABASE).  When None,
+            connectors fall back to their own default resolution.
+    """
     link = AgentLink()
     for connector_name in connector_names:
         normalized = connector_name.strip().replace("-", "_")
         if not normalized:
             continue
         if normalized == "skills_graph":
-            _add_skills_graph_connector(link)
+            _add_skills_graph_connector(link, memgraph_env)
         elif normalized == "actions_graph":
-            _add_actions_graph_connector(link)
+            _add_actions_graph_connector(link, memgraph_env)
         elif normalized == "sessions_graph":
-            _add_sessions_graph_connector(link)
+            _add_sessions_graph_connector(link, memgraph_env)
         else:
             msg = f"Unsupported connector: {connector_name}"
             raise ValueError(msg)
@@ -227,6 +234,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Override the session id from the Codex hook payload.",
     )
     parser.add_argument(
+        "--memgraph-url",
+        default=None,
+        help="Memgraph Bolt URL. Overrides config file value.",
+    )
+    parser.add_argument(
+        "--memgraph-user",
+        default=None,
+        help="Memgraph username. Overrides config file value.",
+    )
+    parser.add_argument(
+        "--memgraph-password",
+        default=None,
+        help="Memgraph password. Overrides config file value.",
+    )
+    parser.add_argument(
+        "--memgraph-database",
+        default=None,
+        help="Memgraph database. Overrides config file value.",
+    )
+    parser.add_argument(
         "--strict",
         action="store_true",
         help="Return a non-zero status if the hook payload cannot be recorded.",
@@ -237,10 +264,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     if connector_names is None:
         connector_names = _connectors_from_env()
 
+    # Resolve Memgraph connection: CLI flag > config file > default.
+    from agent_context_graph.adapters._identity import resolve_memgraph_env
+
+    memgraph_env = resolve_memgraph_env(
+        url=args.memgraph_url,
+        user=args.memgraph_user,
+        password=args.memgraph_password,
+        database=args.memgraph_database,
+    )
+
     payload: dict[str, Any] = {}
     try:
         payload = load_payload()
-        link = create_link(connector_names)
+        link = create_link(connector_names, memgraph_env=memgraph_env)
         adapter = CodexHooksAdapter(link, session_id=args.session_id)
         adapter.handle_payload(payload)
         response = response_for_payload(payload)
@@ -256,7 +293,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 0
 
 
-def _add_skills_graph_connector(link: AgentLink) -> None:
+def _add_skills_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
     try:
         from skills_graph import SkillGraph
         from skills_graph.connector import SkillGraphConnector
@@ -264,13 +301,12 @@ def _add_skills_graph_connector(link: AgentLink) -> None:
         msg = "skills-graph is required for the skills-graph Codex connector"
         raise ImportError(msg) from exc
 
-    # Codex command hooks run in a fresh process for each hook invocation, so
-    # each call builds its own short-lived SkillGraph/Memgraph connection.
-    graph = SkillGraph()
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = SkillGraph(**kwargs)
     link.add_connector(SkillGraphConnector(graph))
 
 
-def _add_sessions_graph_connector(link: AgentLink) -> None:
+def _add_sessions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
     try:
         from sessions_graph import SessionsGraph
         from sessions_graph.connector import SessionsGraphConnector
@@ -278,11 +314,12 @@ def _add_sessions_graph_connector(link: AgentLink) -> None:
         msg = "sessions-graph is required for the sessions-graph Codex connector"
         raise ImportError(msg) from exc
 
-    graph = SessionsGraph()
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = SessionsGraph(**kwargs)
     link.add_connector(SessionsGraphConnector(graph))
 
 
-def _add_actions_graph_connector(link: AgentLink) -> None:
+def _add_actions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
     try:
         from actions_graph import ActionsGraph
         from actions_graph.connector import ActionsGraphConnector
@@ -290,8 +327,21 @@ def _add_actions_graph_connector(link: AgentLink) -> None:
         msg = "actions-graph is required for the actions-graph Codex connector"
         raise ImportError(msg) from exc
 
-    graph = ActionsGraph()
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = ActionsGraph(**kwargs)
     link.add_connector(ActionsGraphConnector(graph))
+
+
+def _memgraph_kwargs(memgraph_env: dict[str, str] | None) -> dict[str, str]:
+    """Convert resolved memgraph env dict to kwargs for graph component constructors."""
+    if memgraph_env is None:
+        return {}
+    return {
+        "url": memgraph_env["MEMGRAPH_URL"],
+        "username": memgraph_env["MEMGRAPH_USER"],
+        "password": memgraph_env["MEMGRAPH_PASSWORD"],
+        "database": memgraph_env["MEMGRAPH_DATABASE"],
+    }
 
 
 def _connectors_from_env() -> list[str]:
@@ -345,10 +395,11 @@ def _resolve_user_id(payload: dict[str, Any]) -> str | None:
     Resolution order:
     1. ``user_id`` field in the hook payload (forward-compat).
     2. ``AGENT_CONTEXT_GRAPH_USER_ID`` environment variable.
+    3. Config file at ``~/.config/agent-context-graph/config.toml``.
     """
-    if uid := _string_or_none(payload.get("user_id")):
-        return uid
-    return os.environ.get("AGENT_CONTEXT_GRAPH_USER_ID") or None
+    from agent_context_graph.adapters._identity import resolve_user_id
+
+    return resolve_user_id(payload)
 
 
 def _debug_log(message: str) -> None:

--- a/context-graph/agent-context-graph/src/agent_context_graph/cli.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/cli.py
@@ -19,6 +19,7 @@ _HELP = """usage: agent-context-graph <command> [options]
 
 Commands:
   bootstrap        Install runtime dependencies and verify hook capture.
+  config           Get or set persistent configuration values.
   doctor           Check runtime hook dependencies and Memgraph connectivity.
   setup <runtime>  Configure an agent runtime.
   hook <command>  Configure or run command hooks.
@@ -42,6 +43,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if command == "bootstrap":
         return _bootstrap(args[1:])
 
+    if command == "config":
+        return _config(args[1:])
+
     if command == "doctor":
         return _doctor(args[1:])
 
@@ -57,6 +61,100 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     print(f"Unknown command: {command}", file=sys.stderr)
     print(_HELP)
+    return 2
+
+
+def _config(argv: list[str]) -> int:
+    """Get or set persistent config values in ~/.config/context-graph/config.toml."""
+    from agent_context_graph.adapters._identity import (
+        config_file_path,
+        load_config,
+        write_config,
+    )
+
+    config_path = config_file_path()
+
+    _CONFIG_KEYS = {
+        "identity.user_id": "user_id",
+        "memgraph.url": "memgraph_url",
+        "memgraph.user": "memgraph_user",
+        "memgraph.password": "memgraph_password",
+        "memgraph.database": "memgraph_database",
+    }
+
+    if not argv or argv[0] in {"-h", "--help"}:
+        print("usage: agent-context-graph config set <key> <value>")
+        print("       agent-context-graph config get <key>")
+        print("       agent-context-graph config show")
+        print("")
+        print("Supported keys:")
+        for key in _CONFIG_KEYS:
+            print(f"  {key}")
+        print(f"\nConfig file: {config_path}")
+        return 0
+
+    action = argv[0]
+
+    if action == "show":
+        config = load_config()
+        print(f"# {config_path}")
+        print(f"identity.user_id = {config.user_id!r}")
+        print(f"memgraph.url = {config.memgraph_url!r}")
+        print(f"memgraph.user = {config.memgraph_user!r}")
+        print(f"memgraph.password = {'***' if config.memgraph_password else repr('')}")
+        print(f"memgraph.database = {config.memgraph_database!r}")
+        return 0
+
+    if action == "set":
+        if len(argv) < 2:
+            print("usage: agent-context-graph config set <key> <value>", file=sys.stderr)
+            return 2
+        key = argv[1]
+        if key not in _CONFIG_KEYS:
+            print(f"Unknown config key: {key}", file=sys.stderr)
+            print(f"Supported keys: {', '.join(_CONFIG_KEYS)}", file=sys.stderr)
+            return 2
+
+        # Password: read from stdin if value not provided.
+        if len(argv) < 3:
+            if key == "memgraph.password":
+                import getpass
+
+                value = getpass.getpass("Enter memgraph password: ")
+            else:
+                print(f"usage: agent-context-graph config set {key} <value>", file=sys.stderr)
+                return 2
+        else:
+            value = argv[2]
+
+        write_config(**{_CONFIG_KEYS[key]: value})
+        display_value = "***" if key == "memgraph.password" else repr(value)
+        print(f"Wrote {key} = {display_value} to {config_path}")
+        return 0
+
+    if action == "get":
+        if len(argv) < 2:
+            print("usage: agent-context-graph config get <key>", file=sys.stderr)
+            return 2
+        key = argv[1]
+        if key not in _CONFIG_KEYS:
+            print(f"Unknown config key: {key}", file=sys.stderr)
+            return 2
+
+        config = load_config()
+        attr = _CONFIG_KEYS[key]
+        value = getattr(config, attr)
+        if value is None:
+            print(f"{key} is not set in {config_path}", file=sys.stderr)
+            return 1
+        # Don't print password to stdout unless explicitly requested.
+        if key == "memgraph.password":
+            print("***")
+        else:
+            print(value)
+        return 0
+
+    print(f"Unknown config action: {action}", file=sys.stderr)
     return 2
 
 
@@ -146,6 +244,30 @@ def _bootstrap(argv: list[str]) -> int:
         return 1
 
     print(f"OK agent-context-graph executable: {executable}")
+
+    # Write hook configuration file (auto-write + inform).
+    from agent_context_graph.adapters._identity import write_full_config
+
+    memgraph_url = f"bolt://{host}:{port}"
+    user_id = os.environ.get("AGENT_CONTEXT_GRAPH_USER_ID", "")
+    memgraph_user = os.environ.get("MEMGRAPH_USER", "")
+    memgraph_password = os.environ.get("MEMGRAPH_PASSWORD", "")
+    memgraph_database = os.environ.get("MEMGRAPH_DATABASE", "memgraph")
+
+    config_path = write_full_config(
+        user_id=user_id,
+        memgraph_url=memgraph_url,
+        memgraph_user=memgraph_user,
+        memgraph_password=memgraph_password,
+        memgraph_database=memgraph_database,
+    )
+    print(f"OK config: wrote {config_path}")
+    if user_id:
+        print(f"   identity.user_id = {user_id!r}")
+    else:
+        print("   identity.user_id is empty — set it with: agent-context-graph config set identity.user_id <your-name>")
+    print(f"   memgraph.url = {memgraph_url!r}")
+
     doctor_args = ["--runtime", args.runtime]
     for connector in connectors:
         doctor_args.extend(["--connector", connector])
@@ -177,6 +299,7 @@ def _doctor(argv: list[str]) -> int:
     checks = [
         _check_cli(),
         _check_package("agent-context-graph"),
+        _check_config(),
         _check_memgraph(),
     ]
     for connector in connectors:
@@ -192,12 +315,40 @@ def _doctor(argv: list[str]) -> int:
     return 0 if ok else 1
 
 
+def _check_config() -> dict[str, object]:
+    from agent_context_graph.adapters._identity import config_file_path, load_config
+
+    path = config_file_path()
+    if not path.is_file():
+        return {
+            "name": "config",
+            "ok": False,
+            "detail": f"{path} not found — run: agent-context-graph bootstrap or agent-context-graph config set identity.user_id <name>",
+        }
+    config = load_config()
+    parts = []
+    if config.user_id:
+        parts.append(f"user_id={config.user_id!r}")
+    else:
+        parts.append("user_id=NOT SET")
+    parts.append(f"memgraph.url={config.memgraph_url!r}")
+    return {"name": "config", "ok": bool(config.user_id), "detail": f"{path} — {'; '.join(parts)}"}
+
+
 def _check_memgraph() -> dict[str, object]:
-    url = os.environ.get("MEMGRAPH_URL", "bolt://localhost:7687")
+    from agent_context_graph.adapters._identity import resolve_memgraph_env
+
+    env = resolve_memgraph_env()
+    url = env["MEMGRAPH_URL"]
     try:
         from memgraph_toolbox.api.memgraph import Memgraph
 
-        db = Memgraph()
+        db = Memgraph(
+            url=env["MEMGRAPH_URL"],
+            username=env["MEMGRAPH_USER"],
+            password=env["MEMGRAPH_PASSWORD"],
+            database=env["MEMGRAPH_DATABASE"],
+        )
         db.query("RETURN 1")
         return {"name": "memgraph", "ok": True, "detail": f"{url} reachable"}
     except Exception as exc:
@@ -253,14 +404,22 @@ def _check_connector(connector_name: str) -> dict[str, object]:
         try:
             from sessions_graph import SessionsGraph
 
-            graph = SessionsGraph()
+            from agent_context_graph.adapters._identity import resolve_memgraph_env, resolve_user_id
+
+            env = resolve_memgraph_env()
+            graph = SessionsGraph(
+                url=env["MEMGRAPH_URL"],
+                username=env["MEMGRAPH_USER"],
+                password=env["MEMGRAPH_PASSWORD"],
+                database=env["MEMGRAPH_DATABASE"],
+            )
             version = _package_version("sessions-graph")
-            user_id = os.environ.get("AGENT_CONTEXT_GRAPH_USER_ID")
+            user_id = resolve_user_id({})
             if not user_id:
                 return {
                     "name": "connector:sessions-graph",
                     "ok": False,
-                    "detail": "AGENT_CONTEXT_GRAPH_USER_ID is not set — set it to a non-empty string identifying the human user",
+                    "detail": "user_id not resolved — run: agent-context-graph config set identity.user_id <your-name>",
                 }
             return {
                 "name": "connector:sessions-graph",

--- a/context-graph/agent-context-graph/tests/test_hook_cli.py
+++ b/context-graph/agent-context-graph/tests/test_hook_cli.py
@@ -45,6 +45,10 @@ def test_top_level_cli_doctor_reports_checks(monkeypatch, capsys):
         lambda package_name: {"name": package_name, "ok": True, "detail": "1.2.3"},
     )
     monkeypatch.setattr(
+        "agent_context_graph.cli._check_config",
+        lambda: {"name": "config", "ok": True, "detail": "ok"},
+    )
+    monkeypatch.setattr(
         "agent_context_graph.cli._check_memgraph",
         lambda: {"name": "memgraph", "ok": True, "detail": "bolt://localhost:7687 reachable"},
     )
@@ -73,6 +77,10 @@ def test_top_level_cli_doctor_fails_when_check_fails(monkeypatch, capsys):
     monkeypatch.setattr(
         "agent_context_graph.cli._check_package",
         lambda package_name: {"name": package_name, "ok": True, "detail": "1.2.3"},
+    )
+    monkeypatch.setattr(
+        "agent_context_graph.cli._check_config",
+        lambda: {"name": "config", "ok": True, "detail": "ok"},
     )
     monkeypatch.setattr(
         "agent_context_graph.cli._check_connector",
@@ -107,6 +115,13 @@ def test_top_level_cli_bootstrap_installs_and_runs_doctor(monkeypatch, capsys):
     monkeypatch.setattr("agent_context_graph.cli.subprocess.run", fake_run)
     monkeypatch.setattr("agent_context_graph.cli._doctor", fake_doctor)
 
+    from pathlib import Path
+
+    monkeypatch.setattr(
+        "agent_context_graph.adapters._identity.write_full_config",
+        lambda **kwargs: Path("/tmp/fake-config.toml"),
+    )
+
     assert top_level_main(["bootstrap", "--runtime", "codex", "--connector", "skills-graph"]) == 0
 
     assert commands == [
@@ -133,6 +148,13 @@ def test_top_level_cli_bootstrap_installs_actions_graph_connector(monkeypatch):
     monkeypatch.setattr("agent_context_graph.cli._memgraph_reachable", lambda host, port: True)
     monkeypatch.setattr("agent_context_graph.cli._doctor", lambda args: 0)
 
+    from pathlib import Path
+
+    monkeypatch.setattr(
+        "agent_context_graph.adapters._identity.write_full_config",
+        lambda **kwargs: Path("/tmp/fake-config.toml"),
+    )
+
     def fake_run(command, *, check):
         commands.append(command)
         assert check is True
@@ -152,6 +174,13 @@ def test_top_level_cli_bootstrap_no_reinstall_omits_reinstall(monkeypatch):
     monkeypatch.setattr("agent_context_graph.cli.shutil.which", lambda name: f"/bin/{name}")
     monkeypatch.setattr("agent_context_graph.cli._memgraph_reachable", lambda host, port: True)
     monkeypatch.setattr("agent_context_graph.cli._doctor", lambda args: 0)
+
+    from pathlib import Path
+
+    monkeypatch.setattr(
+        "agent_context_graph.adapters._identity.write_full_config",
+        lambda **kwargs: Path("/tmp/fake-config.toml"),
+    )
 
     def fake_run(command, *, check):
         commands.append(command)

--- a/context-graph/agent-context-graph/tests/test_identity.py
+++ b/context-graph/agent-context-graph/tests/test_identity.py
@@ -1,0 +1,135 @@
+"""Tests for agent_context_graph.adapters._identity (Hook Configuration)."""
+
+import pytest
+
+from agent_context_graph.adapters import _identity
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Reset module-level cache before each test."""
+    _identity._reset_cache()
+    yield
+    _identity._reset_cache()
+
+
+@pytest.fixture()
+def config_dir(monkeypatch, tmp_path):
+    """Point config at a temp directory."""
+    config_dir = tmp_path / "context-graph"
+    config_file = config_dir / "config.toml"
+    monkeypatch.setattr(_identity, "_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(_identity, "_CONFIG_FILE", config_file)
+    return config_dir
+
+
+# --- resolve_user_id ---
+
+
+def test_payload_user_id_takes_priority(config_dir):
+    _identity.write_config(user_id="config-user")
+    result = _identity.resolve_user_id({"user_id": "payload-user"})
+    assert result == "payload-user"
+
+
+def test_config_file_fallback(config_dir):
+    _identity.write_config(user_id="config-user")
+    result = _identity.resolve_user_id({})
+    assert result == "config-user"
+
+
+def test_returns_none_when_no_config(config_dir):
+    result = _identity.resolve_user_id({})
+    assert result is None
+
+
+# --- resolve_memgraph_env ---
+
+
+def test_memgraph_defaults_when_no_config(config_dir):
+    env = _identity.resolve_memgraph_env()
+    assert env["MEMGRAPH_URL"] == "bolt://localhost:7687"
+    assert env["MEMGRAPH_USER"] == ""
+    assert env["MEMGRAPH_PASSWORD"] == ""
+    assert env["MEMGRAPH_DATABASE"] == "memgraph"
+
+
+def test_memgraph_from_config_file(config_dir):
+    _identity.write_full_config(
+        memgraph_url="bolt://remote:7687",
+        memgraph_user="admin",
+        memgraph_password="secret",
+        memgraph_database="mydb",
+    )
+    _identity._reset_cache()
+    env = _identity.resolve_memgraph_env()
+    assert env["MEMGRAPH_URL"] == "bolt://remote:7687"
+    assert env["MEMGRAPH_USER"] == "admin"
+    assert env["MEMGRAPH_PASSWORD"] == "secret"
+    assert env["MEMGRAPH_DATABASE"] == "mydb"
+
+
+def test_cli_flag_overrides_config(config_dir):
+    _identity.write_full_config(memgraph_url="bolt://config:7687")
+    _identity._reset_cache()
+    env = _identity.resolve_memgraph_env(url="bolt://flag:9999")
+    assert env["MEMGRAPH_URL"] == "bolt://flag:9999"
+
+
+# --- write_config ---
+
+
+def test_write_config_creates_file_with_0600(config_dir):
+    path = _identity.write_config(user_id="testuser")
+    assert path.is_file()
+    mode = path.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_write_config_preserves_existing_values(config_dir):
+    _identity.write_full_config(user_id="original", memgraph_url="bolt://first:7687")
+    _identity._reset_cache()
+    _identity.write_config(user_id="updated")
+    _identity._reset_cache()
+    config = _identity.load_config()
+    assert config.user_id == "updated"
+    assert config.memgraph_url == "bolt://first:7687"
+
+
+def test_write_full_config_writes_all_defaults(config_dir):
+    _identity.write_full_config()
+    _identity._reset_cache()
+    config = _identity.load_config()
+    assert config.user_id is None  # empty string -> None
+    assert config.memgraph_url == "bolt://localhost:7687"
+    assert config.memgraph_database == "memgraph"
+
+
+# --- load_config ---
+
+
+def test_load_config_caches(config_dir):
+    _identity.write_config(user_id="cached")
+    config1 = _identity.load_config()
+    # Modify file behind the cache's back.
+    _identity._CONFIG_FILE.write_text('[identity]\nuser_id = "changed"\n')
+    config2 = _identity.load_config()
+    # Should still return cached value.
+    assert config1.user_id == config2.user_id == "cached"
+
+
+# --- _parse_toml ---
+
+
+def test_parse_toml_handles_comments(config_dir, tmp_path):
+    f = tmp_path / "test.toml"
+    f.write_text('# comment\n[identity]\n# another\nuser_id = "hello"\n')
+    sections = _identity._parse_toml(f)
+    assert sections["identity"]["user_id"] == "hello"
+
+
+def test_parse_toml_handles_bare_values(config_dir, tmp_path):
+    f = tmp_path / "test.toml"
+    f.write_text("[memgraph]\nurl = bolt://localhost:7687\n")
+    sections = _identity._parse_toml(f)
+    assert sections["memgraph"]["url"] == "bolt://localhost:7687"


### PR DESCRIPTION
Hook subprocesses spawned by Claude Code / Codex are non-interactive and don't inherit shell profile env vars (~/.zshrc). This caused [user_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and Memgraph connection settings to be silently unavailable at hook runtime.

This PR introduces a persistent config file as the canonical source for hook subprocesses.