### PR TITLE
unstructured2graph: make lightrag_wrapper optional when only_chunks=True

### DIFF
--- a/unstructured2graph/src/unstructured2graph/loaders.py
+++ b/unstructured2graph/src/unstructured2graph/loaders.py
@@ -111,7 +111,7 @@ def make_chunks(
 async def from_unstructured(
     sources: list[str | Path],
     memgraph: Memgraph,
-    lightrag_wrapper: MemgraphLightRAGWrapper,
+    lightrag_wrapper: MemgraphLightRAGWrapper | None = None,
     only_chunks: bool = False,
     link_chunks: bool = False,
     partition_kwargs: dict[str, Any] | None = None,
@@ -121,13 +121,16 @@ async def from_unstructured(
     Args:
         sources: List of file paths or URLs to process
         memgraph: Memgraph instance for database operations
-        lightrag_wrapper: MemgraphLightRAGWrapper instance (requires lightrag-memgraph)
+        lightrag_wrapper: MemgraphLightRAGWrapper instance (requires lightrag-memgraph).
+            Required unless only_chunks=True, since it's only used for entity extraction.
         only_chunks: If True, only create chunk nodes without LightRAG processing
         link_chunks: If True, link chunks in order with NEXT relationship
         partition_kwargs: Additional keyword arguments to pass to unstructured's
             partition function (e.g., strategy, languages, pdf_infer_table_structure,
             ocr_languages, headers, ssl_verify, etc.)
     """
+    if not only_chunks and lightrag_wrapper is None:
+        raise ValueError("lightrag_wrapper is required when only_chunks=False")
 
     # TODO(gitbuda): Create all required indexes.
     # TODO(gitbuda): Make the calls idempotent.

--- a/unstructured2graph/tests/test_loaders.py
+++ b/unstructured2graph/tests/test_loaders.py
@@ -1,10 +1,11 @@
 """Simple test for unstructured2graph loaders."""
 
 import os
+from unittest.mock import MagicMock
 
 import pytest
 
-from unstructured2graph import Chunk, ChunkedDocument, make_chunks, parse_source
+from unstructured2graph import Chunk, ChunkedDocument, from_unstructured, make_chunks, parse_source
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -72,6 +73,27 @@ def test_partition_kwargs_passed_through(tmp_path):
     # Should not raise - just verify kwargs are accepted
     chunks = parse_source(test_file, partition_kwargs={"encoding": "utf-8"})
     assert isinstance(chunks, list)
+
+
+@pytest.mark.asyncio
+async def test_from_unstructured_requires_lightrag_wrapper_when_not_only_chunks():
+    """lightrag_wrapper=None should raise a clear error unless only_chunks=True."""
+    memgraph = MagicMock()
+
+    with pytest.raises(ValueError, match="lightrag_wrapper"):
+        await from_unstructured(["irrelevant.txt"], memgraph, lightrag_wrapper=None, only_chunks=False)
+
+
+@pytest.mark.asyncio
+async def test_from_unstructured_only_chunks_works_without_lightrag_wrapper(tmp_path):
+    """only_chunks=True should not require a lightrag_wrapper at all."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("Some content for chunk-only ingestion.")
+    memgraph = MagicMock()
+
+    await from_unstructured([str(test_file)], memgraph, lightrag_wrapper=None, only_chunks=True)
+
+    assert memgraph.query.called
 
 
 @pytest.mark.skip(reason="Requires sample-data files and network access - run locally with full deps")


### PR DESCRIPTION
## Summary
- `from_unstructured` required a live `lightrag_wrapper` even when `only_chunks=True`, a path that never touches it.
- `lightrag_wrapper` is now `MemgraphLightRAGWrapper | None = None`, and a clear `ValueError` is raised only when it's actually needed (`only_chunks=False`).

## Test plan
- [x] Added a test asserting `ValueError` when `lightrag_wrapper=None` and `only_chunks=False`.
- [x] Added a test asserting `only_chunks=True` succeeds end-to-end with no `lightrag_wrapper`.
- [x] `pytest tests/test_loaders.py` passes.

Closes #236