### PR TITLE
lightrag-memgraph: reduce duplication across kv/vector/docstatus storage backends

### DIFF
--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/_connection.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/_connection.py
@@ -11,6 +11,7 @@ backend uses different names (``MEMGRAPH_URI``/``USERNAME``), bridged once in
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 from typing import TYPE_CHECKING
 
@@ -19,7 +20,7 @@ from lightrag.utils import logger
 from memgraph_toolbox.api.memgraph import AsyncMemgraph, memgraph_env
 
 if TYPE_CHECKING:
-    from neo4j import AsyncDriver
+    from neo4j import AsyncDriver, AsyncSession
 
 # Keyed by event-loop id so tests spinning up a fresh loop per test don't
 # reuse a driver bound to a closed loop.
@@ -68,3 +69,91 @@ def sanitize_label(value: str) -> str:
 def sanitize_index_name(value: str) -> str:
     """Coerce into a bare identifier: Memgraph vector-index names are unquoted, so replace anything outside [A-Za-z0-9_]."""
     return re.sub(r"[^A-Za-z0-9_]", "_", value)
+
+
+def resolve_workspace(workspace: str | None) -> str:
+    """Resolve the effective workspace for a storage instance.
+
+    ``MEMGRAPH_WORKSPACE`` wins over the constructor argument, which wins over
+    the "base" default -- shared by all three storage backends so this
+    precedence can't drift between them.
+    """
+    return os.environ.get("MEMGRAPH_WORKSPACE") or workspace or "base"
+
+
+async def create_index(session: AsyncSession, *, label: str, prop: str, workspace: str) -> None:
+    """CREATE INDEX on :`label`(prop), swallowing "already exists" (Memgraph has no IF NOT EXISTS)."""
+    try:
+        await (await session.run(f"CREATE INDEX ON :`{label}`({prop})")).consume()
+    except Exception as e:  # index may already exist, which is not an error
+        logger.warning(f"[{workspace}] Index creation on :`{label}`({prop}) may have failed or already exists: {e}")
+
+
+class MemgraphCrudMixin:
+    """Shared ``is_empty``/``filter_keys``/``delete``/``drop`` for the id-keyed,
+    one-label-per-namespace storages (KV and doc-status).
+
+    Requires the including class to set ``self._label`` (a backtick-quoted
+    node label) and ``self.workspace`` in ``__post_init__``. Storages whose
+    deletes need extra bookkeeping (``MemgraphVectorStorage``'s
+    embedding-nulling) override ``delete``/``drop`` instead of using these.
+    """
+
+    _label: str
+    workspace: str
+    namespace: str
+
+    async def is_empty(self) -> bool:
+        driver = await get_driver()
+        async with driver.session(database=get_database(), default_access_mode="READ") as session:
+            result = await session.run(f"MATCH (n:`{self._label}`) RETURN n LIMIT 1")
+            record = await result.single()
+            await result.consume()
+            return record is None
+
+    async def filter_keys(self, keys: set[str]) -> set[str]:
+        # Returns the subset of `keys` that do NOT exist in storage.
+        if not keys:
+            return set()
+        driver = await get_driver()
+        async with driver.session(database=get_database(), default_access_mode="READ") as session:
+            result = await session.run(
+                f"""
+                UNWIND $keys AS k
+                OPTIONAL MATCH (n:`{self._label}` {{id: k}})
+                WITH k, n
+                WHERE n IS NULL
+                RETURN k
+                """,
+                keys=list(keys),
+            )
+            missing = {record["k"] async for record in result}
+            await result.consume()
+        return missing
+
+    async def delete(self, ids: list[str]) -> None:
+        if not ids:
+            return
+        driver = await get_driver()
+        async with driver.session(database=get_database()) as session:
+            await (
+                await session.run(
+                    f"""
+                    UNWIND $ids AS target_id
+                    MATCH (n:`{self._label}` {{id: target_id}})
+                    DETACH DELETE n
+                    """,
+                    ids=list(ids),
+                )
+            ).consume()
+
+    async def drop(self) -> dict[str, str]:
+        try:
+            driver = await get_driver()
+            async with driver.session(database=get_database()) as session:
+                await (await session.run(f"MATCH (n:`{self._label}`) DETACH DELETE n")).consume()
+            logger.info(f"[{self.workspace}] Dropped Memgraph storage for {self.namespace}")
+            return {"status": "success", "message": "data dropped"}
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Error dropping storage for {self.namespace}: {e}")
+            return {"status": "error", "message": str(e)}

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/docstatus_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/docstatus_impl.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from dataclasses import dataclass
 from typing import Any, final
 
