### PR TITLE
lightrag-memgraph: log GC-lag under-return in vector query()

### DIFF
--- a/integrations/lightrag-memgraph/README.md
+++ b/integrations/lightrag-memgraph/README.md
@@ -71,6 +71,19 @@ graph backend: `MEMGRAPH_URI` (or `MEMGRAPH_URL`, which the wrapper bridges to
 `MEMGRAPH_URI`), `MEMGRAPH_USERNAME`, `MEMGRAPH_PASSWORD`, `MEMGRAPH_DATABASE`
 and the optional `MEMGRAPH_WORKSPACE`.
 
+### Known limitations
+
+- **Vector search can under-return right after a bulk delete.** Memgraph's
+  native vector index is garbage-collected on a delay after a node delete, so
+  `CALL vector_search.search(...)` can still hand back index entries for nodes
+  that were already deleted. `MemgraphVectorStorage.query()` detects and
+  excludes these dead candidates, so a query issued shortly after a large
+  delete may legitimately return fewer than `top_k` (or zero) results even
+  though the index itself reports `top_k` hits. When this happens a warning
+  is logged (`vector_search.search returned N candidate(s) ... but only M
+  were still live`) so you can tell a genuine lack of matches apart from
+  GC-lag under-return.
+
 ### Opting out
 
 - `MemgraphLightRAGWrapper(full_memgraph_persistence=False)` keeps only the
@@ -127,7 +140,7 @@ https://platform.claude.com/docs/en/about-claude/models.
    `claude_3_sonnet_complete`, `claude_3_haiku_complete` (fixed older model
    IDs). For current models, use `anthropic_complete` with the desired
    `llm_model_name`.
