### PR TITLE
unstructured2graph: rename create_index to create_property_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Transform PDFs, URLs, and documents into queryable knowledge graphs:
 import asyncio
 from memgraph_toolbox.api.memgraph import Memgraph
 from lightrag_memgraph import MemgraphLightRAGWrapper
-from unstructured2graph import from_unstructured, create_index
+from unstructured2graph import from_unstructured, create_property_index
 
 async def main():
     memgraph = Memgraph()
-    create_index(memgraph, "Chunk", "hash")
+    create_property_index(memgraph, "Chunk", "hash")
 
     lightrag = MemgraphLightRAGWrapper()
     await lightrag.initialize(working_dir="./lightrag_storage")
@@ -167,13 +167,13 @@ uv run main.py
 
 ## ❓ FAQ
 
-**Which databases are supported?**  
+**Which databases are supported?**
 Memgraph is the primary target. The sql2graph agent supports MySQL and PostgreSQL as source databases.
 
-**Do I need an LLM API key?**  
+**Do I need an LLM API key?**
 Yes, for features like entity extraction (unstructured2graph) and natural language queries (langchain-memgraph).
 
-**Can I use local LLMs?**  
+**Can I use local LLMs?**
 Yes! LangChain integration supports any LangChain-compatible model, including Ollama.
 
 ---

--- a/unstructured2graph/README.md
+++ b/unstructured2graph/README.md
@@ -32,11 +32,11 @@ pip install -e ".[all-docs]"
 import asyncio
 from memgraph_toolbox.api.memgraph import Memgraph
 from lightrag_memgraph import MemgraphLightRAGWrapper
-from unstructured2graph import from_unstructured, create_index
+from unstructured2graph import from_unstructured, create_property_index
 
 async def main():
     memgraph = Memgraph(user_agent="unstructured2graph")
-    create_index(memgraph, "Chunk", "hash")
+    create_property_index(memgraph, "Chunk", "hash")
 
     lightrag = MemgraphLightRAGWrapper()
     await lightrag.initialize(working_dir="./lightrag_storage")

--- a/unstructured2graph/examples/loading.py
+++ b/unstructured2graph/examples/loading.py
@@ -7,7 +7,7 @@ import sources as SOURCES
 
 from lightrag_memgraph import MemgraphLightRAGWrapper
 from memgraph_toolbox.api.memgraph import Memgraph
-from unstructured2graph import create_index, from_unstructured
+from unstructured2graph import create_property_index, from_unstructured
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 LIGHTRAG_DIR = os.path.join(SCRIPT_DIR, "..", "lightrag_storage.out")
@@ -26,7 +26,7 @@ async def from_unstructured_with_prep():
     # Cleanup Memgraph database.
     memgraph = Memgraph(user_agent="unstructured2graph")
     memgraph.query("MATCH (n) DETACH DELETE n;")
-    create_index(memgraph, "Chunk", "hash")
+    create_property_index(memgraph, "Chunk", "hash")
 
     lightrag_wrapper = MemgraphLightRAGWrapper(log_level="WARNING")
     await lightrag_wrapper.initialize(working_dir=LIGHTRAG_DIR)

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unstructured2graph"
-version = "0.1.5"
+version = "0.2.0"
 description = "Convert unstructured documents into knowledge graphs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/unstructured2graph/src/unstructured2graph/__init__.py
+++ b/unstructured2graph/src/unstructured2graph/__init__.py
@@ -15,9 +15,9 @@ from .loaders import (
 from .memgraph import (
     compute_embeddings,
     connect_chunks_to_entities,
-    create_index,
     create_label_index,
     create_nodes_from_list,
+    create_property_index,
     create_vector_search_index,
     link_nodes_in_order,
 )
@@ -28,9 +28,9 @@ __all__ = [
     "ChunkedDocument",
     "compute_embeddings",
     "connect_chunks_to_entities",
-    "create_index",
     "create_label_index",
     "create_nodes_from_list",
+    "create_property_index",
     "create_vector_search_index",
     "from_unstructured",
     "link_nodes_in_order",

--- a/unstructured2graph/src/unstructured2graph/memgraph.py
+++ b/unstructured2graph/src/unstructured2graph/memgraph.py
@@ -67,7 +67,7 @@ def link_nodes_in_order(
         logger.error(f"Error creating chunk chain relationships: {e}")
 
 
-def create_index(memgraph: Memgraph, label: str, property: str):
+def create_property_index(memgraph: Memgraph, label: str, property: str):
     try:
         memgraph.query(f"CREATE INDEX ON :{label}({property});")
     except Exception as e:


### PR DESCRIPTION
Closes candidate 7 from the unstructured2graph ergonomics pass: `create_index(label, property)`
and `create_label_index(label)` had near-identical names for different operations (property index
vs. label index), so a call site alone couldn't tell which one a reader was looking at.

## Changes
- Renamed `create_index` -> `create_property_index` in `memgraph.py`.
- Updated the export in `unstructured2graph/__init__.py`.
- Updated both READMEs (root + package) and `examples/loading.py` to the new name.
- Bumped `unstructured2graph` to `0.2.0` (breaking rename), matching how `lightrag-memgraph` bumped
  0.1.6 -> 0.2.0 for its own breaking change (#214).

No behavior change — pure rename, no compat shim added per repo convention.

## Test plan
- [x] `uv run pytest tests/` — 5 passed, 1 skipped (pre-existing skip, needs network/sample-data)
- [x] `uv run ruff check unstructured2graph/` — clean
- [x] `uv run ruff format --check unstructured2graph/` — clean
- [x] `uv run python -c "from unstructured2graph import create_property_index"` — works; `create_index` no longer importable
- [x] `grep -rn "create_index\b"` across the repo — no remaining references outside unrelated same-named functions in `lightrag-memgraph`/`mcp-memgraph`