@@ -18,9 +17,12 @@ from lightrag.base import DocProcessingStatus, DocStatus, DocStatusStorage
 from lightrag.utils import logger
 
 from ._connection import (
+    MemgraphCrudMixin,
     close_driver,
+    create_index,
     get_database,
     get_driver,
+    resolve_workspace,
     sanitize_label,
 )
 
@@ -31,11 +33,11 @@ _SORT_FIELDS = {"created_at", "updated_at", "id", "file_path"}
 
 @final
 @dataclass
-class MemgraphDocStatusStorage(DocStatusStorage):
+class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
     """Document-status storage backend that persists LightRAG doc status in Memgraph."""
 
     def __post_init__(self):
-        workspace = os.environ.get("MEMGRAPH_WORKSPACE") or self.workspace or "base"
+        workspace = resolve_workspace(self.workspace)
         self.workspace = workspace
         self._label = sanitize_label(f"LightRAGDocStatus_{workspace}")
 
@@ -44,12 +46,7 @@ class MemgraphDocStatusStorage(DocStatusStorage):
         driver = await get_driver()
         async with driver.session(database=get_database()) as session:
             for prop in ("id", *_INDEXED_FIELDS):
-                try:
-                    await (await session.run(f"CREATE INDEX ON :`{self._label}`({prop})")).consume()
-                except Exception as e:
-                    logger.warning(
-                        f"[{self.workspace}] Index creation on :`{self._label}`({prop}) may have failed or already exists: {e}"
-                    )
+                await create_index(session, label=self._label, prop=prop, workspace=self.workspace)
             await (await session.run("RETURN 1")).consume()
         logger.info(f"[{self.workspace}] Initialized Memgraph doc-status storage")
 
@@ -107,25 +104,6 @@ class MemgraphDocStatusStorage(DocStatusStorage):
             await result.consume()
         return [json.loads(found[i]) if i in found else None for i in ids]
 
-    async def filter_keys(self, keys: set[str]) -> set[str]:
-        if not keys:
-            return set()
-        driver = await get_driver()
-        async with driver.session(database=get_database(), default_access_mode="READ") as session:
-            result = await session.run(
-                f"""
-                UNWIND $keys AS k
-                OPTIONAL MATCH (n:`{self._label}` {{id: k}})
-                WITH k, n
-                WHERE n IS NULL
-                RETURN k
-                """,
-                keys=list(keys),
-            )
-            missing = {record["k"] async for record in result}
-            await result.consume()
-        return missing
-
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
             return
@@ -155,29 +133,7 @@ class MemgraphDocStatusStorage(DocStatusStorage):
             ).consume()
         logger.debug(f"[{self.workspace}] Upserted {len(entries)} doc-status records")
 
-    async def delete(self, ids: list[str]) -> None:
-        if not ids:
-            return
-        driver = await get_driver()
-        async with driver.session(database=get_database()) as session:
-            await (
-                await session.run(
-                    f"""
-                    UNWIND $ids AS target_id
-                    MATCH (n:`{self._label}` {{id: target_id}})
-                    DETACH DELETE n
-                    """,
-                    ids=list(ids),
-                )
-            ).consume()
-
-    async def is_empty(self) -> bool:
-        driver = await get_driver()
-        async with driver.session(database=get_database(), default_access_mode="READ") as session:
-            result = await session.run(f"MATCH (n:`{self._label}`) RETURN n LIMIT 1")
-            record = await result.single()
-            await result.consume()
-            return record is None
+    # is_empty/filter_keys/delete are provided by MemgraphCrudMixin.
 
     # --- DocStatusStorage interface ---------------------------------------------
 
