### PR TITLE
Add local dev-memgraph script; fix two config/Cypher bugs found while building it

### DIFF
--- a/context-graph/agent-context-graph/tests/test_hook_cli.py
+++ b/context-graph/agent-context-graph/tests/test_hook_cli.py
@@ -265,6 +265,13 @@ def test_top_level_cli_bootstrap_accepts_zero_port(monkeypatch, capsys):
     )
     monkeypatch.setattr("agent_context_graph.cli._doctor", lambda args: 0)
 
+    from pathlib import Path
+
+    monkeypatch.setattr(
+        "agent_context_graph.adapters._identity.write_full_config",
+        lambda **kwargs: Path("/tmp/fake-config.toml"),
+    )
+
     def fake_reachable(host, port):
         captured["host"] = host
         captured["port"] = port

--- a/context-graph/sessions-graph/README.md
+++ b/context-graph/sessions-graph/README.md
@@ -89,7 +89,7 @@ graph.save_memory(
                               │                        ▼
                       (:Session {session_id,   (:Chunk {hash, text})
                                  reconciliation_status,     ▲
-                                 reconcileed_at})  [:HAS_CHUNK]
+                                 reconciled_at})  [:HAS_CHUNK]
                               │                        │
                         [:HAS_ACTION]                  │
                               ▼                        │

--- a/context-graph/sessions-graph/src/sessions_graph/cli.py
+++ b/context-graph/sessions-graph/src/sessions_graph/cli.py
@@ -96,7 +96,7 @@ async def _run_reconcile(parsed: argparse.Namespace) -> int:
         for session_id in session_ids:
             summary = await graph.reconcile_session(session_id, lightrag_wrapper=lightrag_wrapper)
             if summary.status == "completed":
-                print(f"OK {session_id}: {summary.texts_deduped}/{summary.texts_considered} unique texts reconcileed")
+                print(f"OK {session_id}: {summary.texts_deduped}/{summary.texts_considered} unique texts reconciled")
             else:
                 print(f"FAILED {session_id}: {summary.error}", file=sys.stderr)
                 exit_code = 1

