### PR TITLE
fix(lightrag-memgraph): full_memgraph_persistence=False breaks zero-config default Memgraph

### DIFF
--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
@@ -14,9 +14,13 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 def _bridge_lightrag_env_names() -> None:
     """Mirror MEMGRAPH_URL/USER onto LightRAG's graph-backend names (MEMGRAPH_URI/USERNAME) so
     both resolve to the same instance from one env set. Never overwrites an explicit override.
+
+    If neither name is set, default MEMGRAPH_URI to the local default Memgraph instance, matching
+    the zero-config behaviour of a locally-running default Memgraph.
     """
     if "MEMGRAPH_URL" in os.environ and "MEMGRAPH_URI" not in os.environ:
         os.environ["MEMGRAPH_URI"] = os.environ["MEMGRAPH_URL"]
+    os.environ.setdefault("MEMGRAPH_URI", "bolt://localhost:7687")
     if "MEMGRAPH_USER" in os.environ and "MEMGRAPH_USERNAME" not in os.environ:
         os.environ["MEMGRAPH_USERNAME"] = os.environ["MEMGRAPH_USER"]
 

--- a/integrations/lightrag-memgraph/tests/test_core.py
+++ b/integrations/lightrag-memgraph/tests/test_core.py
@@ -1,0 +1,65 @@
+"""Unit tests for lightrag_memgraph.core's env-name bridging.
+
+These don't need a live Memgraph: they only check what _bridge_lightrag_env_names
+writes into os.environ.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from lightrag_memgraph.core import _bridge_lightrag_env_names
+
+_MEMGRAPH_ENV_NAMES = ("MEMGRAPH_URL", "MEMGRAPH_URI", "MEMGRAPH_USER", "MEMGRAPH_USERNAME")
+
+
+@pytest.fixture(autouse=True)
+def _clear_memgraph_env(monkeypatch):
+    """Isolate every test from both the ambient environment and each other.
+
+    _bridge_lightrag_env_names writes to os.environ directly (not through
+    monkeypatch), so teardown must scrub it explicitly or a value set by one
+    test would leak into the next.
+    """
+    for name in _MEMGRAPH_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    yield
+    for name in _MEMGRAPH_ENV_NAMES:
+        os.environ.pop(name, None)
+
+
+def test_bridge_defaults_uri_to_local_memgraph_when_nothing_set():
+    """Regression test for #217: with zero Memgraph env vars set, MEMGRAPH_URI
+    must still end up pointing at the local default Memgraph, matching the
+    behaviour on main (which defaulted it unconditionally at import time).
+    """
+    _bridge_lightrag_env_names()
+    assert os.environ["MEMGRAPH_URI"] == "bolt://localhost:7687"
+
+
+def test_bridge_mirrors_url_onto_uri(monkeypatch):
+    monkeypatch.setenv("MEMGRAPH_URL", "bolt://example:1234")
+    _bridge_lightrag_env_names()
+    assert os.environ["MEMGRAPH_URI"] == "bolt://example:1234"
+
+
+def test_bridge_never_overwrites_explicit_uri(monkeypatch):
+    monkeypatch.setenv("MEMGRAPH_URL", "bolt://example:1234")
+    monkeypatch.setenv("MEMGRAPH_URI", "bolt://explicit:9999")
+    _bridge_lightrag_env_names()
+    assert os.environ["MEMGRAPH_URI"] == "bolt://explicit:9999"
+
+
+def test_bridge_mirrors_user_onto_username(monkeypatch):
+    monkeypatch.setenv("MEMGRAPH_USER", "alice")
+    _bridge_lightrag_env_names()
+    assert os.environ["MEMGRAPH_USERNAME"] == "alice"
+
+
+def test_bridge_never_overwrites_explicit_username(monkeypatch):
+    monkeypatch.setenv("MEMGRAPH_USER", "alice")
+    monkeypatch.setenv("MEMGRAPH_USERNAME", "bob")
+    _bridge_lightrag_env_names()
+    assert os.environ["MEMGRAPH_USERNAME"] == "bob"

--- a/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
+++ b/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
@@ -33,6 +33,7 @@ import pytest_asyncio
 from lightrag.base import DocStatus
 from lightrag.utils import EmbeddingFunc
 
+from lightrag_memgraph import MemgraphLightRAGWrapper
 from lightrag_memgraph._connection import (
     close_driver,
     get_database,
@@ -493,3 +494,77 @@ async def test_vector_query_logs_and_excludes_stale_candidates(
         assert any("vector_search.search returned" in m and "but only" in m for m in warnings), warnings
     finally:
         await store.drop()
+
+
+# --- zero-config MemgraphLightRAGWrapper (#217 regression) -------------------
+
+# All Memgraph-related names the wrapper/backends could possibly read, so the
+# regression test below can genuinely start from zero Memgraph env vars.
+_ALL_MEMGRAPH_ENV_NAMES = (
+    "MEMGRAPH_URL",
+    "MEMGRAPH_URI",
+    "MEMGRAPH_USER",
+    "MEMGRAPH_USERNAME",
+    "MEMGRAPH_PASSWORD",
+    "MEMGRAPH_DATABASE",
+    "MEMGRAPH_HOST",
+    "MEMGRAPH_PORT",
+    "MEMGRAPH_WORKSPACE",
+)
+
+
+@pytest.fixture(scope="session")
+def default_memgraph_reachable() -> None:
+    """Skip unless a Memgraph is reachable at the true zero-config default:
+    bolt://localhost:7687 with no auth. This is what full_memgraph_persistence=False
+    must fall back to with no Memgraph env vars set at all, independent of whatever
+    MEMGRAPH_URL the rest of this module resolves to.
+    """
+    from neo4j import GraphDatabase
+
+    driver = None
+    try:
+        driver = GraphDatabase.driver("bolt://localhost:7687", auth=("", ""), connection_timeout=5)
+        driver.verify_connectivity()
+    except Exception as exc:  # pragma: no cover - depends on the environment
+        pytest.skip(f"No live Memgraph reachable at the zero-config default bolt://localhost:7687: {exc}")
+    finally:
+        if driver is not None:
+            driver.close()
+
+
+async def _dummy_llm_model_func(prompt, **kwargs):
+    return "dummy response"
+
+
+async def test_wrapper_full_persistence_false_works_with_zero_env_vars(
+    default_memgraph_reachable, tmp_path, monkeypatch
+):
+    """Regression test for #217.
+
+    MemgraphLightRAGWrapper(full_memgraph_persistence=False).initialize(...) must
+    work with zero Memgraph-related env vars set, against a local default Memgraph,
+    same as on main. Before the fix, _bridge_lightrag_env_names() left MEMGRAPH_URI
+    unset in this case, and LightRAG's own MemgraphStorage graph backend raised
+    ValueError("... requires the following environment variables: MEMGRAPH_URI")
+    during initialize_storages().
+    """
+    for name in _ALL_MEMGRAPH_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+    wrapper = MemgraphLightRAGWrapper(full_memgraph_persistence=False)
+    ws = "it_" + uuid.uuid4().hex[:10]
+    try:
+        await wrapper.initialize(
+            working_dir=str(tmp_path),
+            workspace=ws,
+            embedding_func=_fake_embedding_func(),
+            llm_model_func=_dummy_llm_model_func,
+        )
+        graph = wrapper.get_lightrag().chunk_entity_relation_graph
+        # A real round trip against Memgraph, not just a successful construction.
+        result = await graph.drop()
+        assert result["status"] == "success"
+    finally:
+        if wrapper.rag is not None:
+            await wrapper.afinalize()


### PR DESCRIPTION
## Summary

- `_bridge_lightrag_env_names()` only mirrored `MEMGRAPH_URL` onto `MEMGRAPH_URI` when `MEMGRAPH_URL` was already set in the environment, so a zero-env-var setup no longer got the unconditional `bolt://localhost:7687` default the pre-refactor code applied at import time.
- LightRAG's built-in `MemgraphStorage` graph backend requires `MEMGRAPH_URI` to literally be present in `os.environ` (checked by `check_storage_env_vars`, independent of its own in-code fallback), so `MemgraphLightRAGWrapper(full_memgraph_persistence=False).initialize(...)` raised `ValueError: Storage implementation 'MemgraphStorage' requires the following environment variables: MEMGRAPH_URI` instead of just working against a local default Memgraph.
- Fix: default `MEMGRAPH_URI` to `bolt://localhost:7687` via `os.environ.setdefault(...)` when neither `MEMGRAPH_URL` nor `MEMGRAPH_URI` is set, restoring the previous zero-config behavior without touching any explicit override.

Fixes #217

## Test plan

- [x] New unit tests in `tests/test_core.py` covering `_bridge_lightrag_env_names()`: default-when-nothing-set, mirroring `MEMGRAPH_URL`/`MEMGRAPH_USER`, and never overwriting explicit `MEMGRAPH_URI`/`MEMGRAPH_USERNAME`.
- [x] New regression test in `tests/test_integration_memgraph.py` (`test_wrapper_full_persistence_false_works_with_zero_env_vars`) that clears all Memgraph-related env vars, initializes `MemgraphLightRAGWrapper(full_memgraph_persistence=False)`, and does a real round trip against a local Memgraph (skips if none reachable).
- [x] Verified the new integration test fails with the exact error from the issue when the fix is reverted, and passes with it applied.
- [x] Full `pytest` suite for `integrations/lightrag-memgraph` passes (27 passed) against a live local Memgraph.
- [x] `ruff check` / `ruff format --check` pass on changed files.