-   
+
 3. **Embeddings**: Anthropic does not provide embeddings, and vectors always
 persist to Memgraph's native vector index, so a real `embedding_func` is
 required. Set `embedding_func` to another provider (e.g. `openai_embed` from

--- a/integrations/lightrag-memgraph/README.md
+++ b/integrations/lightrag-memgraph/README.md
@@ -71,18 +71,20 @@ graph backend: `MEMGRAPH_URI` (or `MEMGRAPH_URL`, which the wrapper bridges to
 `MEMGRAPH_URI`), `MEMGRAPH_USERNAME`, `MEMGRAPH_PASSWORD`, `MEMGRAPH_DATABASE`
 and the optional `MEMGRAPH_WORKSPACE`.
 
-### Known limitations
+### Vector search under concurrent deletes
 
-- **Vector search can under-return right after a bulk delete.** Memgraph's
-  native vector index is garbage-collected on a delay after a node delete, so
-  `CALL vector_search.search(...)` can still hand back index entries for nodes
-  that were already deleted. `MemgraphVectorStorage.query()` detects and
-  excludes these dead candidates, so a query issued shortly after a large
-  delete may legitimately return fewer than `top_k` (or zero) results even
-  though the index itself reports `top_k` hits. When this happens a warning
-  is logged (`vector_search.search returned N candidate(s) ... but only M
-  were still live`) so you can tell a genuine lack of matches apart from
-  GC-lag under-return.
+Memgraph's native vector index operates at `READ_UNCOMMITTED` isolation by
+design (see the
+[vector search docs](https://memgraph.com/docs/querying/vector-search)), so
+while a *concurrent* transaction is deleting matching nodes but hasn't
+committed yet, `CALL vector_search.search(...)` can still hand back those
+nodes as candidates. `MemgraphVectorStorage.query()` detects and excludes any
+such candidate, so a query that races a concurrent delete may momentarily
+return fewer than `top_k` (or zero) results even though the index itself
+reports `top_k` hits -- once that delete commits, this no longer happens.
+When it does happen a warning is logged (`vector_search.search returned N
+candidate(s) ... but only M were still live`) so you can tell a genuine lack
+of matches apart from a concurrent delete in flight.
 
 ### Opting out
 

--- a/integrations/lightrag-memgraph/README.md
+++ b/integrations/lightrag-memgraph/README.md
@@ -71,20 +71,6 @@ graph backend: `MEMGRAPH_URI` (or `MEMGRAPH_URL`, which the wrapper bridges to
 `MEMGRAPH_URI`), `MEMGRAPH_USERNAME`, `MEMGRAPH_PASSWORD`, `MEMGRAPH_DATABASE`
 and the optional `MEMGRAPH_WORKSPACE`.
 
-### Vector search under concurrent deletes
-
-Memgraph's native vector index operates at `READ_UNCOMMITTED` isolation by
-design (see the
-[vector search docs](https://memgraph.com/docs/querying/vector-search)), so
-while a *concurrent* transaction is deleting matching nodes but hasn't
-committed yet, `CALL vector_search.search(...)` can still hand back those
-nodes as candidates. `MemgraphVectorStorage.query()` detects and excludes any
-such candidate, so a query that races a concurrent delete may momentarily
-return fewer than `top_k` (or zero) results even though the index itself
-reports `top_k` hits -- once that delete commits, this no longer happens.
-When it does happen a warning is logged (`vector_search.search returned N
-candidate(s) ... but only M were still live`) so you can tell a genuine lack
-of matches apart from a concurrent delete in flight.
 
 ### Opting out
 

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
@@ -148,15 +148,17 @@ class MemgraphVectorStorage(BaseVectorStorage):
     async def query(self, query: str, top_k: int, query_embedding: list[float] = None) -> list[dict[str, Any]]:
         """Vector-search this namespace and return up to ``top_k`` live results.
 
-        Known Memgraph limitation: the native vector index is garbage-collected
-        on a delay after a node delete, so ``vector_search.search`` can still
-        hand back index entries for nodes that were already deleted (see the
-        inline comment below for how those are detected and excluded). Right
-        after a bulk delete this means ``query()`` may legitimately return
-        fewer than ``top_k`` -- or zero -- results even though the index
-        reports ``top_k`` hits. A warning is logged with both counts whenever
-        this happens, so callers can tell "nothing else matched" apart from
-        "results were dropped because of GC lag".
+        By design, Memgraph's native vector index operates at ``READ_UNCOMMITTED``
+        isolation (see https://memgraph.com/docs/querying/vector-search), so while
+        a concurrent transaction is deleting matching nodes but hasn't committed
+        yet, ``vector_search.search`` can still hand back those nodes as
+        candidates (see the inline comment below for how those are detected and
+        excluded). While such a delete is in flight, ``query()`` may therefore
+        return fewer than ``top_k`` -- or zero -- results even though the index
+        reports ``top_k`` hits; once the concurrent transaction commits, this
+        no longer happens. A warning is logged with both counts whenever this
+        happens, so callers can tell "nothing else matched" apart from "a
+        concurrent delete was in flight".
         """
         if query_embedding is not None:
             embedding = np.asarray(query_embedding, dtype=float).tolist()
@@ -168,12 +170,14 @@ class MemgraphVectorStorage(BaseVectorStorage):
         # default_access_mode="READ" is just a routing hint; it doesn't affect the vector index's isolation.
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             try:
-                # Memgraph's vector index runs at READ_UNCOMMITTED with deferred GC, so
-                # vector_search.search can hand back a handle to an already-deleted node --
+                # Memgraph's vector index runs at READ_UNCOMMITTED isolation by design, so
+                # while a concurrent transaction's delete of a matching node hasn't committed
+                # yet, vector_search.search can still hand back a handle to that node --
                 # reading a property off it raises 50N42. We never touch that raw `node`
                 # handle directly: re-MATCH each candidate by identity via OPTIONAL MATCH,
-                # so a dangling candidate comes back as a row with `id IS NULL` instead of
-                # erroring, and we can count + log it below instead of silently dropping it.
+                # so a candidate caught mid-delete comes back as a row with `id IS NULL`
+                # instead of erroring, and we can count + log it below instead of silently
+                # dropping it.
                 # Index name is a sanitized string literal (not accepted as a query param).
                 result = await session.run(
                     f"""
@@ -191,7 +195,7 @@ class MemgraphVectorStorage(BaseVectorStorage):
                 records = [record async for record in result]
                 await result.consume()
             except Exception as e:
-                # Real failure, not a dangling index entry (those are excluded above) -- surface it.
+                # Real failure, not a candidate caught mid-delete (those are excluded above) -- surface it.
                 logger.error(f"[{self.workspace}] Vector search failed for {self.namespace}: {e}")
                 raise
 
@@ -202,7 +206,7 @@ class MemgraphVectorStorage(BaseVectorStorage):
             logger.warning(
                 f"[{self.workspace}] vector_search.search returned {raw_hit_count} candidate(s) for "
                 f"{self.namespace} but only {live_count} were still live; "
-                f"{raw_hit_count - live_count} were excluded as GC-pending deletes"
+                f"{raw_hit_count - live_count} were excluded as concurrent, not-yet-committed deletes"
             )
 
         threshold = self.cosine_better_than_threshold
@@ -283,7 +287,8 @@ class MemgraphVectorStorage(BaseVectorStorage):
         driver = await get_driver()
         async with driver.session(database=get_database()) as session:
             # Null the embedding before DETACH DELETE so the entry leaves the vector index
-            # (a bare delete would leave a dangling entry -- see query()'s 50N42 note).
+            # (a bare delete can still surface via vector_search.search while this
+            # transaction is in flight -- see query()'s note on READ_UNCOMMITTED).
             await (
                 await session.run(
                     f"""

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
@@ -146,6 +146,18 @@ class MemgraphVectorStorage(BaseVectorStorage):
         logger.debug(f"[{self.workspace}] Upserted {len(entries)} vectors to {self.namespace}")
 
     async def query(self, query: str, top_k: int, query_embedding: list[float] = None) -> list[dict[str, Any]]:
+        """Vector-search this namespace and return up to ``top_k`` live results.
+
+        Known Memgraph limitation: the native vector index is garbage-collected
+        on a delay after a node delete, so ``vector_search.search`` can still
+        hand back index entries for nodes that were already deleted (see the
+        inline comment below for how those are detected and excluded). Right
+        after a bulk delete this means ``query()`` may legitimately return
+        fewer than ``top_k`` -- or zero -- results even though the index
+        reports ``top_k`` hits. A warning is logged with both counts whenever
+        this happens, so callers can tell "nothing else matched" apart from
+        "results were dropped because of GC lag".
+        """
         if query_embedding is not None:
             embedding = np.asarray(query_embedding, dtype=float).tolist()
         else:
@@ -159,25 +171,22 @@ class MemgraphVectorStorage(BaseVectorStorage):
                 # Memgraph's vector index runs at READ_UNCOMMITTED with deferred GC, so
                 # vector_search.search can hand back a handle to an already-deleted node --
                 # reading a property off it raises 50N42. We never touch that raw `node`
-                # handle: re-MATCH by identity and read properties only off live nodes, so
-                # a dangling candidate is silently excluded instead of erroring.
+                # handle directly: re-MATCH each candidate by identity via OPTIONAL MATCH,
+                # so a dangling candidate comes back as a row with `id IS NULL` instead of
+                # erroring, and we can count + log it below instead of silently dropping it.
                 # Index name is a sanitized string literal (not accepted as a query param).
                 result = await session.run(
                     f"""
                     CALL vector_search.search("{self._index_name}", $top_k, $embedding)
                     YIELD node, similarity
-                    WITH collect(node) AS cand_nodes,
-                         collect({{node: node, similarity: similarity}}) AS cand_pairs
-                    MATCH (live:`{self._label}`)
-                    WHERE live IN cand_nodes
-                    WITH live, [p IN cand_pairs WHERE p.node = live | p.similarity][0] AS similarity
-                    WHERE similarity >= $threshold
-                    RETURN live.id AS id, similarity AS similarity, properties(live) AS props
-                    ORDER BY similarity DESC
+                    WITH collect({{node: node, similarity: similarity}}) AS cand_pairs
+                    UNWIND cand_pairs AS cp
+                    OPTIONAL MATCH (live:`{self._label}`) WHERE live = cp.node
+                    RETURN live.id AS id, cp.similarity AS similarity,
+                           CASE WHEN live IS NULL THEN NULL ELSE properties(live) END AS props
                     """,
                     top_k=int(top_k),
                     embedding=embedding,
-                    threshold=self.cosine_better_than_threshold,
                 )
                 records = [record async for record in result]
                 await result.consume()
@@ -186,8 +195,22 @@ class MemgraphVectorStorage(BaseVectorStorage):
                 logger.error(f"[{self.workspace}] Vector search failed for {self.namespace}: {e}")
                 raise
 
+        raw_hit_count = len(records)
+        live_records = [record for record in records if record["id"] is not None]
+        live_count = len(live_records)
+        if live_count != raw_hit_count:
+            logger.warning(
+                f"[{self.workspace}] vector_search.search returned {raw_hit_count} candidate(s) for "
+                f"{self.namespace} but only {live_count} were still live; "
+                f"{raw_hit_count - live_count} were excluded as GC-pending deletes"
+            )
+
+        threshold = self.cosine_better_than_threshold
+        live_records = [record for record in live_records if record["similarity"] >= threshold]
+        live_records.sort(key=lambda record: record["similarity"], reverse=True)
+
         output: list[dict[str, Any]] = []
-        for record in records:
+        for record in live_records:
             props = dict(record["props"])
             props.pop("embedding", None)
             created_at = props.pop("created_at", None)

--- a/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
+++ b/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
@@ -445,12 +445,14 @@ async def test_vector_respects_threshold(shared_driver, vector_search_supported,
         await store.drop()
 
 
-async def test_vector_query_logs_and_excludes_gc_pending_deletes(
+async def test_vector_query_logs_and_excludes_stale_candidates(
     shared_driver, vector_search_supported, workspace, caplog
 ):
-    """A node deleted without nulling its embedding first leaves a dangling
-    vector-index entry (Memgraph's deferred GC). query() must exclude it
-    instead of erroring, and warn with the raw-hit vs live-candidate counts.
+    """A node deleted without nulling its embedding first (bypassing the
+    store's own delete(), which nulls it precisely to avoid this) can still
+    surface as a vector_search.search candidate even though it's gone from
+    the graph. query() must exclude it instead of erroring, and warn with
+    the raw-hit vs live-candidate counts.
     """
     store = MemgraphVectorStorage(
         namespace="chunks",
@@ -469,7 +471,7 @@ async def test_vector_query_logs_and_excludes_gc_pending_deletes(
         )
 
         # Bypass store.delete() (which nulls the embedding first) so the raw
-        # DETACH DELETE leaves a dangling entry in the native vector index.
+        # DETACH DELETE leaves a stale entry in the native vector index.
         driver = await get_driver()
         async with driver.session(database=get_database()) as session:
             await (await session.run(f"MATCH (n:`{store._label}` {{id: 'v-cat'}}) DETACH DELETE n")).consume()
@@ -484,7 +486,7 @@ async def test_vector_query_logs_and_excludes_gc_pending_deletes(
         finally:
             lightrag_logger.removeHandler(caplog.handler)
 
-        # The dangling candidate is excluded, not erroring and not silently
+        # The stale candidate is excluded, not erroring and not silently
         # dropped without a trace.
         assert [r["id"] for r in results] == ["v-kitten"]
         warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]

--- a/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
+++ b/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
@@ -23,6 +23,7 @@ tests actually run there.
 
 from __future__ import annotations
 
+import logging
 import os
 import uuid
 
@@ -34,6 +35,7 @@ from lightrag.utils import EmbeddingFunc
 
 from lightrag_memgraph._connection import (
     close_driver,
+    get_database,
     get_driver,
 )
 from lightrag_memgraph.docstatus_impl import MemgraphDocStatusStorage
@@ -439,5 +441,53 @@ async def test_vector_respects_threshold(shared_driver, vector_search_supported,
         # cos(cat, kitten) = 0.8 < 0.95, so only the exact match survives.
         results = await store.query("cat", top_k=4)
         assert [r["id"] for r in results] == ["v-cat"]
+    finally:
+        await store.drop()
+
+
+async def test_vector_query_logs_and_excludes_gc_pending_deletes(
+    shared_driver, vector_search_supported, workspace, caplog
+):
+    """A node deleted without nulling its embedding first leaves a dangling
+    vector-index entry (Memgraph's deferred GC). query() must exclude it
+    instead of erroring, and warn with the raw-hit vs live-candidate counts.
+    """
+    store = MemgraphVectorStorage(
+        namespace="chunks",
+        workspace=workspace,
+        global_config=_global_config(),
+        embedding_func=_fake_embedding_func(),
+        meta_fields={"content"},
+    )
+    await store.initialize()
+    try:
+        await store.upsert(
+            {
+                "v-cat": {"content": "cat"},
+                "v-kitten": {"content": "kitten"},
+            }
+        )
+
+        # Bypass store.delete() (which nulls the embedding first) so the raw
+        # DETACH DELETE leaves a dangling entry in the native vector index.
+        driver = await get_driver()
+        async with driver.session(database=get_database()) as session:
+            await (await session.run(f"MATCH (n:`{store._label}` {{id: 'v-cat'}}) DETACH DELETE n")).consume()
+
+        # lightrag's logger has propagate=False, so caplog.at_level (which only
+        # relies on root-logger propagation) never sees its records; attach the
+        # capture handler directly instead.
+        lightrag_logger = logging.getLogger("lightrag")
+        lightrag_logger.addHandler(caplog.handler)
+        try:
+            results = await store.query("cat", top_k=4)
+        finally:
+            lightrag_logger.removeHandler(caplog.handler)
+
+        # The dangling candidate is excluded, not erroring and not silently
+        # dropped without a trace.
+        assert [r["id"] for r in results] == ["v-kitten"]
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("vector_search.search returned" in m and "but only" in m for m in warnings), warnings
     finally:
         await store.drop()


### PR DESCRIPTION
## Summary
- `MemgraphVectorStorage.query()` silently dropped vector-search candidates whose backing node had already been deleted (e.g. by a concurrent, not-yet-committed transaction — Memgraph's native vector index runs at `READ_UNCOMMITTED` isolation by design, see [the vector search docs](https://memgraph.com/docs/querying/vector-search)), with no signal to callers that a shortfall could be caused by this rather than a genuine lack of matches.
- The Cypher query now re-matches each raw hit by identity via `OPTIONAL MATCH` (instead of `MATCH`), so a candidate caught mid-delete comes back as a row with `id IS NULL` rather than being silently excluded, letting us count it.
- `query()` now logs a warning with both the raw `vector_search.search()` hit count and the live-candidate count whenever they differ.
- Documented the behavior (README + `query()` docstring) as expected `READ_UNCOMMITTED` behavior under concurrent deletes, not a general "GC lag" limitation.

## Test plan
- [x] Existing vector integration tests still pass (`test_vector_roundtrip_and_nearest_neighbour`, `test_vector_respects_threshold`)
- [x] Added `test_vector_query_logs_and_excludes_stale_candidates`: deletes a node directly (bypassing `store.delete()`, which nulls the embedding first) to leave a stale vector-index entry, then asserts `query()` excludes it and logs the expected warning
- [x] Full suite (`pytest tests/`) passes against a live Memgraph instance: 19 passed
- [x] `ruff check` / `ruff format --check` pass

Fixes #225