### PR TITLE
lightrag-memgraph: re-cap lightrag-hku <1.6 and guard registry internals

### DIFF
--- a/integrations/lightrag-memgraph/pyproject.toml
+++ b/integrations/lightrag-memgraph/pyproject.toml
@@ -22,12 +22,9 @@ classifiers = [
 ]
 
 dependencies = [
-    # Capped below 1.6: 1.5.4 added new abstract DocStatusStorage methods
-    # (get_doc_by_file_basename, get_doc_by_content_hash, and a status_filters
-    # param on get_docs_paginated) that broke this integration until it was
-    # updated to match. registry.py also monkey-patches undocumented
-    # lightrag.kg internals, so a 1.6+ release is not safe to pick up silently.
-    # Bump only after verifying compatibility against the new release.
+    # Capped below 1.6: 1.5.4 broke this integration's DocStatusStorage once
+    # already (see registry.py's compat guard). Bump only after verifying
+    # compatibility with the new release.
     "lightrag-hku>=1.5,<1.6",
     "memgraph-toolbox>=0.1.11",
     "numpy>=1.22.0",

--- a/integrations/lightrag-memgraph/pyproject.toml
+++ b/integrations/lightrag-memgraph/pyproject.toml
@@ -22,7 +22,13 @@ classifiers = [
 ]
 
 dependencies = [
-    "lightrag-hku>=1.5",
+    # Capped below 1.6: 1.5.4 added new abstract DocStatusStorage methods
+    # (get_doc_by_file_basename, get_doc_by_content_hash, and a status_filters
+    # param on get_docs_paginated) that broke this integration until it was
+    # updated to match. registry.py also monkey-patches undocumented
+    # lightrag.kg internals, so a 1.6+ release is not safe to pick up silently.
+    # Bump only after verifying compatibility against the new release.
+    "lightrag-hku>=1.5,<1.6",
     "memgraph-toolbox>=0.1.11",
     "numpy>=1.22.0",
     "anthropic>=0.40.0",

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/registry.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/registry.py
@@ -10,6 +10,8 @@ it's idempotent.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
+
 import lightrag.kg as _kg
 from lightrag.utils import logger
 
@@ -26,11 +28,60 @@ _ENV_REQUIREMENTS = ["MEMGRAPH_URL"]
 _registered = False
 
 
+class LightRAGCompatibilityError(RuntimeError):
+    """lightrag.kg's internal registry doesn't have the shape this integration expects.
+
+    STORAGES, STORAGE_IMPLEMENTATIONS and STORAGE_ENV_REQUIREMENTS are undocumented
+    lightrag.kg internals, not a public plugin API, so a lightrag-hku release can
+    change their shape without notice (pyproject.toml pins lightrag-hku<1.6 for this
+    reason). Raised instead of letting a raw KeyError/AttributeError surface from
+    deep inside registration.
+    """
+
+
+def _installed_lightrag_version() -> str:
+    try:
+        return version("lightrag-hku")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _check_lightrag_kg_shape() -> None:
+    problem = None
+    if not hasattr(_kg, "STORAGES"):
+        problem = "lightrag.kg.STORAGES no longer exists"
+    elif not hasattr(_kg, "STORAGE_IMPLEMENTATIONS"):
+        problem = "lightrag.kg.STORAGE_IMPLEMENTATIONS no longer exists"
+    elif not hasattr(_kg, "STORAGE_ENV_REQUIREMENTS"):
+        problem = "lightrag.kg.STORAGE_ENV_REQUIREMENTS no longer exists"
+    else:
+        for storage_type in {storage_type for storage_type, _ in _STORAGES.values()}:
+            entry = _kg.STORAGE_IMPLEMENTATIONS.get(storage_type)
+            if not isinstance(entry, dict) or "implementations" not in entry:
+                problem = (
+                    f"lightrag.kg.STORAGE_IMPLEMENTATIONS[{storage_type!r}] is missing or has no 'implementations' list"
+                )
+                break
+
+    if problem:
+        raise LightRAGCompatibilityError(
+            f"lightrag-memgraph is incompatible with the installed lightrag-hku "
+            f"{_installed_lightrag_version()}: {problem}. This integration is "
+            "pinned to lightrag-hku>=1.5,<1.6 in pyproject.toml precisely because "
+            "it monkey-patches these undocumented lightrag.kg internals; install "
+            "a version within that range, or update "
+            "lightrag_memgraph.registry.register_memgraph_storage() for the new "
+            "lightrag.kg layout."
+        )
+
+
 def register_memgraph_storage() -> None:
     """Patch LightRAG's storage registry to accept the Memgraph backends by name. Idempotent."""
     global _registered
     if _registered:
         return
+
+    _check_lightrag_kg_shape()
 
     for name, (storage_type, module_path) in _STORAGES.items():
         _kg.STORAGES[name] = module_path  # absolute module path for lazy import

--- a/integrations/lightrag-memgraph/tests/test_storages.py
+++ b/integrations/lightrag-memgraph/tests/test_storages.py
@@ -62,6 +62,34 @@ def test_verify_storage_implementation_accepts_names(name, storage_type):
     verify_storage_implementation(storage_type, name)
 
 
+def test_check_lightrag_kg_shape_reports_missing_attribute(monkeypatch):
+    import lightrag.kg as kg
+
+    from lightrag_memgraph.registry import (
+        LightRAGCompatibilityError,
+        _check_lightrag_kg_shape,
+    )
+
+    monkeypatch.delattr(kg, "STORAGE_ENV_REQUIREMENTS")
+
+    with pytest.raises(LightRAGCompatibilityError, match="STORAGE_ENV_REQUIREMENTS"):
+        _check_lightrag_kg_shape()
+
+
+def test_check_lightrag_kg_shape_reports_missing_implementations_key(monkeypatch):
+    import lightrag.kg as kg
+
+    from lightrag_memgraph.registry import (
+        LightRAGCompatibilityError,
+        _check_lightrag_kg_shape,
+    )
+
+    monkeypatch.setitem(kg.STORAGE_IMPLEMENTATIONS, "KV_STORAGE", {})
+
+    with pytest.raises(LightRAGCompatibilityError, match="KV_STORAGE"):
+        _check_lightrag_kg_shape()
+
+
 def test_kv_storage_instantiation():
     from lightrag_memgraph import MemgraphKVStorage
 


### PR DESCRIPTION
## Summary
- Re-add the `lightrag-hku<1.6` upper bound that was dropped without justification in 39327f8, with the reasoning documented in `pyproject.toml` this time: 1.5.4 added new abstract `DocStatusStorage` methods (`get_doc_by_file_basename`, `get_doc_by_content_hash`, `status_filters` on `get_docs_paginated`) that broke this integration until it was updated to match.
- `register_memgraph_storage()` now validates that `lightrag.kg`'s `STORAGES`, `STORAGE_IMPLEMENTATIONS`, and `STORAGE_ENV_REQUIREMENTS` still have the expected shape before mutating them, raising a clear `LightRAGCompatibilityError` (instead of a raw `KeyError`/`AttributeError`) if a future lightrag-hku release changes these undocumented internals.
- Added tests covering the new compatibility guard (missing attribute, missing `"implementations"` key).

Closes #216

## Test plan
- [x] `pytest tests/test_storages.py tests/test_import.py` — 16 passed
- [x] `pre-commit` hooks (ruff, ruff-format, etc.) pass