### PR TITLE
lightrag-memgraph: default embedding_func to Memgraph's local sentence-transformer

### DIFF
--- a/integrations/lightrag-memgraph/README.md
+++ b/integrations/lightrag-memgraph/README.md
@@ -106,9 +106,8 @@ If `embedding_func` is not passed to `initialize()`, the wrapper defaults to
 `embeddings.text()` procedure. This requires no API key and makes no external
 network calls -- unlike LightRAG's own `openai_embed`, which used to be this
 wrapper's silent default and would bill your `OPENAI_API_KEY` for every
-insert/query even if you only meant to use OpenAI for the LLM, or not at all
-(see [#222](https://github.com/memgraph/ai-toolkit/issues/222)). Applying this
-default is logged as a warning so it's never silent.
+insert/query even if you only meant to use OpenAI for the LLM, or not at all.
+Applying this default is logged as a warning so it's never silent.
 
 This default requires the `memgraph-mage` Docker image (not plain `memgraph`)
 so the `embeddings` module is loaded.

--- a/integrations/lightrag-memgraph/README.md
+++ b/integrations/lightrag-memgraph/README.md
@@ -20,9 +20,10 @@ specific document page or chunk).
 
 ## Quick start
 
-**Prerequisites:** [Memgraph](https://memgraph.com/docs/getting-started) running
-*(default `bolt://localhost:7687`), and an LLM API key (e.g. `OPENAI_API_KEY` or
-*`ANTHROPIC_API_KEY`).
+**Prerequisites:** [Memgraph MAGE](https://memgraph.com/docs/getting-started)
+running (default `bolt://localhost:7687`; the `memgraph-mage` image, not plain
+`memgraph`, since the default embeddings below need its `embeddings` module),
+and an LLM API key (e.g. `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`).
 
 **Install:**
 
@@ -64,7 +65,8 @@ Memgraph, not just the entity/relationship graph:
 The KV/vector/doc-status labels are namespaced by workspace + namespace so they
 never collide with the graph's entity nodes. Vectors always persist to
 Memgraph's native vector index (`CREATE VECTOR INDEX ... {"metric": "cos"}` +
-`CALL vector_search.search(...)`), so a real `embedding_func` is required.
+`CALL vector_search.search(...)`), so a real `embedding_func` is required --
+see [Embeddings](#embeddings) below for the default.
 
 Connection settings are read from the same environment variables as lightrag's
 graph backend: `MEMGRAPH_URI` (or `MEMGRAPH_URL`, which the wrapper bridges to
@@ -95,6 +97,36 @@ rag = LightRAG(
 )
 ```
 
+## Embeddings
+
+If `embedding_func` is not passed to `initialize()`, the wrapper defaults to
+`memgraph_sentence_embed`: a local sentence-transformer (`all-MiniLM-L6-v2`,
+384 dims) run by Memgraph itself, via the
+[`embeddings` MAGE module](https://memgraph.com/docs/advanced-algorithms/available-algorithms/embeddings)'s
+`embeddings.text()` procedure. This requires no API key and makes no external
+network calls -- unlike LightRAG's own `openai_embed`, which used to be this
+wrapper's silent default and would bill your `OPENAI_API_KEY` for every
+insert/query even if you only meant to use OpenAI for the LLM, or not at all
+(see [#222](https://github.com/memgraph/ai-toolkit/issues/222)). Applying this
+default is logged as a warning so it's never silent.
+
+This default requires the `memgraph-mage` Docker image (not plain `memgraph`)
+so the `embeddings` module is loaded.
+
+To use a different local model served the same way, build a variant with
+`build_memgraph_sentence_embed`:
+
+```python
+from lightrag_memgraph import build_memgraph_sentence_embed
+
+# A different local model -- embedding_dim must match what it actually outputs.
+embedding_func = build_memgraph_sentence_embed(model_name="all-mpnet-base-v2", embedding_dim=768)
+```
+
+To use OpenAI/Anthropic-compatible/other Python embedding functions instead,
+pass `embedding_func` explicitly, as shown in the Anthropic and OpenAI
+sections below.
+
 ## Using Anthropic (Claude) as the LLM
 
 LightRAG supports Claude via the `lightrag.llm.anthropic` module. Set your API
@@ -112,7 +144,6 @@ https://platform.claude.com/docs/en/about-claude/models.
 
    ```python
    from lightrag.llm.anthropic import anthropic_complete
-   from lightrag.llm.openai import openai_embed
    from lightrag_memgraph import MemgraphLightRAGWrapper
 
    wrapper = MemgraphLightRAGWrapper()
@@ -120,7 +151,8 @@ https://platform.claude.com/docs/en/about-claude/models.
        working_dir="./lightrag_storage",
        llm_model_func=anthropic_complete,
        llm_model_name="claude-3-5-sonnet-20241022",  # or claude-3-haiku-20240307, etc.
-       embedding_func=openai_embed,  # Anthropic has no embeddings; supply one
+       # embedding_func omitted: defaults to Memgraph's local sentence-transformer,
+       # see Embeddings above. Anthropic itself has no embeddings API.
    )
    ```
 
@@ -129,11 +161,13 @@ https://platform.claude.com/docs/en/about-claude/models.
    IDs). For current models, use `anthropic_complete` with the desired
    `llm_model_name`.
 
-3. **Embeddings**: Anthropic does not provide embeddings, and vectors always
-persist to Memgraph's native vector index, so a real `embedding_func` is
-required. Set `embedding_func` to another provider (e.g. `openai_embed` from
-`lightrag.llm.openai` with `OPENAI_API_KEY`, or Voyage AI via
-`lightrag.llm.anthropic.anthropic_embed` with `VOYAGE_API_KEY`).
+3. **Embeddings**: Anthropic does not provide embeddings. Leaving
+`embedding_func` unset (as above) uses Memgraph's local sentence-transformer
+default -- no additional API key needed, no silent no-op option exists (a real
+`embedding_func` always runs since vectors persist to Memgraph's native vector
+index). To use a different provider instead, set `embedding_func` explicitly,
+e.g. `openai_embed` from `lightrag.llm.openai` with `OPENAI_API_KEY`, or
+Voyage AI via `lightrag.llm.anthropic.anthropic_embed` with `VOYAGE_API_KEY`.
 
 ## Using OpenAI as the LLM
 

--- a/integrations/lightrag-memgraph/example.py
+++ b/integrations/lightrag-memgraph/example.py
@@ -5,8 +5,8 @@ import time
 import traceback
 
 # OpenAI-only for a single-API-key example. To use Claude instead, see the
-# README's "Using Anthropic (Claude)" section (needs a separate embedder).
-from lightrag.llm.openai import gpt_4o_mini_complete, openai_embed
+# README's "Using Anthropic (Claude)" section.
+from lightrag.llm.openai import gpt_4o_mini_complete
 
 from lightrag_memgraph import MemgraphLightRAGWrapper
 from memgraph_toolbox.api.memgraph import Memgraph
@@ -73,7 +73,8 @@ async def main():
             working_dir=WORKING_DIR,
             max_parallel_insert=8,
             llm_model_func=gpt_4o_mini_complete,
-            embedding_func=openai_embed,
+            # embedding_func omitted: defaults to Memgraph's local
+            # sentence-transformer (see README's "Embeddings" section).
         )
 
         total_time = 0.0

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/__init__.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/__init__.py
@@ -6,6 +6,7 @@ This package provides a wrapper around LightRAG that uses Memgraph as the graph 
 
 from .core import MemgraphLightRAGWrapper
 from .docstatus_impl import MemgraphDocStatusStorage
+from .embeddings import build_memgraph_sentence_embed, memgraph_sentence_embed
 from .kv_impl import MemgraphKVStorage
 from .registry import register_memgraph_storage
 from .vector_impl import MemgraphVectorStorage
@@ -128,5 +129,7 @@ __all__ = [
     "MemgraphKVStorage",
     "MemgraphLightRAGWrapper",
     "MemgraphVectorStorage",
+    "build_memgraph_sentence_embed",
+    "memgraph_sentence_embed",
     "register_memgraph_storage",
 ]

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
@@ -31,9 +31,9 @@ def _apply_lightrag_defaults(lightrag_kwargs: dict) -> None:
 
     `embedding_func` defaults to Memgraph's own local sentence-transformer
     (via the `embeddings` MAGE module, see `embeddings.py`), not `openai_embed`
-    -- a zero-config wrapper should not silently make billed OpenAI calls
-    (issue #222). Defaulting is logged since it changes what network calls
-    `ainsert`/`aquery` make.
+    -- a zero-config wrapper should not silently make billed OpenAI calls.
+    Defaulting is logged since it changes what network calls `ainsert`/`aquery`
+    make.
     """
     if "llm_model_func" not in lightrag_kwargs:
         lightrag_kwargs["llm_model_func"] = gpt_4o_mini_complete

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
@@ -4,8 +4,9 @@ import os
 from lightrag import LightRAG
 from lightrag.kg.shared_storage import initialize_pipeline_status
 from lightrag.llm.openai import gpt_4o_mini_complete, openai_embed
-from lightrag.utils import setup_logger
+from lightrag.utils import logger, setup_logger
 
+from .embeddings import DEFAULT_EMBEDDING_DIM, DEFAULT_MODEL_NAME, memgraph_sentence_embed
 from .registry import register_memgraph_storage
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -25,6 +26,32 @@ def _bridge_lightrag_env_names() -> None:
         os.environ["MEMGRAPH_USERNAME"] = os.environ["MEMGRAPH_USER"]
 
 
+def _apply_lightrag_defaults(lightrag_kwargs: dict) -> None:
+    """Fill in `llm_model_func`/`embedding_func` defaults in place.
+
+    `embedding_func` defaults to Memgraph's own local sentence-transformer
+    (via the `embeddings` MAGE module, see `embeddings.py`), not `openai_embed`
+    -- a zero-config wrapper should not silently make billed OpenAI calls
+    (issue #222). Defaulting is logged since it changes what network calls
+    `ainsert`/`aquery` make.
+    """
+    if "llm_model_func" not in lightrag_kwargs:
+        lightrag_kwargs["llm_model_func"] = gpt_4o_mini_complete
+    if "embedding_func" not in lightrag_kwargs:
+        logger.warning(
+            "embedding_func not provided to MemgraphLightRAGWrapper.initialize(); defaulting to "
+            f"Memgraph's local sentence-transformer embeddings ({DEFAULT_MODEL_NAME}, "
+            f"{DEFAULT_EMBEDDING_DIM} dims) via the `embeddings` MAGE module -- no API key or "
+            "external cost involved. Pass an explicit embedding_func (e.g. openai_embed) to use "
+            "a different provider."
+        )
+        lightrag_kwargs["embedding_func"] = memgraph_sentence_embed
+    if lightrag_kwargs["llm_model_func"] == gpt_4o_mini_complete or lightrag_kwargs["embedding_func"] == openai_embed:
+        openai_api_key = os.environ.get("OPENAI_API_KEY")
+        if not openai_api_key:
+            raise OSError("OPENAI_API_KEY environment variable is not set. Please set your OpenAI API key.")
+
+
 class MemgraphLightRAGWrapper:
     def __init__(
         self,
@@ -34,7 +61,9 @@ class MemgraphLightRAGWrapper:
         """Wrap LightRAG configured to use Memgraph as its storage backend.
 
         Vectors always go to Memgraph's native vector index, so a real
-        ``embedding_func`` is required.
+        ``embedding_func`` is required; if omitted from ``initialize()``, it
+        defaults to Memgraph's own local sentence-transformer (see
+        ``embeddings.py``), not a billed external API.
 
         Args:
             log_level: Logging level for LightRAG's loggers.
@@ -62,17 +91,7 @@ class MemgraphLightRAGWrapper:
             working_dir = lightrag_kwargs["working_dir"]
             if not os.path.exists(working_dir):
                 os.mkdir(working_dir)
-        if "llm_model_func" not in lightrag_kwargs:
-            lightrag_kwargs["llm_model_func"] = gpt_4o_mini_complete
-        if "embedding_func" not in lightrag_kwargs:
-            lightrag_kwargs["embedding_func"] = openai_embed
-        if (
-            lightrag_kwargs["llm_model_func"] == gpt_4o_mini_complete
-            or lightrag_kwargs["embedding_func"] == openai_embed
-        ):
-            openai_api_key = os.environ.get("OPENAI_API_KEY")
-            if not openai_api_key:
-                raise OSError("OPENAI_API_KEY environment variable is not set. Please set your OpenAI API key.")
+        _apply_lightrag_defaults(lightrag_kwargs)
         self.rag = LightRAG(graph_storage="MemgraphStorage", **lightrag_kwargs)
         await self.rag.initialize_storages()
         await initialize_pipeline_status()

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/embeddings.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/embeddings.py
@@ -1,0 +1,72 @@
+"""Default embedding function backed by Memgraph's own `embeddings` MAGE module.
+
+https://memgraph.com/docs/advanced-algorithms/available-algorithms/embeddings
+
+`embeddings.text()` runs a local Hugging Face SentenceTransformer model
+*inside* Memgraph (the default model is `all-MiniLM-L6-v2`, 384 dims), so
+using it as the default `embedding_func` means a zero-config
+`MemgraphLightRAGWrapper` needs no external API key and incurs no per-call
+embedding cost -- unlike `openai_embed`, which was the previous silent
+default (see issue #222). It also avoids pulling `torch` /
+`sentence-transformers` into this package: the model runs on the Memgraph
+server, reusing the same driver already used for storage.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from lightrag.utils import EmbeddingFunc
+
+from ._connection import get_database, get_driver
+
+DEFAULT_MODEL_NAME = "all-MiniLM-L6-v2"
+DEFAULT_EMBEDDING_DIM = 384
+DEFAULT_MAX_TOKEN_SIZE = 256  # all-MiniLM-L6-v2's trained max sequence length
+
+
+def _build_embed_func(model_name: str):
+    async def _embed(texts: list[str]) -> np.ndarray:
+        driver = await get_driver()
+        async with driver.session(database=get_database(), default_access_mode="READ") as session:
+            result = await session.run(
+                "CALL embeddings.text($texts, $config) YIELD success, embeddings, dimension "
+                "RETURN success, embeddings, dimension",
+                texts=texts,
+                config={"model_name": model_name},
+            )
+            record = await result.single()
+            await result.consume()
+        if record is None or not record["success"]:
+            raise RuntimeError(
+                f"Memgraph's `embeddings.text()` procedure failed for model '{model_name}'. "
+                "It requires Memgraph MAGE with the `embeddings` module loaded -- see "
+                "https://memgraph.com/docs/advanced-algorithms/available-algorithms/embeddings. "
+                "Pass an explicit embedding_func to MemgraphLightRAGWrapper.initialize() to use "
+                "a different embedding provider instead."
+            )
+        return np.array(record["embeddings"], dtype=np.float32)
+
+    return _embed
+
+
+def build_memgraph_sentence_embed(
+    model_name: str = DEFAULT_MODEL_NAME,
+    embedding_dim: int = DEFAULT_EMBEDDING_DIM,
+    max_token_size: int = DEFAULT_MAX_TOKEN_SIZE,
+) -> EmbeddingFunc:
+    """Build an `EmbeddingFunc` that calls Memgraph's `embeddings.text()` for a given model.
+
+    `all-MiniLM-L6-v2` (384 dims) is the module's own default and needs no
+    `embedding_dim` override. For any other `model_name`, pass the matching
+    `embedding_dim` -- the module doesn't report it up front, and a mismatch
+    will raise (via `EmbeddingFunc`'s own dimension check) on first use.
+    """
+    return EmbeddingFunc(
+        embedding_dim=embedding_dim,
+        max_token_size=max_token_size,
+        model_name=model_name,
+        func=_build_embed_func(model_name),
+    )
+
+
+memgraph_sentence_embed = build_memgraph_sentence_embed()

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/embeddings.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/embeddings.py
@@ -7,9 +7,9 @@ https://memgraph.com/docs/advanced-algorithms/available-algorithms/embeddings
 using it as the default `embedding_func` means a zero-config
 `MemgraphLightRAGWrapper` needs no external API key and incurs no per-call
 embedding cost -- unlike `openai_embed`, which was the previous silent
-default (see issue #222). It also avoids pulling `torch` /
-`sentence-transformers` into this package: the model runs on the Memgraph
-server, reusing the same driver already used for storage.
+default. It also avoids pulling `torch` / `sentence-transformers` into this
+package: the model runs on the Memgraph server, reusing the same driver
+already used for storage.
 """
 
 from __future__ import annotations

--- a/integrations/lightrag-memgraph/tests/test_core.py
+++ b/integrations/lightrag-memgraph/tests/test_core.py
@@ -1,7 +1,9 @@
-"""Unit tests for lightrag_memgraph.core's env-name bridging.
+"""Unit tests for lightrag_memgraph.core's env-name bridging and LLM/embedding defaults.
 
-These don't need a live Memgraph: they only check what _bridge_lightrag_env_names
-writes into os.environ.
+These don't need a live Memgraph: _bridge_lightrag_env_names only checks what it
+writes into os.environ, and _apply_lightrag_defaults only mutates a plain dict
+(the embedding/LLM functions it defaults to aren't called until LightRAG actually
+runs an insert/query).
 """
 
 from __future__ import annotations
@@ -9,8 +11,11 @@ from __future__ import annotations
 import os
 
 import pytest
+from lightrag.llm.openai import gpt_4o_mini_complete, openai_embed
+from lightrag.utils import logger as lightrag_logger
 
-from lightrag_memgraph.core import _bridge_lightrag_env_names
+from lightrag_memgraph.core import _apply_lightrag_defaults, _bridge_lightrag_env_names
+from lightrag_memgraph.embeddings import memgraph_sentence_embed
 
 _MEMGRAPH_ENV_NAMES = ("MEMGRAPH_URL", "MEMGRAPH_URI", "MEMGRAPH_USER", "MEMGRAPH_USERNAME")
 
@@ -63,3 +68,71 @@ def test_bridge_never_overwrites_explicit_username(monkeypatch):
     monkeypatch.setenv("MEMGRAPH_USERNAME", "bob")
     _bridge_lightrag_env_names()
     assert os.environ["MEMGRAPH_USERNAME"] == "bob"
+
+
+# --- _apply_lightrag_defaults -------------------------------------------------
+
+
+def test_embedding_func_defaults_to_memgraph_sentence_embed_not_openai(monkeypatch):
+    """Regression test for #222: a caller who omits embedding_func must not
+    silently get billed OpenAI calls. The default is Memgraph's own local
+    sentence-transformer instead, which needs no OPENAI_API_KEY.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    kwargs = {"llm_model_func": lambda *a, **kw: None}  # non-default LLM, so no key is required
+    _apply_lightrag_defaults(kwargs)
+    assert kwargs["embedding_func"] is memgraph_sentence_embed
+
+
+def test_defaulting_embedding_func_logs_a_warning(monkeypatch):
+    """lightrag's shared logger has propagate=False (set at import time), so
+    caplog can't see it via the root logger; patch .warning directly instead.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    warnings: list[str] = []
+    monkeypatch.setattr(lightrag_logger, "warning", lambda msg, *a, **kw: warnings.append(msg))
+    kwargs = {"llm_model_func": lambda *a, **kw: None}
+    _apply_lightrag_defaults(kwargs)
+    assert any("embedding_func" in w for w in warnings)
+
+
+def test_explicit_embedding_func_is_not_overridden(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    async def custom_embed(texts):
+        return texts
+
+    kwargs = {"llm_model_func": lambda *a, **kw: None, "embedding_func": custom_embed}
+    _apply_lightrag_defaults(kwargs)
+    assert kwargs["embedding_func"] is custom_embed
+
+
+def test_llm_model_func_defaults_to_gpt_4o_mini_complete(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    kwargs = {"embedding_func": memgraph_sentence_embed}
+    _apply_lightrag_defaults(kwargs)
+    assert kwargs["llm_model_func"] is gpt_4o_mini_complete
+
+
+def test_requires_openai_api_key_when_llm_defaults_to_gpt_4o_mini(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    kwargs = {"embedding_func": memgraph_sentence_embed}
+    with pytest.raises(OSError, match="OPENAI_API_KEY"):
+        _apply_lightrag_defaults(kwargs)
+
+
+def test_requires_openai_api_key_when_embedding_func_is_explicitly_openai(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    kwargs = {"llm_model_func": lambda *a, **kw: None, "embedding_func": openai_embed}
+    with pytest.raises(OSError, match="OPENAI_API_KEY"):
+        _apply_lightrag_defaults(kwargs)
+
+
+def test_no_openai_key_required_with_non_openai_llm_and_embedding_default(monkeypatch):
+    """The whole point of #222's fix: a Claude-only setup (no OPENAI_API_KEY at
+    all) must be able to omit embedding_func and still initialize.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    kwargs = {"llm_model_func": lambda *a, **kw: None}
+    _apply_lightrag_defaults(kwargs)  # must not raise
+    assert kwargs["embedding_func"] is memgraph_sentence_embed

--- a/integrations/lightrag-memgraph/tests/test_core.py
+++ b/integrations/lightrag-memgraph/tests/test_core.py
@@ -74,9 +74,9 @@ def test_bridge_never_overwrites_explicit_username(monkeypatch):
 
 
 def test_embedding_func_defaults_to_memgraph_sentence_embed_not_openai(monkeypatch):
-    """Regression test for #222: a caller who omits embedding_func must not
-    silently get billed OpenAI calls. The default is Memgraph's own local
-    sentence-transformer instead, which needs no OPENAI_API_KEY.
+    """A caller who omits embedding_func must not silently get billed OpenAI
+    calls. The default is Memgraph's own local sentence-transformer instead,
+    which needs no OPENAI_API_KEY.
     """
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     kwargs = {"llm_model_func": lambda *a, **kw: None}  # non-default LLM, so no key is required
@@ -129,8 +129,8 @@ def test_requires_openai_api_key_when_embedding_func_is_explicitly_openai(monkey
 
 
 def test_no_openai_key_required_with_non_openai_llm_and_embedding_default(monkeypatch):
-    """The whole point of #222's fix: a Claude-only setup (no OPENAI_API_KEY at
-    all) must be able to omit embedding_func and still initialize.
+    """A Claude-only setup (no OPENAI_API_KEY at all) must be able to omit
+    embedding_func and still initialize.
     """
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     kwargs = {"llm_model_func": lambda *a, **kw: None}

--- a/integrations/lightrag-memgraph/tests/test_embeddings.py
+++ b/integrations/lightrag-memgraph/tests/test_embeddings.py
@@ -1,0 +1,117 @@
+"""Live-Memgraph tests for the default `embeddings.text()`-backed embedding function.
+
+Mirrors test_integration_memgraph.py's pattern: skip the whole module (not fail)
+if no live Memgraph is reachable, or if it has no `embeddings` module loaded
+(e.g. a plain `memgraph` image instead of `memgraph-mage`).
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+import pytest_asyncio
+
+from lightrag_memgraph._connection import close_driver, get_driver
+from lightrag_memgraph.embeddings import (
+    DEFAULT_EMBEDDING_DIM,
+    DEFAULT_MODEL_NAME,
+    build_memgraph_sentence_embed,
+    memgraph_sentence_embed,
+)
+from memgraph_toolbox.api.memgraph import memgraph_env
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+def _connection_settings() -> tuple[str, str, str, str]:
+    env = memgraph_env()
+    return (env["MEMGRAPH_URL"], env["MEMGRAPH_USER"], env["MEMGRAPH_PASSWORD"], env["MEMGRAPH_DATABASE"])
+
+
+def _resolve_uri() -> str:
+    uri = os.environ.get("MEMGRAPH_URL")
+    if not uri:
+        host = os.environ.get("MEMGRAPH_HOST")
+        if host:
+            uri = f"bolt://{host}:{os.environ.get('MEMGRAPH_PORT') or 7687}"
+    if uri:
+        os.environ["MEMGRAPH_URL"] = uri
+    else:
+        uri = _connection_settings()[0]
+    return uri
+
+
+@pytest.fixture(scope="session")
+def memgraph_uri() -> str:
+    uri = _resolve_uri()
+    _uri, username, password, database = _connection_settings()
+    try:
+        from neo4j import GraphDatabase
+    except ImportError as exc:  # pragma: no cover - neo4j is a hard dependency
+        pytest.skip(f"neo4j driver not importable: {exc}")
+
+    driver = None
+    try:
+        driver = GraphDatabase.driver(uri, auth=(username, password), connection_timeout=5)
+        driver.verify_connectivity()
+        with driver.session(database=database) as session:
+            session.run("RETURN 1").consume()
+    except Exception as exc:  # pragma: no cover - depends on the environment
+        pytest.skip(f"No live Memgraph reachable at {uri}: {exc}")
+    finally:
+        if driver is not None:
+            driver.close()
+    return uri
+
+
+@pytest.fixture(scope="session")
+def embeddings_module_supported(memgraph_uri: str) -> bool:
+    """Skip if the server has no `embeddings` module (e.g. plain `memgraph`, not `memgraph-mage`)."""
+    from neo4j import GraphDatabase
+
+    _uri, username, password, database = _connection_settings()
+    driver = GraphDatabase.driver(memgraph_uri, auth=(username, password))
+    try:
+        with driver.session(database=database) as session:
+            names = {record["name"] for record in session.run("CALL mg.procedures() YIELD name RETURN name")}
+        if not any(n.startswith("embeddings.") for n in names):
+            pytest.skip("Memgraph server has no `embeddings` module (needs the memgraph-mage image)")
+    finally:
+        driver.close()
+    return True
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def shared_driver(memgraph_uri: str):
+    driver = await get_driver()
+    yield driver
+    await close_driver()
+
+
+async def test_memgraph_sentence_embed_returns_real_vectors(shared_driver, embeddings_module_supported):
+    result = await memgraph_sentence_embed(["hello world", "graph databases are fast"])
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (2, DEFAULT_EMBEDDING_DIM)
+    # Real model output, not a stub -- rows for different sentences must differ.
+    assert not np.allclose(result[0], result[1])
+
+
+async def test_memgraph_sentence_embed_model_name_is_default(shared_driver, embeddings_module_supported):
+    assert memgraph_sentence_embed.model_name == DEFAULT_MODEL_NAME
+
+
+async def test_memgraph_sentence_embed_handles_empty_input(shared_driver, embeddings_module_supported):
+    result = await memgraph_sentence_embed([])
+    assert result.shape == (0,) or result.size == 0
+
+
+async def test_build_memgraph_sentence_embed_dimension_mismatch_raises(shared_driver, embeddings_module_supported):
+    """A model_name/embedding_dim pair that doesn't match the module's real output
+    must surface as an error (via EmbeddingFunc's own dimension check), not silently
+    return misshapen vectors.
+    """
+    mismatched = build_memgraph_sentence_embed(model_name=DEFAULT_MODEL_NAME, embedding_dim=999)
+    with pytest.raises(ValueError, match="dimension mismatch"):
+        await mismatched(["hello world"])

--- a/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
+++ b/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
@@ -588,15 +588,15 @@ async def test_wrapper_full_persistence_false_works_with_zero_env_vars(
             await wrapper.afinalize()
 
 
-# --- default embedding_func (#222 regression) ---------------------------------
+# --- default embedding_func ---------------------------------------------------
 
 
 async def test_wrapper_defaults_embedding_func_to_working_memgraph_sentence_embed(
     shared_driver, embeddings_module_supported, workspace, tmp_path, monkeypatch
 ):
-    """Regression test for #222: omitting embedding_func must not silently fall
-    back to a billed openai_embed call. It must resolve to Memgraph's own
-    sentence-transformer default, and that default must actually work end to end.
+    """Omitting embedding_func must not silently fall back to a billed
+    openai_embed call. It must resolve to Memgraph's own sentence-transformer
+    default, and that default must actually work end to end.
     """
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     wrapper = MemgraphLightRAGWrapper()

--- a/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
+++ b/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
@@ -40,6 +40,7 @@ from lightrag_memgraph._connection import (
     get_driver,
 )
 from lightrag_memgraph.docstatus_impl import MemgraphDocStatusStorage
+from lightrag_memgraph.embeddings import DEFAULT_EMBEDDING_DIM, memgraph_sentence_embed
 from lightrag_memgraph.kv_impl import MemgraphKVStorage
 from lightrag_memgraph.vector_impl import MemgraphVectorStorage
 from memgraph_toolbox.api.memgraph import memgraph_env
@@ -171,6 +172,23 @@ def vector_search_supported(memgraph_uri: str) -> bool:
             names = {record["name"] for record in session.run("CALL mg.procedures() YIELD name RETURN name")}
         if not any(n.startswith("vector_search.") for n in names):
             pytest.skip("Memgraph server has no vector_search module")
+    finally:
+        driver.close()
+    return True
+
+
+@pytest.fixture(scope="session")
+def embeddings_module_supported(memgraph_uri: str) -> bool:
+    """Skip if the server has no ``embeddings`` module (needs the memgraph-mage image)."""
+    from neo4j import GraphDatabase
+
+    _uri, username, password, database = _connection_settings()
+    driver = GraphDatabase.driver(memgraph_uri, auth=(username, password))
+    try:
+        with driver.session(database=database) as session:
+            names = {record["name"] for record in session.run("CALL mg.procedures() YIELD name RETURN name")}
+        if not any(n.startswith("embeddings.") for n in names):
+            pytest.skip("Memgraph server has no embeddings module (needs the memgraph-mage image)")
     finally:
         driver.close()
     return True
@@ -565,6 +583,39 @@ async def test_wrapper_full_persistence_false_works_with_zero_env_vars(
         # A real round trip against Memgraph, not just a successful construction.
         result = await graph.drop()
         assert result["status"] == "success"
+    finally:
+        if wrapper.rag is not None:
+            await wrapper.afinalize()
+
+
+# --- default embedding_func (#222 regression) ---------------------------------
+
+
+async def test_wrapper_defaults_embedding_func_to_working_memgraph_sentence_embed(
+    shared_driver, embeddings_module_supported, workspace, tmp_path, monkeypatch
+):
+    """Regression test for #222: omitting embedding_func must not silently fall
+    back to a billed openai_embed call. It must resolve to Memgraph's own
+    sentence-transformer default, and that default must actually work end to end.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    wrapper = MemgraphLightRAGWrapper()
+    try:
+        await wrapper.initialize(
+            working_dir=str(tmp_path),
+            workspace=workspace,
+            llm_model_func=_dummy_llm_model_func,
+            # embedding_func intentionally omitted.
+        )
+        rag = wrapper.get_lightrag()
+        # LightRAG re-wraps the passed EmbeddingFunc (concurrency-limiting the
+        # underlying callable, unwrapping the EmbeddingFunc nesting), so identity
+        # doesn't survive the round trip -- the declared model/dim and, most
+        # importantly, actual behaviour do.
+        assert rag.embedding_func.model_name == memgraph_sentence_embed.model_name
+        assert rag.embedding_func.embedding_dim == DEFAULT_EMBEDDING_DIM
+        vectors = await rag.embedding_func(["hello world", "graph databases are fast"])
+        assert vectors.shape == (2, DEFAULT_EMBEDDING_DIM)
     finally:
         if wrapper.rag is not None:
             await wrapper.afinalize()


### PR DESCRIPTION
## Summary

Closes #222.

- `MemgraphLightRAGWrapper.initialize()` used to silently default `embedding_func` to `openai_embed` whenever it was omitted, checking only whether `OPENAI_API_KEY` happened to be set in the environment -- not whether the caller actually wanted OpenAI. A Claude-only user who forgot `embedding_func` could end up making real, billed OpenAI embedding calls on every insert/query with zero warning.
- `embedding_func` now defaults to a new `memgraph_sentence_embed`: it calls Memgraph's own [`embeddings.text()`](https://memgraph.com/docs/advanced-algorithms/available-algorithms/embeddings) MAGE procedure, which runs a local Hugging Face sentence-transformer (`all-MiniLM-L6-v2`, 384 dims) *inside* Memgraph itself, over the same driver already used for storage. No API key, no external network call, no added `torch`/`sentence-transformers` dependency in this package.
- Applying this default now logs a warning (never silent), and `build_memgraph_sentence_embed(model_name=..., embedding_dim=...)` lets callers pick a different local model.
- `openai_embed` (and other providers) are still fully supported by passing `embedding_func` explicitly -- README's Anthropic/OpenAI sections updated accordingly, and the "silent no-op" callout requested in the issue is now explicit in the Anthropic section.
- Requires the `memgraph-mage` Docker image (not plain `memgraph`) for the default to work; README prerequisites and a new "Embeddings" section call this out.

## Test plan

- [x] New unit tests in `tests/test_core.py` covering the extracted `_apply_lightrag_defaults` (embedding default, warning log, explicit override, OPENAI_API_KEY enforcement only when actually needed)
- [x] New `tests/test_embeddings.py` live-Memgraph tests for `memgraph_sentence_embed` / `build_memgraph_sentence_embed`, skipped gracefully if no Memgraph/embeddings module is reachable
- [x] New wrapper-level regression test in `tests/test_integration_memgraph.py` verifying `initialize()` without `embedding_func` works end-to-end and produces real 384-dim vectors
- [x] Manually verified against a live `memgraph/memgraph-mage:latest` container (`CALL embeddings.text(...)`) before wiring it in
- [x] Full existing test suite passes against live Memgraph MAGE (one pre-existing, unrelated flaky test confirmed to fail identically on `main`)
- [x] `ruff check` / `ruff format --check` pass