@@ -362,13 +318,4 @@ class MemgraphDocStatusStorage(DocStatusStorage):
             return None
         return record["id"], json.loads(record["data"])
 
-    async def drop(self) -> dict[str, str]:
-        try:
-            driver = await get_driver()
-            async with driver.session(database=get_database()) as session:
-                await (await session.run(f"MATCH (n:`{self._label}`) DETACH DELETE n")).consume()
-            logger.info(f"[{self.workspace}] Dropped Memgraph doc-status storage")
-            return {"status": "success", "message": "data dropped"}
-        except Exception as e:
-            logger.error(f"[{self.workspace}] Error dropping doc-status storage: {e}")
-            return {"status": "error", "message": str(e)}
+    # drop() is provided by MemgraphCrudMixin.

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/kv_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/kv_impl.py
@@ -9,7 +9,6 @@ entity nodes (which use the bare workspace label).
 from __future__ import annotations
 
 import json
-import os
 import time
 from dataclasses import dataclass
 from typing import Any, final
@@ -18,20 +17,23 @@ from lightrag.base import BaseKVStorage
 from lightrag.utils import logger
 
 from ._connection import (
+    MemgraphCrudMixin,
     close_driver,
+    create_index,
     get_database,
     get_driver,
+    resolve_workspace,
     sanitize_label,
 )
 
 
 @final
 @dataclass
-class MemgraphKVStorage(BaseKVStorage):
+class MemgraphKVStorage(MemgraphCrudMixin, BaseKVStorage):
     """Key/value storage backend that persists LightRAG KV namespaces in Memgraph."""
 
     def __post_init__(self):
-        workspace = os.environ.get("MEMGRAPH_WORKSPACE") or self.workspace or "base"
+        workspace = resolve_workspace(self.workspace)
         self.workspace = workspace
         self._label = sanitize_label(f"LightRAGKV_{workspace}_{self.namespace}")
 
@@ -39,12 +41,7 @@ class MemgraphKVStorage(BaseKVStorage):
         """Create the id index for this namespace (idempotent)."""
         driver = await get_driver()
         async with driver.session(database=get_database()) as session:
-            try:
-                await (await session.run(f"CREATE INDEX ON :`{self._label}`(id)")).consume()
-            except Exception as e:  # index may already exist, which is not an error
-                logger.warning(
-                    f"[{self.workspace}] Index creation on :`{self._label}`(id) may have failed or already exists: {e}"
-                )
+            await create_index(session, label=self._label, prop="id", workspace=self.workspace)
             await (await session.run("RETURN 1")).consume()
         logger.info(f"[{self.workspace}] Initialized Memgraph KV storage for {self.namespace}")
 
@@ -97,26 +94,6 @@ class MemgraphKVStorage(BaseKVStorage):
             await result.consume()
         return [self._decode(i, found.get(i)) for i in ids]
 
-    async def filter_keys(self, keys: set[str]) -> set[str]:
-        # Returns the subset of `keys` that do NOT exist in storage.
-        if not keys:
-            return set()
-        driver = await get_driver()
-        async with driver.session(database=get_database(), default_access_mode="READ") as session:
-            result = await session.run(
-                f"""
-                UNWIND $keys AS k
-                OPTIONAL MATCH (n:`{self._label}` {{id: k}})
-                WITH k, n
-                WHERE n IS NULL
-                RETURN k
-                """,
-                keys=list(keys),
-            )
-            missing = {record["k"] async for record in result}
-            await result.consume()
-        return missing
-
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
             return