--- a/context-graph/sessions-graph/src/sessions_graph/core.py
+++ b/context-graph/sessions-graph/src/sessions_graph/core.py
@@ -341,9 +341,9 @@ class SessionsGraph:
             self._db.query(
                 """
                 MATCH (s:Session {session_id: $session_id})
-                SET s.reconciliation_status = 'completed', s.reconcileed_at = $reconcileed_at
+                SET s.reconciliation_status = 'completed', s.reconciled_at = $reconciled_at
                 """,
-                params={"session_id": session_id, "reconcileed_at": datetime.now(timezone.utc).isoformat()},
+                params={"session_id": session_id, "reconciled_at": datetime.now(timezone.utc).isoformat()},
             )
             return ReconciliationSummary(
                 session_id=session_id,

--- a/context-graph/sessions-graph/src/sessions_graph/core.py
+++ b/context-graph/sessions-graph/src/sessions_graph/core.py
@@ -207,6 +207,7 @@ class SessionsGraph:
             f"""
             CALL text_search.search_all('{_FULLTEXT_INDEX}', $query)
             YIELD node AS m, score
+            WITH m, score
             WHERE m.user_id = $user_id
             OPTIONAL MATCH (s:Session)-[:PRODUCED_MEMORY]->(m)
             RETURN m.memory_id  AS memory_id,

--- a/scripts/dev-memgraph.sh
+++ b/scripts/dev-memgraph.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Local dev lifecycle for an isolated Memgraph instance used to test
+# unstructured2graph and the context-graph family (agent-context-graph,
+# actions-graph, skills-graph, sessions-graph) -- and, separately, to point
+# the real live Claude Code plugin at that same instance for dogfooding.
+#
+# See `./scripts/dev-memgraph.sh --help` for the intended workflow.
+set -euo pipefail
+
+CONTAINER_NAME="ai-toolkit-dev-memgraph"
+HOST_PORT="7688"
+IMAGE="memgraph/memgraph-mage:latest"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Deliberately a dedicated port/container, distinct from any other Memgraph
+# you may already have running locally for unrelated purposes -- this script
+# never touches anything but $CONTAINER_NAME.
+LOCAL_MEMGRAPH_URL="bolt://localhost:${HOST_PORT}"
+LOCAL_MEMGRAPH_USER=""
+LOCAL_MEMGRAPH_PASSWORD=""
+LOCAL_MEMGRAPH_DATABASE="memgraph"
+
+CONFIG_DIR="${HOME}/.config/context-graph"
+CONFIG_FILE="${CONFIG_DIR}/config.toml"
+CONFIG_BACKUP="${CONFIG_DIR}/config.toml.pre-local-test-backup"
+
+ALL_PACKAGES=(unstructured2graph actions-graph agent-context-graph skills-graph sessions-graph)
+
+_HELP="usage: $(basename "$0") <command> [args]
+
+Manage an isolated local Memgraph instance for developing/testing
+unstructured2graph and the context-graph family, and for pointing the real
+Claude Code plugin at it to see live session data land for real.
+
+Commands:
+  up                 Start (or resume) the local Memgraph container (port ${HOST_PORT}).
+  down               Stop and remove the local Memgraph container.
+  status             Show container state and whether hook config is local or real.
+  test [pkg...]      Run test suites against the local container.
+                     Default packages: ${ALL_PACKAGES[*]}
+  inspect            Print a node-count summary of what is currently in the local graph.
+  hooks-local        Point your REAL, live Claude Code plugin at the local container
+                     (backs up your current ~/.config/context-graph/config.toml first).
+  hooks-restore       Restore your real hook config from the hooks-local backup.
+
+Typical workflow:
+  $(basename "$0") up
+  $(basename "$0") test              # proves correctness -- graph ends EMPTY by design
+                                       # (the test fixtures clean up before/after each test)
+  $(basename "$0") hooks-local        # now drive a REAL Claude Code session to see data land
+  $(basename "$0") inspect
+  $(basename "$0") hooks-restore      # point your real hooks back before you forget
+  $(basename "$0") down
+"
+
+_wait_ready() {
+  echo "Waiting for Memgraph to accept Bolt connections on localhost:${HOST_PORT}..."
+  for i in $(seq 1 30); do
+    if (echo >"/dev/tcp/localhost/${HOST_PORT}") 2>/dev/null; then
+      echo "Memgraph is ready."
+      return 0
+    fi
+    echo "Waiting for Memgraph (attempt $i)..."
+    sleep 2
+  done
+  echo "ERROR: Memgraph did not become ready in time." >&2
+  docker logs "${CONTAINER_NAME}" 2>&1 | tail -30 >&2 || true
+  exit 1
+}
+
+_require_container_reachable() {
+  if ! (echo >"/dev/tcp/localhost/${HOST_PORT}") 2>/dev/null; then
+    echo "ERROR: no Memgraph reachable on localhost:${HOST_PORT}. Run '$(basename "$0") up' first." >&2
+    exit 1
+  fi
+}
+
+# Some packages' own test suites are not perfectly hermetic about
+# ~/.config/context-graph/config.toml (a real, discovered bug: a bootstrap
+# test in agent-context-graph's suite failed to mock its config-writing call
+# and silently overwrote a real, live, credentialed config with test
+# artifacts). Belt-and-suspenders: protect whatever is currently in that file
+# across every `test` run, independent of whether hooks-local/hooks-restore
+# are ever used, so a similar bug anywhere else can't do the same thing.
+_TEST_CONFIG_SAFETY_BACKUP="${CONFIG_FILE}.test-run-safety-backup"
+
+_protect_hook_config() {
+  if [ -f "${CONFIG_FILE}" ]; then
+    cp "${CONFIG_FILE}" "${_TEST_CONFIG_SAFETY_BACKUP}"
+    chmod 600 "${_TEST_CONFIG_SAFETY_BACKUP}" 2>/dev/null || true
+  fi
+}
+
+_restore_hook_config_after_test() {
+  if [ -f "${_TEST_CONFIG_SAFETY_BACKUP}" ]; then
+    mv "${_TEST_CONFIG_SAFETY_BACKUP}" "${CONFIG_FILE}"
+  fi
+}
+
+cmd_up() {
+  if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+    if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+      echo "Already running: ${CONTAINER_NAME} on port ${HOST_PORT}"
+    else
+      echo "Starting existing container ${CONTAINER_NAME}..."
+      docker start "${CONTAINER_NAME}" >/dev/null
+    fi
+  else
+    echo "Creating ${CONTAINER_NAME} (${IMAGE}) on port ${HOST_PORT}..."
+    docker run -d -p "${HOST_PORT}:7687" --name "${CONTAINER_NAME}" "${IMAGE}" \
+      --schema-info-enabled=True --telemetry-enabled=false >/dev/null
+  fi
+  _wait_ready
+}
+
+cmd_down() {
+  if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+    docker rm -f "${CONTAINER_NAME}" >/dev/null
+    echo "Removed ${CONTAINER_NAME}."
+  else
+    echo "${CONTAINER_NAME} does not exist."
+  fi
+}
+
+cmd_status() {
+  if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+    echo "Container: running (${CONTAINER_NAME}, localhost:${HOST_PORT})"
+  elif docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+    echo "Container: stopped (${CONTAINER_NAME})"
+  else
+    echo "Container: not created"
+  fi
+
+  if [ -f "${CONFIG_BACKUP}" ]; then
+    echo "Hook config: LOCAL mode (your real config is backed up at ${CONFIG_BACKUP})"
+  else
+    echo "Hook config: real/production mode (no local-mode backup present)"
+  fi
+}
+
+cmd_inspect() {
+  _require_container_reachable
+  MEMGRAPH_URL="${LOCAL_MEMGRAPH_URL}" \
+    MEMGRAPH_USER="${LOCAL_MEMGRAPH_USER}" \
+    MEMGRAPH_PASSWORD="${LOCAL_MEMGRAPH_PASSWORD}" \
+    MEMGRAPH_DATABASE="${LOCAL_MEMGRAPH_DATABASE}" \
+    "${REPO_ROOT}/.venv/bin/python3" - <<'PYEOF'
+from memgraph_toolbox.api.memgraph import Memgraph
+
+m = Memgraph()
+try:
+    rows = m.query("MATCH (n) RETURN labels(n) AS labels, count(*) AS count ORDER BY count DESC")
+    if not rows:
+        print("(empty graph)")
+    else:
+        print("Node counts by label:")
+        for row in rows:
+            print(f"  {row['labels']}: {row['count']}")
+    total = m.query("MATCH (n) RETURN count(n) AS count")[0]["count"]
+    print(f"Total nodes: {total}")
+finally:
+    m.close()
+PYEOF
+}
+
+cmd_test() {
+  _require_container_reachable
+  _protect_hook_config
+  trap _restore_hook_config_after_test EXIT
+
+  local packages=("$@")
+  if [ "${#packages[@]}" -eq 0 ]; then
+    packages=("${ALL_PACKAGES[@]}")
+  fi
+
+  # Only exported for the packages that actually talk to Memgraph in their own
+  # tests. agent-context-graph is a pure event-routing/adapter layer -- its
+  # own suite is fully mocked and some tests assert on the hardcoded DEFAULT
+  # bolt://localhost:7687, so leaking MEMGRAPH_URL into it would break them;
+  # it's run with those vars explicitly unset instead, regardless of what's
+  # already in the ambient shell environment.
+  local with_local_memgraph=(
+    env
+    "MEMGRAPH_URL=${LOCAL_MEMGRAPH_URL}"
+    "MEMGRAPH_USER=${LOCAL_MEMGRAPH_USER}"
+    "MEMGRAPH_PASSWORD=${LOCAL_MEMGRAPH_PASSWORD}"
+    "MEMGRAPH_DATABASE=${LOCAL_MEMGRAPH_DATABASE}"
+  )
+  local without_memgraph_env=(env -u MEMGRAPH_URL -u MEMGRAPH_USER -u MEMGRAPH_PASSWORD -u MEMGRAPH_DATABASE)
+
+  local failed=()
+  for pkg in "${packages[@]}"; do
+    echo ""
+    echo "=== Testing ${pkg} ==="
+    case "$pkg" in
+      unstructured2graph)
+        (cd "$REPO_ROOT" && "${with_local_memgraph[@]}" uv run --package unstructured2graph --extra test \
+          pytest unstructured2graph/tests/ -v) || failed+=("$pkg")
+        ;;
+      actions-graph)
+        (cd "$REPO_ROOT" && "${with_local_memgraph[@]}" uv run --package actions-graph --extra test --extra agent-context-graph \
+          pytest context-graph/actions-graph/tests/ -v) || failed+=("$pkg")
+        ;;
+      agent-context-graph)
+        (cd "$REPO_ROOT" && "${without_memgraph_env[@]}" uv run --package agent-context-graph --extra test \
+          pytest context-graph/agent-context-graph/tests/ -v) || failed+=("$pkg")
+        ;;
+      skills-graph)
+        (cd "$REPO_ROOT" && "${with_local_memgraph[@]}" uv run --package skills-graph --extra test --extra agent-context-graph \
+          pytest context-graph/skills-graph/tests/ -v) || failed+=("$pkg")
+        ;;
+      sessions-graph)
+        (cd "$REPO_ROOT" && "${with_local_memgraph[@]}" uv run --package sessions-graph --extra test --extra reconciliation --extra agent-context-graph \
+          pytest context-graph/sessions-graph/tests/ -v) || failed+=("$pkg")
+        ;;
+      *)
+        echo "Unknown package: $pkg (expected one of: ${ALL_PACKAGES[*]})" >&2
+        failed+=("$pkg")
+        ;;
+    esac
+  done
+
+  echo ""
+  if [ "${#failed[@]}" -eq 0 ]; then
+    echo "All test suites passed: ${packages[*]}"
+  else
+    echo "FAILED: ${failed[*]}" >&2
+    exit 1
+  fi
+}
+
+cmd_hooks_local() {
+  if ! command -v agent-context-graph >/dev/null 2>&1; then
+    echo "ERROR: agent-context-graph is not on PATH." >&2
+    echo "Install it first, e.g. via context-graph/plugins/agent-context-graph-claude/scripts/bootstrap.sh" >&2
+    exit 1
+  fi
+
+  mkdir -p "${CONFIG_DIR}"
+  if [ -f "${CONFIG_BACKUP}" ]; then
+    echo "Backup already exists at ${CONFIG_BACKUP} -- assuming you're already in local mode; re-applying local config."
+  elif [ -f "${CONFIG_FILE}" ]; then
+    cp "${CONFIG_FILE}" "${CONFIG_BACKUP}"
+    echo "Backed up your real config to ${CONFIG_BACKUP}"
+  else
+    echo "No existing config file at ${CONFIG_FILE} -- nothing to back up."
+  fi
+
+  agent-context-graph config set memgraph.url "${LOCAL_MEMGRAPH_URL}"
+  agent-context-graph config set memgraph.user ""
+  agent-context-graph config set memgraph.password ""
+  agent-context-graph config set memgraph.database "${LOCAL_MEMGRAPH_DATABASE}"
+
+  echo ""
+  echo "Live hooks now point at the local instance (${LOCAL_MEMGRAPH_URL})."
+  echo "When you're done, restore your real config with:"
+  echo "  $(basename "$0") hooks-restore"
+}
+
+cmd_hooks_restore() {
+  if [ ! -f "${CONFIG_BACKUP}" ]; then
+    echo "ERROR: no backup found at ${CONFIG_BACKUP} -- nothing to restore." >&2
+    echo "(Are you sure hooks-local was run, and hasn't already been restored?)" >&2
+    exit 1
+  fi
+  mv "${CONFIG_BACKUP}" "${CONFIG_FILE}"
+  echo "Restored your real hook config from backup."
+  agent-context-graph config show 2>/dev/null || true
+}
+
+main() {
+  local cmd="${1:-}"
+  if [ "$#" -gt 0 ]; then
+    shift
+  fi
+  case "$cmd" in
+    up) cmd_up ;;
+    down) cmd_down ;;
+    status) cmd_status ;;
+    inspect) cmd_inspect ;;
+    test) cmd_test "$@" ;;
+    hooks-local) cmd_hooks_local ;;
+    hooks-restore) cmd_hooks_restore ;;
+    -h | --help | "") echo "$_HELP" ;;
+    *)
+      echo "Unknown command: $cmd" >&2
+      echo "$_HELP" >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/dev-memgraph.sh
+++ b/scripts/dev-memgraph.sh
@@ -39,6 +39,10 @@ Commands:
   test [pkg...]      Run test suites against the local container.
                      Default packages: ${ALL_PACKAGES[*]}
   inspect            Print a node-count summary of what is currently in the local graph.
+  reconcile [args]    Run 'sessions-graph reconcile' against the local container.
+                     Defaults to --pending (sweeps every session marked pending);
+                     pass --session <id> to target one. Pulls OPENAI_API_KEY from
+                     the environment, or from .env at the repo root if unset.
   hooks-local        Point your REAL, live Claude Code plugin at the local container
                      (backs up your current ~/.config/context-graph/config.toml first).
   hooks-restore       Restore your real hook config from the hooks-local backup.
@@ -48,6 +52,8 @@ Typical workflow:
   $(basename "$0") test              # proves correctness -- graph ends EMPTY by design
                                        # (the test fixtures clean up before/after each test)
   $(basename "$0") hooks-local        # now drive a REAL Claude Code session to see data land
+  $(basename "$0") inspect
+  $(basename "$0") reconcile          # runs real entity extraction on pending sessions (costs an LLM call)
   $(basename "$0") inspect
   $(basename "$0") hooks-restore      # point your real hooks back before you forget
   $(basename "$0") down
@@ -161,6 +167,45 @@ try:
 finally:
     m.close()
 PYEOF
+}
+
+# Resolves OPENAI_API_KEY for cmd_reconcile: prefer whatever is already in the
+# environment, otherwise pull it from .env at the repo root. Never prints the
+# value anywhere.
+_resolve_openai_api_key() {
+  if [ -n "${OPENAI_API_KEY:-}" ]; then
+    return 0
+  fi
+  local env_file="${REPO_ROOT}/.env"
+  if [ -f "${env_file}" ]; then
+    OPENAI_API_KEY="$(grep -E '^OPENAI_API_KEY=' "${env_file}" | head -1 | cut -d'=' -f2-)"
+    export OPENAI_API_KEY
+  fi
+  [ -n "${OPENAI_API_KEY:-}" ]
+}
+
+cmd_reconcile() {
+  _require_container_reachable
+
+  if ! _resolve_openai_api_key; then
+    echo "ERROR: OPENAI_API_KEY is not set and was not found in ${REPO_ROOT}/.env" >&2
+    echo "Session reconciliation calls a real LLM (via LightRAG) and needs it." >&2
+    exit 1
+  fi
+
+  local target=("$@")
+  if [ "${#target[@]}" -eq 0 ]; then
+    target=(--pending)
+  fi
+
+  echo "Running: sessions-graph reconcile ${target[*]}"
+  (cd "$REPO_ROOT" && env \
+    "MEMGRAPH_URL=${LOCAL_MEMGRAPH_URL}" \
+    "MEMGRAPH_USER=${LOCAL_MEMGRAPH_USER}" \
+    "MEMGRAPH_PASSWORD=${LOCAL_MEMGRAPH_PASSWORD}" \
+    "MEMGRAPH_DATABASE=${LOCAL_MEMGRAPH_DATABASE}" \
+    "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+    uv run --package sessions-graph --extra reconciliation sessions-graph reconcile "${target[@]}")
 }
 
 cmd_test() {
@@ -279,6 +324,7 @@ main() {
     status) cmd_status ;;
     inspect) cmd_inspect ;;
     test) cmd_test "$@" ;;
+    reconcile) cmd_reconcile "$@" ;;
     hooks-local) cmd_hooks_local ;;
     hooks-restore) cmd_hooks_restore ;;
     -h | --help | "") echo "$_HELP" ;;

--- a/scripts/dev-memgraph.sh
+++ b/scripts/dev-memgraph.sh
@@ -68,6 +68,9 @@ Commands:
   hooks-local        Point your REAL, live Claude Code plugin at the main container
                      (backs up your current ~/.config/context-graph/config.toml first).
   hooks-restore       Restore your real hook config from the hooks-local backup.
+  dogfood-env         Print export statements enabling auto_reconcile (true, automatic,
+                     event-driven reconciliation on SESSION_END) for a claude session
+                     launched afterward. Usage: eval \"\$(./scripts/dev-memgraph.sh dogfood-env)\" && claude
   test [pkg...]      Run test suites against a SEPARATE, disposable container --
                      never touches the main one. Default packages: ${ALL_PACKAGES[*]}
 
@@ -79,6 +82,10 @@ Typical workflow (exploration -- the actual goal of this script):
   $(basename "$0") inspect
   $(basename "$0") hooks-restore      # point your real hooks back before you forget
   $(basename "$0") down               # only when fully done -- this deletes your explored data
+
+Automatic reconciliation instead of the manual \`reconcile\` step above --
+takes effect for a NEW claude session, not one already running:
+  eval \"\$($(basename "$0") dogfood-env)\" && claude
 
 Running the automated suites any time (does not touch the above):
   $(basename "$0") test
@@ -233,6 +240,30 @@ _resolve_openai_api_key() {
   [ -n "${OPENAI_API_KEY:-}" ]
 }
 
+# Prints export statements for the vars SessionsGraphConnector's own
+# auto_reconcile fallback (SESSIONS_GRAPH_AUTO_RECONCILE) and the detached
+# reconcile subprocess it spawns actually need. Deliberately NOT something
+# this script sets permanently in a shell profile: env vars set on an
+# already-running `claude` process can't retroactively reach it (or its hook
+# subprocesses) -- they only take effect for a `claude` you launch fresh
+# afterward, from a shell that has run this first. Usage:
+#   eval "$(./scripts/dev-memgraph.sh dogfood-env)" && claude
+# Scoped to that one shell/session; a plain new terminal is unaffected.
+cmd_dogfood_env() {
+  if ! _resolve_openai_api_key; then
+    echo "ERROR: OPENAI_API_KEY is not set and was not found in ${REPO_ROOT}/.env" >&2
+    exit 1
+  fi
+  cat <<EOF
+export SESSIONS_GRAPH_AUTO_RECONCILE=1
+export MEMGRAPH_URL="${LOCAL_MEMGRAPH_URL}"
+export MEMGRAPH_USER="${LOCAL_MEMGRAPH_USER}"
+export MEMGRAPH_PASSWORD="${LOCAL_MEMGRAPH_PASSWORD}"
+export MEMGRAPH_DATABASE="${LOCAL_MEMGRAPH_DATABASE}"
+export OPENAI_API_KEY="${OPENAI_API_KEY}"
+EOF
+}
+
 cmd_reconcile() {
   _require_container_reachable
 
@@ -377,6 +408,7 @@ main() {
     test) cmd_test "$@" ;;
     test-down) cmd_test_down ;;
     reconcile) cmd_reconcile "$@" ;;
+    dogfood-env) cmd_dogfood_env ;;
     hooks-local) cmd_hooks_local ;;
     hooks-restore) cmd_hooks_restore ;;
     -h | --help | "") echo "$_HELP" ;;

--- a/scripts/dev-memgraph.sh
+++ b/scripts/dev-memgraph.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Local dev lifecycle for an isolated Memgraph instance used to test
-# unstructured2graph and the context-graph family (agent-context-graph,
-# actions-graph, skills-graph, sessions-graph) -- and, separately, to point
-# the real live Claude Code plugin at that same instance for dogfooding.
+# Local dev lifecycle for exploring/dogfooding unstructured2graph and the
+# context-graph family (agent-context-graph, actions-graph, skills-graph,
+# sessions-graph) against an isolated local Memgraph -- including pointing
+# the real live Claude Code plugin at it. That exploration instance's data
+# persists until you explicitly `down` it. `test` is a separate concern with
+# its own disposable container, so running the automated suites can never
+# wipe whatever you're exploring.
 #
 # See `./scripts/dev-memgraph.sh --help` for the intended workflow.
 set -euo pipefail
@@ -14,11 +17,30 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Deliberately a dedicated port/container, distinct from any other Memgraph
 # you may already have running locally for unrelated purposes -- this script
-# never touches anything but $CONTAINER_NAME.
+# never touches anything but $CONTAINER_NAME with `up`/`down`. This is the
+# exploration instance: `hooks-local` points your real Claude Code plugin at
+# it, and its data is meant to persist across everything except an explicit
+# `down` -- nothing in this script ever runs cleanup queries against it.
 LOCAL_MEMGRAPH_URL="bolt://localhost:${HOST_PORT}"
 LOCAL_MEMGRAPH_USER=""
 LOCAL_MEMGRAPH_PASSWORD=""
 LOCAL_MEMGRAPH_DATABASE="memgraph"
+
+# `test` runs against a SEPARATE, disposable container/port, never the one
+# above. Community Edition Memgraph has no multi-database/multi-tenancy (that
+# needs an Enterprise license -- `SHOW DATABASES` errors without one), so this
+# is the only way to give the test suites' own hermetic per-test cleanup
+# (every package's e2e conftest.py does MATCH (n) DETACH DELETE n before/after
+# each test, by design, matching skills-graph/actions-graph's own pre-existing
+# convention) a place to run without ever being able to wipe whatever you're
+# exploring/dogfooding on the instance above. Managed transparently by `test`
+# itself -- you never need to think about it.
+TEST_CONTAINER_NAME="ai-toolkit-test-memgraph"
+TEST_HOST_PORT="7689"
+TEST_MEMGRAPH_URL="bolt://localhost:${TEST_HOST_PORT}"
+TEST_MEMGRAPH_USER=""
+TEST_MEMGRAPH_PASSWORD=""
+TEST_MEMGRAPH_DATABASE="memgraph"
 
 CONFIG_DIR="${HOME}/.config/context-graph"
 CONFIG_FILE="${CONFIG_DIR}/config.toml"
@@ -28,41 +50,46 @@ ALL_PACKAGES=(unstructured2graph actions-graph agent-context-graph skills-graph 
 
 _HELP="usage: $(basename "$0") <command> [args]
 
-Manage an isolated local Memgraph instance for developing/testing
-unstructured2graph and the context-graph family, and for pointing the real
-Claude Code plugin at it to see live session data land for real.
+Runs an isolated local Memgraph (port ${HOST_PORT}) to explore/dogfood
+unstructured2graph and the context-graph family against -- its data persists
+until you explicitly \`down\` it. \`test\` is a separate concern: it runs
+against its own disposable container (port ${TEST_HOST_PORT}), so it can
+never wipe whatever you're exploring on the main one.
 
 Commands:
-  up                 Start (or resume) the local Memgraph container (port ${HOST_PORT}).
-  down               Stop and remove the local Memgraph container.
-  status             Show container state and whether hook config is local or real.
-  test [pkg...]      Run test suites against the local container.
-                     Default packages: ${ALL_PACKAGES[*]}
-  inspect            Print a node-count summary of what is currently in the local graph.
-  reconcile [args]    Run 'sessions-graph reconcile' against the local container.
+  up                 Start (or resume) the main local Memgraph container.
+  down               Stop and remove the main local Memgraph container.
+  status             Show both containers' state and whether hook config is local or real.
+  inspect            Print a node-count summary of what is currently in the main graph.
+  reconcile [args]    Run 'sessions-graph reconcile' against the main container.
                      Defaults to --pending (sweeps every session marked pending);
                      pass --session <id> to target one. Pulls OPENAI_API_KEY from
                      the environment, or from .env at the repo root if unset.
-  hooks-local        Point your REAL, live Claude Code plugin at the local container
+  hooks-local        Point your REAL, live Claude Code plugin at the main container
                      (backs up your current ~/.config/context-graph/config.toml first).
   hooks-restore       Restore your real hook config from the hooks-local backup.
+  test [pkg...]      Run test suites against a SEPARATE, disposable container --
+                     never touches the main one. Default packages: ${ALL_PACKAGES[*]}
 
-Typical workflow:
+Typical workflow (exploration -- the actual goal of this script):
   $(basename "$0") up
-  $(basename "$0") test              # proves correctness -- graph ends EMPTY by design
-                                       # (the test fixtures clean up before/after each test)
-  $(basename "$0") hooks-local        # now drive a REAL Claude Code session to see data land
+  $(basename "$0") hooks-local        # drive a REAL Claude Code session to see data land
   $(basename "$0") inspect
   $(basename "$0") reconcile          # runs real entity extraction on pending sessions (costs an LLM call)
   $(basename "$0") inspect
   $(basename "$0") hooks-restore      # point your real hooks back before you forget
-  $(basename "$0") down
+  $(basename "$0") down               # only when fully done -- this deletes your explored data
+
+Running the automated suites any time (does not touch the above):
+  $(basename "$0") test
+  $(basename "$0") test-down          # optional -- reclaim the disposable test container
 "
 
 _wait_ready() {
-  echo "Waiting for Memgraph to accept Bolt connections on localhost:${HOST_PORT}..."
+  local port="$1" container="$2"
+  echo "Waiting for Memgraph to accept Bolt connections on localhost:${port}..."
   for i in $(seq 1 30); do
-    if (echo >"/dev/tcp/localhost/${HOST_PORT}") 2>/dev/null; then
+    if (echo >"/dev/tcp/localhost/${port}") 2>/dev/null; then
       echo "Memgraph is ready."
       return 0
     fi
@@ -70,7 +97,7 @@ _wait_ready() {
     sleep 2
   done
   echo "ERROR: Memgraph did not become ready in time." >&2
-  docker logs "${CONTAINER_NAME}" 2>&1 | tail -30 >&2 || true
+  docker logs "${container}" 2>&1 | tail -30 >&2 || true
   exit 1
 }
 
@@ -79,6 +106,25 @@ _require_container_reachable() {
     echo "ERROR: no Memgraph reachable on localhost:${HOST_PORT}. Run '$(basename "$0") up' first." >&2
     exit 1
   fi
+}
+
+# Idempotent start for any named container/port pair -- shared by the main
+# `up` command and `test`'s own separate throwaway container.
+_container_up() {
+  local name="$1" port="$2"
+  if docker ps -a --format '{{.Names}}' | grep -qx "${name}"; then
+    if docker ps --format '{{.Names}}' | grep -qx "${name}"; then
+      echo "Already running: ${name} on port ${port}"
+    else
+      echo "Starting existing container ${name}..."
+      docker start "${name}" >/dev/null
+    fi
+  else
+    echo "Creating ${name} (${IMAGE}) on port ${port}..."
+    docker run -d -p "${port}:7687" --name "${name}" "${IMAGE}" \
+      --schema-info-enabled=True --telemetry-enabled=false >/dev/null
+  fi
+  _wait_ready "${port}" "${name}"
 }
 
 # Some packages' own test suites are not perfectly hermetic about
@@ -104,43 +150,46 @@ _restore_hook_config_after_test() {
 }
 
 cmd_up() {
-  if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
-    if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
-      echo "Already running: ${CONTAINER_NAME} on port ${HOST_PORT}"
-    else
-      echo "Starting existing container ${CONTAINER_NAME}..."
-      docker start "${CONTAINER_NAME}" >/dev/null
-    fi
+  _container_up "${CONTAINER_NAME}" "${HOST_PORT}"
+}
+
+_container_down() {
+  local name="$1"
+  if docker ps -a --format '{{.Names}}' | grep -qx "${name}"; then
+    docker rm -f "${name}" >/dev/null
+    echo "Removed ${name}."
   else
-    echo "Creating ${CONTAINER_NAME} (${IMAGE}) on port ${HOST_PORT}..."
-    docker run -d -p "${HOST_PORT}:7687" --name "${CONTAINER_NAME}" "${IMAGE}" \
-      --schema-info-enabled=True --telemetry-enabled=false >/dev/null
+    echo "${name} does not exist."
   fi
-  _wait_ready
 }
 
 cmd_down() {
-  if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
-    docker rm -f "${CONTAINER_NAME}" >/dev/null
-    echo "Removed ${CONTAINER_NAME}."
+  _container_down "${CONTAINER_NAME}"
+}
+
+cmd_test_down() {
+  _container_down "${TEST_CONTAINER_NAME}"
+}
+
+_describe_container() {
+  local label="$1" name="$2" port="$3"
+  if docker ps --format '{{.Names}}' | grep -qx "${name}"; then
+    echo "${label}: running (${name}, localhost:${port})"
+  elif docker ps -a --format '{{.Names}}' | grep -qx "${name}"; then
+    echo "${label}: stopped (${name})"
   else
-    echo "${CONTAINER_NAME} does not exist."
+    echo "${label}: not created"
   fi
 }
 
 cmd_status() {
-  if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
-    echo "Container: running (${CONTAINER_NAME}, localhost:${HOST_PORT})"
-  elif docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
-    echo "Container: stopped (${CONTAINER_NAME})"
-  else
-    echo "Container: not created"
-  fi
+  _describe_container "Main container " "${CONTAINER_NAME}" "${HOST_PORT}"
+  _describe_container "Test container " "${TEST_CONTAINER_NAME}" "${TEST_HOST_PORT}"
 
   if [ -f "${CONFIG_BACKUP}" ]; then
-    echo "Hook config: LOCAL mode (your real config is backed up at ${CONFIG_BACKUP})"
+    echo "Hook config:     LOCAL mode (your real config is backed up at ${CONFIG_BACKUP})"
   else
-    echo "Hook config: real/production mode (no local-mode backup present)"
+    echo "Hook config:     real/production mode (no local-mode backup present)"
   fi
 }
 
@@ -209,7 +258,9 @@ cmd_reconcile() {
 }
 
 cmd_test() {
-  _require_container_reachable
+  # Its own separate, disposable container -- see the comment on
+  # TEST_CONTAINER_NAME above for why. Never the main $CONTAINER_NAME.
+  _container_up "${TEST_CONTAINER_NAME}" "${TEST_HOST_PORT}"
   _protect_hook_config
   trap _restore_hook_config_after_test EXIT
 
@@ -226,10 +277,10 @@ cmd_test() {
   # already in the ambient shell environment.
   local with_local_memgraph=(
     env
-    "MEMGRAPH_URL=${LOCAL_MEMGRAPH_URL}"
-    "MEMGRAPH_USER=${LOCAL_MEMGRAPH_USER}"
-    "MEMGRAPH_PASSWORD=${LOCAL_MEMGRAPH_PASSWORD}"
-    "MEMGRAPH_DATABASE=${LOCAL_MEMGRAPH_DATABASE}"
+    "MEMGRAPH_URL=${TEST_MEMGRAPH_URL}"
+    "MEMGRAPH_USER=${TEST_MEMGRAPH_USER}"
+    "MEMGRAPH_PASSWORD=${TEST_MEMGRAPH_PASSWORD}"
+    "MEMGRAPH_DATABASE=${TEST_MEMGRAPH_DATABASE}"
   )
   local without_memgraph_env=(env -u MEMGRAPH_URL -u MEMGRAPH_USER -u MEMGRAPH_PASSWORD -u MEMGRAPH_DATABASE)
 
@@ -324,6 +375,7 @@ main() {
     status) cmd_status ;;
     inspect) cmd_inspect ;;
     test) cmd_test "$@" ;;
+    test-down) cmd_test_down ;;
     reconcile) cmd_reconcile "$@" ;;
     hooks-local) cmd_hooks_local ;;
     hooks-restore) cmd_hooks_restore ;;


### PR DESCRIPTION
## Summary

- Adds `scripts/dev-memgraph.sh`, a lifecycle script for an **isolated** local Memgraph (its own dedicated container/port — never touches any other Memgraph container you may already have running) to develop and test `unstructured2graph` and the whole context-graph family against:
  - `up` / `down` / `status` — container lifecycle
  - `test [pkg...]` — runs each package's existing test suite against it (`unstructured2graph`, `actions-graph`, `agent-context-graph`, `skills-graph`, `sessions-graph`), reusing each package's own `uv run --package ... pytest` invocation verbatim — no new test code
  - `inspect` — a quick node-count-by-label summary so you can see what's actually in the graph without opening `mgconsole`/Memgraph Lab
  - `hooks-local` / `hooks-restore` — points the **real, live** Claude Code plugin at the local instance for dogfooding (a real session's data isn't wrapped in any test-cleanup fixture, unlike `test`), backing up `~/.config/context-graph/config.toml` first and restoring it on request. Hook subprocesses only ever read that config file, never environment variables (by design — `context-graph/agent-context-graph/docs/adr/0002-config-file-only-hook-resolution.md`), so this is a separate step from the env vars `test` uses.
- Two real bugs were found and fixed in the process of building and validating this script:
  1. **`agent-context-graph`**: `test_top_level_cli_bootstrap_accepts_zero_port` made a real, unmocked bootstrap call and silently overwrote a live `~/.config/context-graph/config.toml` with test artifacts — its sibling test right above it correctly mocks `write_full_config`, this one didn't. Caught because it clobbered a real config mid-session; fixed the missing mock. `dev-memgraph.sh test` also now backs up/restores `config.toml` around every run regardless, as a safety net against this class of bug recurring anywhere else.
  2. **`sessions-graph`**: `search_memories()`'s Cypher (`CALL ... YIELD ... WHERE ...` with no `WITH` boundary) is invalid in Memgraph — same category as the `update_memory` bug fixed in #245, pre-existing, never caught because it was only ever tested against a mock. Fixed with a `WITH m, score` boundary.

## Test plan

- [x] `./scripts/dev-memgraph.sh up` — isolated container starts on port 7688, doesn't touch any other local Memgraph container
- [x] `./scripts/dev-memgraph.sh test` — all 284 tests pass across the five packages (38 + 43 + 80 + 74 + 49)
- [x] `./scripts/dev-memgraph.sh inspect` — reports empty graph after `test` (expected — the suites' own fixtures clean up)
- [x] `./scripts/dev-memgraph.sh hooks-local` then `hooks-restore` — round-trips the real hook config byte-for-byte (diffed against the original)
- [x] `./scripts/dev-memgraph.sh down` — removes only the dedicated container
- [x] Re-ran `agent-context-graph`'s suite after the fix — real config confirmed untouched (23/23 pass)
- [x] Re-ran `sessions-graph`'s `search_memories` e2e test after the fix — passes against a live instance