### PR TITLE
Bump versions for release: toolbox, mcp, lightrag, unstructured2graph

### DIFF
--- a/integrations/lightrag-memgraph/pyproject.toml
+++ b/integrations/lightrag-memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lightrag-memgraph"
-version = "0.2.0"
+version = "0.3.0"
 description = "LightRAG integration with Memgraph"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/mcp-memgraph/pyproject.toml
+++ b/integrations/mcp-memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-memgraph"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCP integration and utilities for Memgraph MCP server"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -24,7 +24,7 @@ dependencies = [
   "httpx>=0.28.1",
   "mcp[cli]>=1.23.0",
   "neo4j>=5.28.1",
-  "memgraph-toolbox>=0.1.11",
+  "memgraph-toolbox>=0.2.0",
   "fastmcp>=3.2.0",
   "pyjwt[crypto]>=2.10.1",
   "uvicorn>=0.48",

--- a/memgraph-toolbox/pyproject.toml
+++ b/memgraph-toolbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memgraph-toolbox"
-version = "0.1.11"
+version = "0.2.0"
 description = "Memgraph toolbox library for Memgraph AI tools and utilities"
 readme = "README.md"
 authors = [

--- a/memgraph-toolbox/uv.lock
+++ b/memgraph-toolbox/uv.lock
@@ -1220,7 +1220,7 @@ wheels = [
 
 [[package]]
 name = "memgraph-toolbox"
-version = "0.1.11"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unstructured2graph"
-version = "0.2.0"
+version = "0.3.0"
 description = "Convert unstructured documents into knowledge graphs"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "unstructured>=0.18.18",
-    "lightrag-memgraph>=0.2.0",
+    "lightrag-memgraph>=0.3.0",
     "memgraph-toolbox>=0.1.11",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Prepares four packages for release. All are bumped as pre-1.0 minor
versions (feature/breaking batches):

| Package | Version | Notes |
|---|---|---|
| `memgraph-toolbox` | 0.1.11 → 0.2.0 | The #211 tool-module consolidation (individual tool files merged into `schema.py`, several tool classes removed) was **never version-bumped or released** — PyPI's latest is still 0.1.11 with the old tools. `mcp-memgraph`'s server already imports the new `schema.py` classes (`EnumSchemaTool`, `NodeSchemaTool`, etc.), so releasing a new `mcp-memgraph` without this would resolve a stale toolbox and fail to import. |
| `mcp-memgraph` | 0.2.0 → 0.3.0 | Covers the toolbox integration rewrite (#211) and `readOnlyHint` tool annotations (#213). Bumps its `memgraph-toolbox` floor to `>=0.2.0` to match. |
| `lightrag-memgraph` | 0.2.0 → 0.3.0 | The prior 0.2.0 bump was also never published (PyPI is still on 0.1.6). This release bundles everything since: round-trip fixes, GC-lag logging, storage backend dedup, `lightrag-hku` version guard, zero-config default restore, defaulting `embedding_func` to Memgraph's local sentence-transformer, and the new `DEFAULT_EMBEDDING_DIM`/`DEFAULT_MODEL_NAME` exports (#243). |
| `unstructured2graph` | 0.2.0 → 0.3.0 | Same situation — 0.2.0 was never published (PyPI still on 0.1.5). Bundles `create_property_index` rename, entity workspace derivation, idempotent chunk ingestion, optional `lightrag_wrapper`, and vector index parameterization (#238–#243). Bumps its `lightrag-memgraph` floor to `>=0.3.0` since it now imports `DEFAULT_EMBEDDING_DIM`. |

No source code changes — version/dependency-pin metadata only, plus the corresponding single-line self-version update in `memgraph-toolbox/uv.lock`.

## Test plan
- [x] `ruff check .` / `ruff format --check .` pass repo-wide
- [x] `memgraph-toolbox` test suite (47 passed) against a live Memgraph container
- [x] `mcp-memgraph` test suite (44 passed) against a live Memgraph container
- [x] `lightrag-memgraph` test suite (39 passed, 1 pre-existing unrelated failure reproduced on `main` too — a GC-lag-timing integration test, not caused by this change)
- [x] `unstructured2graph` test suite (19 passed, 1 skipped)
- [ ] After merge: manually trigger the `Release memgraph-toolbox`, `Release mcp-memgraph`, `Release lightrag-memgraph`, and `Release unstructured2graph` GitHub Actions workflows (workflow_dispatch) to actually publish to PyPI — **toolbox must be released before or alongside mcp-memgraph** to avoid a broken install.