### PR TITLE
Bump versions for release: sessions-graph, unstructured2graph

### DIFF
--- a/context-graph/sessions-graph/pyproject.toml
+++ b/context-graph/sessions-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sessions-graph"
-version = "0.1.2"
+version = "0.2.0"
 description = "Cross-session memory store for agents, backed by Memgraph"
 readme = "README.md"
 license = { text = "MIT" }
@@ -21,7 +21,7 @@ agent-context-graph = [
 ]
 reconciliation = [
     "actions-graph>=0.1.1",
-    "unstructured2graph>=0.3.0",
+    "unstructured2graph>=0.4.0",
 ]
 test = [
     "pytest>=9.0.3",

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unstructured2graph"
-version = "0.3.0"
+version = "0.4.0"
 description = "Convert unstructured documents into knowledge graphs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/unstructured2graph/src/unstructured2graph/__init__.py
+++ b/unstructured2graph/src/unstructured2graph/__init__.py
@@ -25,7 +25,7 @@ from .memgraph import (
     link_nodes_in_order,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.4.0"
 __all__ = [
     "Chunk",
     "ChunkedDocument",


### PR DESCRIPTION
## Summary

Prepares two packages for release, following on from #245.

| Package | Version | Notes |
|---|---|---|
| `unstructured2graph` | 0.3.0 → 0.4.0 | Adds the raw-string entry point (`parse_text()` / `from_texts()`) alongside the existing file/URL pipeline. `from_unstructured()` now returns a grouped `list[list[Chunk]]` instead of `None`. Also fixes `__init__.py`'s `__version__` string, which had drifted to a stale `"0.1.0"` and never actually tracked the published version. |
| `sessions-graph` | 0.1.2 → 0.2.0 | Adds session reconciliation: `SessionsGraph.reconcile_session()`, the `sessions-graph reconcile` CLI, and `SessionsGraphConnector`'s `auto_reconcile`, via the new `reconciliation` extra. Bumps its `unstructured2graph` floor to `>=0.4.0`, since `reconcile_session()` depends on `from_texts()`, which doesn't exist in the currently-published 0.3.0. |

No other package's source or version changed — this is metadata-only, matching the convention from #244.

## Test plan

- [x] `unstructured2graph` test suite passes with the bumped version (28 passed, 1 skipped, pre-existing)
- [x] `ruff check` / `ruff format --check` pass
- [ ] After merge: manually trigger the `Release unstructured2graph` and `Release sessions-graph` GitHub Actions workflows (`workflow_dispatch`) to publish to PyPI — release `unstructured2graph` first (or alongside), since `sessions-graph[reconciliation]`'s floor now requires it.