@@ -161,37 +138,4 @@ class MemgraphKVStorage(BaseKVStorage):
             ).consume()
         logger.debug(f"[{self.workspace}] Upserted {len(entries)} records to {self.namespace}")
 
-    async def delete(self, ids: list[str]) -> None:
-        if not ids:
-            return
-        driver = await get_driver()
-        async with driver.session(database=get_database()) as session:
-            await (
-                await session.run(
-                    f"""
-                    UNWIND $ids AS target_id
-                    MATCH (n:`{self._label}` {{id: target_id}})
-                    DETACH DELETE n
-                    """,
-                    ids=list(ids),
-                )
-            ).consume()
-
-    async def is_empty(self) -> bool:
-        driver = await get_driver()
-        async with driver.session(database=get_database(), default_access_mode="READ") as session:
-            result = await session.run(f"MATCH (n:`{self._label}`) RETURN n LIMIT 1")
-            record = await result.single()
-            await result.consume()
-            return record is None
-
-    async def drop(self) -> dict[str, str]:
-        try:
-            driver = await get_driver()
-            async with driver.session(database=get_database()) as session:
-                await (await session.run(f"MATCH (n:`{self._label}`) DETACH DELETE n")).consume()
-            logger.info(f"[{self.workspace}] Dropped Memgraph KV storage for {self.namespace}")
-            return {"status": "success", "message": "data dropped"}
-        except Exception as e:
-            logger.error(f"[{self.workspace}] Error dropping KV storage {self.namespace}: {e}")
-            return {"status": "error", "message": str(e)}
+    # is_empty/filter_keys/delete/drop are provided by MemgraphCrudMixin.

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
@@ -10,7 +10,6 @@ with the embedding on an ``embedding`` property.
 from __future__ import annotations
 
 import asyncio
-import os
 import time
 from dataclasses import dataclass
 from typing import Any, final
@@ -21,8 +20,10 @@ from lightrag.utils import compute_mdhash_id, logger
 
 from ._connection import (
     close_driver,
+    create_index,
     get_database,
     get_driver,
+    resolve_workspace,
     sanitize_index_name,
     sanitize_label,
 )
@@ -38,7 +39,7 @@ class MemgraphVectorStorage(BaseVectorStorage):
 
     def __post_init__(self):
         self._validate_embedding_func()
-        workspace = os.environ.get("MEMGRAPH_WORKSPACE") or self.workspace or "base"
+        workspace = resolve_workspace(self.workspace)
         self.workspace = workspace
         self._label = sanitize_label(f"LightRAGVector_{workspace}_{self.namespace}")
         self._index_name = sanitize_index_name(f"lightrag_vec_{workspace}_{self.namespace}")
@@ -58,12 +59,7 @@ class MemgraphVectorStorage(BaseVectorStorage):
         """Create the id index and the native vector index (both idempotent)."""
         driver = await get_driver()
         async with driver.session(database=get_database()) as session:
-            try:
-                await (await session.run(f"CREATE INDEX ON :`{self._label}`(id)")).consume()
-            except Exception as e:
-                logger.warning(
-                    f"[{self.workspace}] Index creation on :`{self._label}`(id) may have failed or already exists: {e}"
-                )
+            await create_index(session, label=self._label, prop="id", workspace=self.workspace)
             await self._ensure_vector_index(session)
             await (await session.run("RETURN 1")).consume()
         logger.info(
@@ -281,52 +277,51 @@ class MemgraphVectorStorage(BaseVectorStorage):
             await result.consume()
         return vectors
 
-    async def delete(self, ids: list[str]):
-        if not ids:
-            return
+    async def _detach_delete(self, where_clause: str, params: dict[str, Any]) -> None:
+        """Null the embedding then DETACH DELETE the nodes matched by ``where_clause``.
+
+        Nulling first makes a to-be-deleted entry leave the native vector index
+        before the node itself is removed -- a bare delete can still surface via
+        vector_search.search while the delete transaction is in flight (see
+        query()'s note on READ_UNCOMMITTED). Every deletion path (delete,
+        delete_entity_relation, drop) routes through here so none of them can
+        forget this step.
+        """
         driver = await get_driver()
         async with driver.session(database=get_database()) as session:
-            # Null the embedding before DETACH DELETE so the entry leaves the vector index
-            # (a bare delete can still surface via vector_search.search while this
-            # transaction is in flight -- see query()'s note on READ_UNCOMMITTED).
             await (
                 await session.run(
                     f"""
-                    UNWIND $ids AS target_id
-                    MATCH (n:`{self._label}` {{id: target_id}})
+                    MATCH (n:`{self._label}`)
+                    {where_clause}
                     SET n.embedding = NULL
                     DETACH DELETE n
                     """,
-                    ids=list(ids),
+                    **params,
                 )
             ).consume()
+
+    async def delete(self, ids: list[str]):
+        if not ids:
+            return
+        await self._detach_delete("WHERE n.id IN $ids", {"ids": list(ids)})
 
     async def delete_entity(self, entity_name: str) -> None:
         entity_id = compute_mdhash_id(entity_name, prefix="ent-")
         await self.delete([entity_id])
 
     async def delete_entity_relation(self, entity_name: str) -> None:
-        driver = await get_driver()
-        async with driver.session(database=get_database()) as session:
-            # See delete() -- null the embedding first so these leave the vector index.
-            await (
-                await session.run(
-                    f"""
-                    MATCH (n:`{self._label}`)
-                    WHERE n.src_id = $entity_name OR n.tgt_id = $entity_name
-                    SET n.embedding = NULL
-                    DETACH DELETE n
-                    """,
-                    entity_name=entity_name,
-                )
-            ).consume()
+        await self._detach_delete(
+            "WHERE n.src_id = $entity_name OR n.tgt_id = $entity_name",
+            {"entity_name": entity_name},
+        )
 
     async def drop(self) -> dict[str, str]:
         try:
+            # Null embeddings first in case DROP VECTOR INDEX below fails (see _detach_delete()).
+            await self._detach_delete("", {})
             driver = await get_driver()
             async with driver.session(database=get_database()) as session:
-                # Null embeddings first in case DROP VECTOR INDEX below fails (see delete()).
-                await (await session.run(f"MATCH (n:`{self._label}`) SET n.embedding = NULL DETACH DELETE n")).consume()
                 try:
                     await (await session.run(f"DROP VECTOR INDEX {self._index_name}")).consume()
                 except Exception as e:

--- a/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
@@ -15,6 +15,36 @@ MEMGRAPH_ENV_DEFAULTS = {
 MEMGRAPH_ENV_KEYS = tuple(MEMGRAPH_ENV_DEFAULTS)
 
 
+def _is_implicit_transaction_fallback_error(error: Any) -> bool:
+    """True if `error` (a ``Neo4jError``) means the query can't run in a managed
+    transaction and should be retried as an implicit one.
+
+    Shared by :meth:`Memgraph.query` and :meth:`AsyncMemgraph.query` so the two
+    stay in lockstep instead of drifting as two hand-copied predicates.
+    """
+    return (
+        (
+            (  # isCallInTransactionError
+                error.code == "Neo.DatabaseError.Statement.ExecutionFailed"
+                or error.code == "Neo.DatabaseError.Transaction.TransactionStartFailed"
+            )
+            and "in an implicit transaction" in error.message
+        )
+        or (  # isPeriodicCommitError
+            error.code == "Neo.ClientError.Statement.SemanticError"
+            and (
+                "in an open transaction is not possible" in error.message
+                or "tried to execute in an explicit transaction" in error.message
+            )
+        )
+        or (
+            error.code == "Memgraph.ClientError.MemgraphError.MemgraphError"
+            and ("in multicommand transactions" in error.message)
+        )
+        or (error.code == "Memgraph.ClientError.MemgraphError.MemgraphError" and "SchemaInfo disabled" in error.message)
+    )
+
+
 def memgraph_env(
     *,
     url: str | None = None,
@@ -133,27 +163,7 @@ class Memgraph:
             json_data = [serialize_record_data(r.data()) for r in data]
             return json_data
         except Neo4jError as e:
-            if not (
-                (
-                    (  # isCallInTransactionError
-                        e.code == "Neo.DatabaseError.Statement.ExecutionFailed"
-                        or e.code == "Neo.DatabaseError.Transaction.TransactionStartFailed"
-                    )
-                    and "in an implicit transaction" in e.message
-                )
-                or (  # isPeriodicCommitError
-                    e.code == "Neo.ClientError.Statement.SemanticError"
-                    and (
-                        "in an open transaction is not possible" in e.message
-                        or "tried to execute in an explicit transaction" in e.message
-                    )
-                )
-                or (
-                    e.code == "Memgraph.ClientError.MemgraphError.MemgraphError"
-                    and ("in multicommand transactions" in e.message)
-                )
-                or (e.code == "Memgraph.ClientError.MemgraphError.MemgraphError" and "SchemaInfo disabled" in e.message)
-            ):
+            if not _is_implicit_transaction_fallback_error(e):
                 raise
 
         # fallback to allow implicit transactions
@@ -253,27 +263,7 @@ class AsyncMemgraph:
             json_data = [serialize_record_data(r.data()) for r in data]
             return json_data
         except Neo4jError as e:
-            if not (
-                (
-                    (  # isCallInTransactionError
-                        e.code == "Neo.DatabaseError.Statement.ExecutionFailed"
-                        or e.code == "Neo.DatabaseError.Transaction.TransactionStartFailed"
-                    )
-                    and "in an implicit transaction" in e.message
-                )
-                or (  # isPeriodicCommitError
-                    e.code == "Neo.ClientError.Statement.SemanticError"
-                    and (
-                        "in an open transaction is not possible" in e.message
-                        or "tried to execute in an explicit transaction" in e.message
-                    )
-                )
-                or (
-                    e.code == "Memgraph.ClientError.MemgraphError.MemgraphError"
-                    and ("in multicommand transactions" in e.message)
-                )
-                or (e.code == "Memgraph.ClientError.MemgraphError.MemgraphError" and "SchemaInfo disabled" in e.message)
-            ):
+            if not _is_implicit_transaction_fallback_error(e):
                 raise
 
         # fallback to allow implicit transactions


### PR DESCRIPTION
## Summary

- Adds `resolve_workspace()`, `create_index()`, and `MemgraphCrudMixin` (`is_empty`/`filter_keys`/`delete`/`drop`) to `_connection.py`; `kv_impl.py` and `docstatus_impl.py` now use the mixin instead of hand-copied CRUD methods.
- `AsyncMemgraph.query()` and `Memgraph.query()` in `memgraph-toolbox` now share one `_is_implicit_transaction_fallback_error()` predicate instead of two copies of the same ~25-line Neo4jError classification block.
- `MemgraphVectorStorage`'s "null the embedding before DETACH DELETE" workaround (needed because Memgraph's vector index runs at READ_UNCOMMITTED with deferred GC) is now funneled through one `_detach_delete(where_clause, params)` helper used by `delete()`, `delete_entity_relation()`, and `drop()`.

No behavior changes intended — same Cypher semantics, same public API.

Closes #224

## Test plan
- [x] `pytest integrations/lightrag-memgraph/tests/` (19 passed, unit only)
- [x] `pytest integrations/lightrag-memgraph/tests/test_integration_memgraph.py` against a live local Memgraph (5 passed, exercises the refactored is_empty/filter_keys/delete/drop and vector embedding-nulling paths end to end)
- [x] `pytest memgraph-toolbox/src/memgraph_toolbox/tests/test_toolbox.py test_async_memgraph.py` (6 passed, exercises both `Memgraph.query()` and `AsyncMemgraph.query()` live)
- [x] `ruff check` / `ruff format --check` clean