### PR TITLE
unstructured2graph: promote entity_type to real Memgraph labels, gated by an ontology

### DIFF
--- a/context-graph/sessions-graph/pyproject.toml
+++ b/context-graph/sessions-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sessions-graph"
-version = "0.2.0"
+version = "0.3.0"
 description = "Cross-session memory store for agents, backed by Memgraph"
 readme = "README.md"
 license = { text = "MIT" }
@@ -21,7 +21,7 @@ agent-context-graph = [
 ]
 reconciliation = [
     "actions-graph>=0.1.1",
-    "unstructured2graph>=0.4.0",
+    "unstructured2graph>=0.5.0",
 ]
 test = [
     "pytest>=9.0.3",

--- a/integrations/lightrag-memgraph/pyproject.toml
+++ b/integrations/lightrag-memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lightrag-memgraph"
-version = "0.3.0"
+version = "0.3.1"
 description = "LightRAG integration with Memgraph"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from lightrag import LightRAG
-from lightrag.kg.shared_storage import initialize_pipeline_status
+from lightrag.kg.shared_storage import finalize_share_data, initialize_pipeline_status
 from lightrag.llm.openai import gpt_4o_mini_complete, openai_embed
 from lightrag.utils import logger, setup_logger
 
@@ -114,6 +114,15 @@ class MemgraphLightRAGWrapper:
         await self.rag.ainsert(**kwargs)
 
     async def afinalize(self) -> None:
+        """
+        Finalize storages and reset LightRAG's process-global shared-storage
+        state (locks, shared dicts). Without the latter reset, a second
+        LightRAG instance created later in the same process reuses asyncio
+        locks bound to this instance's (by-then-closed) event loop and raises
+        "bound to a different event loop" -- e.g. two real-LightRAG tests
+        run back-to-back under pytest-asyncio's function-scoped event loop.
+        """
         if self.rag is None:
             raise RuntimeError("LightRAG not initialized. Call initialize() first.")
         await self.rag.finalize_storages()
+        finalize_share_data()

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/core.py
@@ -121,8 +121,15 @@ class MemgraphLightRAGWrapper:
         locks bound to this instance's (by-then-closed) event loop and raises
         "bound to a different event loop" -- e.g. two real-LightRAG tests
         run back-to-back under pytest-asyncio's function-scoped event loop.
+
+        The reset runs in a finally block: if finalize_storages() raises
+        (e.g. a transient network error), the shared-storage state would
+        otherwise stay registered as initialized and break every subsequent
+        LightRAG instance in this process, not just this one's cleanup.
         """
         if self.rag is None:
             raise RuntimeError("LightRAG not initialized. Call initialize() first.")
-        await self.rag.finalize_storages()
-        finalize_share_data()
+        try:
+            await self.rag.finalize_storages()
+        finally:
+            finalize_share_data()

--- a/integrations/lightrag-memgraph/tests/test_core.py
+++ b/integrations/lightrag-memgraph/tests/test_core.py
@@ -9,12 +9,13 @@ runs an insert/query).
 from __future__ import annotations
 
 import os
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from lightrag.llm.openai import gpt_4o_mini_complete, openai_embed
 from lightrag.utils import logger as lightrag_logger
 
-from lightrag_memgraph.core import _apply_lightrag_defaults, _bridge_lightrag_env_names
+from lightrag_memgraph.core import MemgraphLightRAGWrapper, _apply_lightrag_defaults, _bridge_lightrag_env_names
 from lightrag_memgraph.embeddings import memgraph_sentence_embed
 
 _MEMGRAPH_ENV_NAMES = ("MEMGRAPH_URL", "MEMGRAPH_URI", "MEMGRAPH_USER", "MEMGRAPH_USERNAME")
@@ -136,3 +137,34 @@ def test_no_openai_key_required_with_non_openai_llm_and_embedding_default(monkey
     kwargs = {"llm_model_func": lambda *a, **kw: None}
     _apply_lightrag_defaults(kwargs)  # must not raise
     assert kwargs["embedding_func"] is memgraph_sentence_embed
+
+
+@pytest.mark.asyncio
+async def test_afinalize_resets_shared_data_on_success():
+    wrapper = MemgraphLightRAGWrapper()
+    wrapper.rag = AsyncMock()
+
+    with patch("lightrag_memgraph.core.finalize_share_data") as mock_finalize_share_data:
+        await wrapper.afinalize()
+
+    wrapper.rag.finalize_storages.assert_awaited_once()
+    mock_finalize_share_data.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_afinalize_resets_shared_data_even_if_finalize_storages_raises():
+    """A transient error in finalize_storages() must not leave the
+    process-global shared-storage state stuck as initialized -- that would
+    break every subsequent LightRAG instance in this process, not just this
+    one's cleanup."""
+    wrapper = MemgraphLightRAGWrapper()
+    wrapper.rag = AsyncMock()
+    wrapper.rag.finalize_storages.side_effect = RuntimeError("transient network error")
+
+    with (
+        patch("lightrag_memgraph.core.finalize_share_data") as mock_finalize_share_data,
+        pytest.raises(RuntimeError, match="transient network error"),
+    ):
+        await wrapper.afinalize()
+
+    mock_finalize_share_data.assert_called_once()

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unstructured2graph"
-version = "0.4.0"
+version = "0.5.0"
 description = "Convert unstructured documents into knowledge graphs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "unstructured>=0.18.18",
     "lightrag-memgraph>=0.3.0",
     "memgraph-toolbox>=0.1.11",
+    "pyyaml>=6.0",
 ]
 [project.optional-dependencies]
 all-docs = [

--- a/unstructured2graph/src/unstructured2graph/__init__.py
+++ b/unstructured2graph/src/unstructured2graph/__init__.py
@@ -25,11 +25,12 @@ from .memgraph import (
     link_nodes_in_order,
     promote_entity_types_to_labels,
 )
-from .ontology import DEFAULT_ONTOLOGY, EntityType, Ontology
+from .ontology import DEFAULT_ONTOLOGY, DEFAULT_ONTOLOGY_PATH, EntityType, Ontology, load_ontology
 
 __version__ = "0.5.0"
 __all__ = [
     "DEFAULT_ONTOLOGY",
+    "DEFAULT_ONTOLOGY_PATH",
     "Chunk",
     "ChunkedDocument",
     "EntityType",
@@ -44,6 +45,7 @@ __all__ = [
     "from_texts",
     "from_unstructured",
     "link_nodes_in_order",
+    "load_ontology",
     "make_chunks",
     "parse_source",
     "parse_text",

--- a/unstructured2graph/src/unstructured2graph/__init__.py
+++ b/unstructured2graph/src/unstructured2graph/__init__.py
@@ -23,12 +23,17 @@ from .memgraph import (
     create_unique_constraint,
     create_vector_search_index,
     link_nodes_in_order,
+    promote_entity_types_to_labels,
 )
+from .ontology import DEFAULT_ONTOLOGY, EntityType, Ontology
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __all__ = [
+    "DEFAULT_ONTOLOGY",
     "Chunk",
     "ChunkedDocument",
+    "EntityType",
+    "Ontology",
     "compute_embeddings",
     "connect_chunks_to_entities",
     "create_label_index",
@@ -42,4 +47,5 @@ __all__ = [
     "make_chunks",
     "parse_source",
     "parse_text",
+    "promote_entity_types_to_labels",
 ]

--- a/unstructured2graph/src/unstructured2graph/default_ontology.yaml
+++ b/unstructured2graph/src/unstructured2graph/default_ontology.yaml
@@ -1,0 +1,27 @@
+# Default entity-type ontology. Mirrors LightRAG's own built-in vocabulary
+# (lightrag.prompt's default_entity_types_guidance), so label promotion
+# matches what LightRAG extracts by default even before this file is
+# customized or overridden with a project-specific ontology_path.
+entity_types:
+  - label: Person
+    description: Human individuals, real or fictional
+  - label: Creature
+    description: Non-human living beings (animals, mythical beings, etc.)
+  - label: Organization
+    description: Companies, institutions, government bodies, groups
+  - label: Location
+    description: Geographic places (cities, countries, buildings, regions)
+  - label: Event
+    description: Occurrences, incidents, ceremonies, meetings
+  - label: Concept
+    description: Abstract ideas, theories, principles, beliefs
+  - label: Method
+    description: Procedures, techniques, algorithms, workflows
+  - label: Content
+    description: Creative or informational works (books, articles, films, reports)
+  - label: Data
+    description: Quantitative or structured information (statistics, datasets, measurements)
+  - label: Artifact
+    description: Physical or digital objects created by humans (tools, software, devices)
+  - label: NaturalObject
+    description: Natural non-living objects (minerals, celestial bodies, chemical compounds)

--- a/unstructured2graph/src/unstructured2graph/loaders.py
+++ b/unstructured2graph/src/unstructured2graph/loaders.py
@@ -167,14 +167,15 @@ async def _ingest_chunks(
     only_chunks: bool = False,
     link_chunks: bool = False,
     entity_workspace: str | None = None,
+    enforce_ontology: bool = False,
     ontology_path: str | Path | None = None,
 ) -> list[Chunk]:
     """
     Ingest an already-produced flat list of chunks into Memgraph: upsert Chunk
     nodes, optionally chain them with NEXT, and (unless only_chunks) run
     LightRAG entity extraction, connect the resulting entities back to their
-    chunks via MENTIONED_IN, and promote entity_type to a real label for
-    entities that match the ontology.
+    chunks via MENTIONED_IN, and (if enforce_ontology) promote entity_type to
+    a real label for entities that match the ontology.
 
     Internal helper shared by from_unstructured() and from_texts(). Not
     exported: it relies on its caller having already ensured the Chunk.hash
@@ -192,8 +193,11 @@ async def _ingest_chunks(
         only_chunks: If True, only create chunk nodes without LightRAG processing.
         link_chunks: If True, link chunks in order with NEXT relationship.
         entity_workspace: Node label LightRAG entities were written under.
-        ontology_path: Path to an ontology YAML config file. Governs which entity_type
-            values get promoted to labels. Defaults to DEFAULT_ONTOLOGY_PATH.
+        enforce_ontology: If True, promote entity_type to labels per ontology_path (or
+            DEFAULT_ONTOLOGY_PATH). If False (default), entities are left exactly as
+            LightRAG wrote them -- no label promotion, no ontology_conformant flagging.
+        ontology_path: Path to an ontology YAML config file. Only consulted when
+            enforce_ontology=True; defaults to DEFAULT_ONTOLOGY_PATH.
     Returns:
         The same chunks that were passed in, for convenience chaining.
     """
@@ -203,6 +207,9 @@ async def _ingest_chunks(
 
     if not only_chunks and lightrag_wrapper is None:
         raise ValueError("lightrag_wrapper is required when only_chunks=False")
+
+    if ontology_path and not enforce_ontology:
+        logger.warning("ontology_path was provided but enforce_ontology=False; ignoring ontology_path")
 
     memgraph_node_props = []
     for chunk in chunks:
@@ -220,8 +227,9 @@ async def _ingest_chunks(
         for chunk in chunks:
             await lightrag_wrapper.ainsert(input=chunk.text, file_paths=[chunk.hash])
         connect_chunks_to_entities(memgraph, "Chunk", entity_workspace)
-        ontology = load_ontology(ontology_path) if ontology_path else DEFAULT_ONTOLOGY
-        promote_entity_types_to_labels(memgraph, entity_workspace, ontology)
+        if enforce_ontology:
+            ontology = load_ontology(ontology_path) if ontology_path else DEFAULT_ONTOLOGY
+            promote_entity_types_to_labels(memgraph, entity_workspace, ontology)
 
     return chunks
 
@@ -232,6 +240,7 @@ async def from_texts(
     lightrag_wrapper: MemgraphLightRAGWrapper | None = None,
     only_chunks: bool = False,
     entity_workspace: str | None = None,
+    enforce_ontology: bool = False,
     ontology_path: str | Path | None = None,
 ) -> list[list[Chunk]]:
     """
@@ -250,17 +259,20 @@ async def from_texts(
         entity_workspace: Node label LightRAG entities were written under. If None
             (default), auto-derived from lightrag_wrapper's resolved LightRAG
             workspace, falling back to "base" if that fails.
-        ontology_path: Path to an ontology YAML config file (see load_ontology()),
-            governing which entity_type values get promoted to a real Memgraph label
-            (e.g. entity_type="person" -> :Person) in addition to the entity_workspace
-            label every entity already gets. Defaults to DEFAULT_ONTOLOGY_PATH, which
-            mirrors LightRAG's own built-in type vocabulary. entity_type values outside
-            the ontology are never rejected -- the node and its entity_type property
-            are kept, stamped ontology_conformant=false instead of getting a label. To
-            also steer LightRAG's extraction itself toward the same vocabulary, load
-            the same path with load_ontology() and pass its addon_params() into
-            MemgraphLightRAGWrapper.initialize() -- using the same path at both call
-            sites is what keeps them in sync.
+        enforce_ontology: If False (default), entities are left exactly as LightRAG
+            wrote them -- no label promotion, no ontology_conformant flagging. If True,
+            entity_type gets promoted to a real Memgraph label (e.g. entity_type="person"
+            -> :Person) in addition to the entity_workspace label every entity already
+            gets, per ontology_path.
+        ontology_path: Path to an ontology YAML config file (see load_ontology()). Only
+            consulted when enforce_ontology=True; defaults to DEFAULT_ONTOLOGY_PATH,
+            which mirrors LightRAG's own built-in type vocabulary. entity_type values
+            outside the ontology are never rejected -- the node and its entity_type
+            property are kept, stamped ontology_conformant=false instead of getting a
+            label. To also steer LightRAG's extraction itself toward the same
+            vocabulary, load the same path with load_ontology() and pass its
+            addon_params() into MemgraphLightRAGWrapper.initialize() -- using the same
+            path at both call sites is what keeps them in sync.
     Returns:
         One list of Chunks per input text, in input order. A text that
         parse_text() splits into several pieces contributes several Chunks in
@@ -289,6 +301,7 @@ async def from_texts(
         only_chunks=only_chunks,
         link_chunks=False,
         entity_workspace=resolved_entity_workspace,
+        enforce_ontology=enforce_ontology,
         ontology_path=ontology_path,
     )
     return grouped_chunks
@@ -302,6 +315,7 @@ async def from_unstructured(
     link_chunks: bool = False,
     entity_workspace: str | None = None,
     partition_kwargs: dict[str, Any] | None = None,
+    enforce_ontology: bool = False,
     ontology_path: str | Path | None = None,
 ) -> list[list[Chunk]]:
     """
@@ -319,10 +333,11 @@ async def from_unstructured(
         partition_kwargs: Additional keyword arguments to pass to unstructured's
             partition function (e.g., strategy, languages, pdf_infer_table_structure,
             ocr_languages, headers, ssl_verify, etc.)
-        ontology_path: Path to an ontology YAML config file, governing which entity_type
-            values get promoted to a real Memgraph label, in addition to the
-            entity_workspace label every entity already gets. Defaults to
-            DEFAULT_ONTOLOGY_PATH. See from_texts() for details.
+        enforce_ontology: If False (default), no label promotion or ontology_conformant
+            flagging happens. If True, entity_type gets promoted to a real Memgraph
+            label per ontology_path. See from_texts() for details.
+        ontology_path: Path to an ontology YAML config file. Only consulted when
+            enforce_ontology=True; defaults to DEFAULT_ONTOLOGY_PATH.
     Returns:
         One list of Chunks per source, in `sources` order — the same
         grouped-return contract as from_texts(). A source that produced no
@@ -354,6 +369,7 @@ async def from_unstructured(
             only_chunks=only_chunks,
             link_chunks=link_chunks,
             entity_workspace=resolved_entity_workspace,
+            enforce_ontology=enforce_ontology,
             ontology_path=ontology_path,
         )
         grouped_chunks.append(document.chunks)

--- a/unstructured2graph/src/unstructured2graph/loaders.py
+++ b/unstructured2graph/src/unstructured2graph/loaders.py
@@ -21,7 +21,7 @@ from .memgraph import (
     link_nodes_in_order,
     promote_entity_types_to_labels,
 )
-from .ontology import DEFAULT_ONTOLOGY, Ontology
+from .ontology import DEFAULT_ONTOLOGY, load_ontology
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 logger = logging.getLogger(__name__)
@@ -167,7 +167,7 @@ async def _ingest_chunks(
     only_chunks: bool = False,
     link_chunks: bool = False,
     entity_workspace: str | None = None,
-    ontology: Ontology | None = None,
+    ontology_path: str | Path | None = None,
 ) -> list[Chunk]:
     """
     Ingest an already-produced flat list of chunks into Memgraph: upsert Chunk
@@ -192,8 +192,8 @@ async def _ingest_chunks(
         only_chunks: If True, only create chunk nodes without LightRAG processing.
         link_chunks: If True, link chunks in order with NEXT relationship.
         entity_workspace: Node label LightRAG entities were written under.
-        ontology: Governs which entity_type values get promoted to labels. Defaults to
-            DEFAULT_ONTOLOGY.
+        ontology_path: Path to an ontology YAML config file. Governs which entity_type
+            values get promoted to labels. Defaults to DEFAULT_ONTOLOGY_PATH.
     Returns:
         The same chunks that were passed in, for convenience chaining.
     """
@@ -220,7 +220,8 @@ async def _ingest_chunks(
         for chunk in chunks:
             await lightrag_wrapper.ainsert(input=chunk.text, file_paths=[chunk.hash])
         connect_chunks_to_entities(memgraph, "Chunk", entity_workspace)
-        promote_entity_types_to_labels(memgraph, entity_workspace, ontology or DEFAULT_ONTOLOGY)
+        ontology = load_ontology(ontology_path) if ontology_path else DEFAULT_ONTOLOGY
+        promote_entity_types_to_labels(memgraph, entity_workspace, ontology)
 
     return chunks
 
@@ -231,7 +232,7 @@ async def from_texts(
     lightrag_wrapper: MemgraphLightRAGWrapper | None = None,
     only_chunks: bool = False,
     entity_workspace: str | None = None,
-    ontology: Ontology | None = None,
+    ontology_path: str | Path | None = None,
 ) -> list[list[Chunk]]:
     """
     Ingest raw in-memory strings (not files or URLs) into Memgraph.
@@ -249,14 +250,17 @@ async def from_texts(
         entity_workspace: Node label LightRAG entities were written under. If None
             (default), auto-derived from lightrag_wrapper's resolved LightRAG
             workspace, falling back to "base" if that fails.
-        ontology: Governs which entity_type values get promoted to a real Memgraph
-            label (e.g. entity_type="person" -> :Person) in addition to the
-            entity_workspace label every entity already gets. Defaults to
-            DEFAULT_ONTOLOGY, which mirrors LightRAG's own built-in type vocabulary.
-            entity_type values outside the ontology are left unlabeled -- the node
-            and its entity_type property are untouched. To also steer LightRAG's
-            extraction itself toward the same vocabulary, pass
-            ontology.addon_params() into MemgraphLightRAGWrapper.initialize().
+        ontology_path: Path to an ontology YAML config file (see load_ontology()),
+            governing which entity_type values get promoted to a real Memgraph label
+            (e.g. entity_type="person" -> :Person) in addition to the entity_workspace
+            label every entity already gets. Defaults to DEFAULT_ONTOLOGY_PATH, which
+            mirrors LightRAG's own built-in type vocabulary. entity_type values outside
+            the ontology are never rejected -- the node and its entity_type property
+            are kept, stamped ontology_conformant=false instead of getting a label. To
+            also steer LightRAG's extraction itself toward the same vocabulary, load
+            the same path with load_ontology() and pass its addon_params() into
+            MemgraphLightRAGWrapper.initialize() -- using the same path at both call
+            sites is what keeps them in sync.
     Returns:
         One list of Chunks per input text, in input order. A text that
         parse_text() splits into several pieces contributes several Chunks in
@@ -285,7 +289,7 @@ async def from_texts(
         only_chunks=only_chunks,
         link_chunks=False,
         entity_workspace=resolved_entity_workspace,
-        ontology=ontology,
+        ontology_path=ontology_path,
     )
     return grouped_chunks
 
@@ -298,7 +302,7 @@ async def from_unstructured(
     link_chunks: bool = False,
     entity_workspace: str | None = None,
     partition_kwargs: dict[str, Any] | None = None,
-    ontology: Ontology | None = None,
+    ontology_path: str | Path | None = None,
 ) -> list[list[Chunk]]:
     """
     Process unstructured sources and ingest them into Memgraph using LightRAG.
@@ -315,9 +319,10 @@ async def from_unstructured(
         partition_kwargs: Additional keyword arguments to pass to unstructured's
             partition function (e.g., strategy, languages, pdf_infer_table_structure,
             ocr_languages, headers, ssl_verify, etc.)
-        ontology: Governs which entity_type values get promoted to a real Memgraph
-            label, in addition to the entity_workspace label every entity already
-            gets. Defaults to DEFAULT_ONTOLOGY. See from_texts() for details.
+        ontology_path: Path to an ontology YAML config file, governing which entity_type
+            values get promoted to a real Memgraph label, in addition to the
+            entity_workspace label every entity already gets. Defaults to
+            DEFAULT_ONTOLOGY_PATH. See from_texts() for details.
     Returns:
         One list of Chunks per source, in `sources` order — the same
         grouped-return contract as from_texts(). A source that produced no
@@ -349,7 +354,7 @@ async def from_unstructured(
             only_chunks=only_chunks,
             link_chunks=link_chunks,
             entity_workspace=resolved_entity_workspace,
-            ontology=ontology,
+            ontology_path=ontology_path,
         )
         grouped_chunks.append(document.chunks)
 

--- a/unstructured2graph/src/unstructured2graph/loaders.py
+++ b/unstructured2graph/src/unstructured2graph/loaders.py
@@ -19,7 +19,9 @@ from .memgraph import (
     create_nodes_from_list,
     create_unique_constraint,
     link_nodes_in_order,
+    promote_entity_types_to_labels,
 )
+from .ontology import DEFAULT_ONTOLOGY, Ontology
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 logger = logging.getLogger(__name__)
@@ -165,12 +167,14 @@ async def _ingest_chunks(
     only_chunks: bool = False,
     link_chunks: bool = False,
     entity_workspace: str | None = None,
+    ontology: Ontology | None = None,
 ) -> list[Chunk]:
     """
     Ingest an already-produced flat list of chunks into Memgraph: upsert Chunk
     nodes, optionally chain them with NEXT, and (unless only_chunks) run
-    LightRAG entity extraction and connect the resulting entities back to
-    their chunks via MENTIONED_IN.
+    LightRAG entity extraction, connect the resulting entities back to their
+    chunks via MENTIONED_IN, and promote entity_type to a real label for
+    entities that match the ontology.
 
     Internal helper shared by from_unstructured() and from_texts(). Not
     exported: it relies on its caller having already ensured the Chunk.hash
@@ -188,6 +192,8 @@ async def _ingest_chunks(
         only_chunks: If True, only create chunk nodes without LightRAG processing.
         link_chunks: If True, link chunks in order with NEXT relationship.
         entity_workspace: Node label LightRAG entities were written under.
+        ontology: Governs which entity_type values get promoted to labels. Defaults to
+            DEFAULT_ONTOLOGY.
     Returns:
         The same chunks that were passed in, for convenience chaining.
     """
@@ -214,6 +220,7 @@ async def _ingest_chunks(
         for chunk in chunks:
             await lightrag_wrapper.ainsert(input=chunk.text, file_paths=[chunk.hash])
         connect_chunks_to_entities(memgraph, "Chunk", entity_workspace)
+        promote_entity_types_to_labels(memgraph, entity_workspace, ontology or DEFAULT_ONTOLOGY)
 
     return chunks
 
@@ -224,6 +231,7 @@ async def from_texts(
     lightrag_wrapper: MemgraphLightRAGWrapper | None = None,
     only_chunks: bool = False,
     entity_workspace: str | None = None,
+    ontology: Ontology | None = None,
 ) -> list[list[Chunk]]:
     """
     Ingest raw in-memory strings (not files or URLs) into Memgraph.
@@ -241,6 +249,14 @@ async def from_texts(
         entity_workspace: Node label LightRAG entities were written under. If None
             (default), auto-derived from lightrag_wrapper's resolved LightRAG
             workspace, falling back to "base" if that fails.
+        ontology: Governs which entity_type values get promoted to a real Memgraph
+            label (e.g. entity_type="person" -> :Person) in addition to the
+            entity_workspace label every entity already gets. Defaults to
+            DEFAULT_ONTOLOGY, which mirrors LightRAG's own built-in type vocabulary.
+            entity_type values outside the ontology are left unlabeled -- the node
+            and its entity_type property are untouched. To also steer LightRAG's
+            extraction itself toward the same vocabulary, pass
+            ontology.addon_params() into MemgraphLightRAGWrapper.initialize().
     Returns:
         One list of Chunks per input text, in input order. A text that
         parse_text() splits into several pieces contributes several Chunks in
@@ -269,6 +285,7 @@ async def from_texts(
         only_chunks=only_chunks,
         link_chunks=False,
         entity_workspace=resolved_entity_workspace,
+        ontology=ontology,
     )
     return grouped_chunks
 
@@ -281,6 +298,7 @@ async def from_unstructured(
     link_chunks: bool = False,
     entity_workspace: str | None = None,
     partition_kwargs: dict[str, Any] | None = None,
+    ontology: Ontology | None = None,
 ) -> list[list[Chunk]]:
     """
     Process unstructured sources and ingest them into Memgraph using LightRAG.
@@ -297,6 +315,9 @@ async def from_unstructured(
         partition_kwargs: Additional keyword arguments to pass to unstructured's
             partition function (e.g., strategy, languages, pdf_infer_table_structure,
             ocr_languages, headers, ssl_verify, etc.)
+        ontology: Governs which entity_type values get promoted to a real Memgraph
+            label, in addition to the entity_workspace label every entity already
+            gets. Defaults to DEFAULT_ONTOLOGY. See from_texts() for details.
     Returns:
         One list of Chunks per source, in `sources` order — the same
         grouped-return contract as from_texts(). A source that produced no
@@ -328,6 +349,7 @@ async def from_unstructured(
             only_chunks=only_chunks,
             link_chunks=link_chunks,
             entity_workspace=resolved_entity_workspace,
+            ontology=ontology,
         )
         grouped_chunks.append(document.chunks)
 

--- a/unstructured2graph/src/unstructured2graph/memgraph.py
+++ b/unstructured2graph/src/unstructured2graph/memgraph.py
@@ -1,8 +1,12 @@
 import logging
 import time
+from typing import TYPE_CHECKING
 
 from lightrag_memgraph import DEFAULT_EMBEDDING_DIM
 from memgraph_toolbox.api.memgraph import Memgraph
+
+if TYPE_CHECKING:
+    from .ontology import Ontology
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +71,29 @@ def connect_chunks_to_entities(memgraph: Memgraph, chunk_label: str, entity_labe
         MERGE (n)-[:MENTIONED_IN]->(m);
         """
     )
+
+
+def promote_entity_types_to_labels(memgraph: Memgraph, workspace_label: str, ontology: "Ontology") -> None:
+    """
+    Additively promote each entity's `entity_type` property to a real
+    Memgraph label (e.g. entity_type="person" -> :Person), for entity_type
+    values that match the given ontology.
+
+    The workspace label is never touched: LightRAG's own upsert_node()
+    re-MERGEs future updates by matching on it, so removing it would break
+    LightRAG's ability to recognize this node on subsequent re-ingestion.
+    Entities whose entity_type doesn't match any type in the ontology are
+    left as-is -- no label is added, nothing is rejected or deleted.
+    """
+    for label in ontology.allowed_labels():
+        memgraph.query(
+            f"""
+            MATCH (n:{workspace_label})
+            WHERE toLower(n.entity_type) = toLower($label)
+            SET n:{label}
+            """,
+            params={"label": label},
+        )
 
 
 def link_nodes_in_order(

--- a/unstructured2graph/src/unstructured2graph/memgraph.py
+++ b/unstructured2graph/src/unstructured2graph/memgraph.py
@@ -83,9 +83,15 @@ def promote_entity_types_to_labels(memgraph: Memgraph, workspace_label: str, ont
     re-MERGEs future updates by matching on it, so removing it would break
     LightRAG's ability to recognize this node on subsequent re-ingestion.
     Entities whose entity_type doesn't match any type in the ontology are
-    left as-is -- no label is added, nothing is rejected or deleted.
+    never rejected -- the node and its raw entity_type are always kept, and
+    are instead stamped `ontology_conformant: false` so what the ontology
+    doesn't recognize stays visible and queryable rather than silently
+    indistinguishable from an unprocessed node. Re-running this (e.g. after
+    the ontology grows a new type) clears the flag on anything that now
+    conforms.
     """
-    for label in ontology.allowed_labels():
+    labels = ontology.allowed_labels()
+    for label in labels:
         memgraph.query(
             f"""
             MATCH (n:{workspace_label})
@@ -94,6 +100,14 @@ def promote_entity_types_to_labels(memgraph: Memgraph, workspace_label: str, ont
             """,
             params={"label": label},
         )
+
+    if not labels:
+        memgraph.query(f"MATCH (n:{workspace_label}) SET n.ontology_conformant = false")
+        return
+
+    conforms_clause = " OR ".join(f"n:{label}" for label in labels)
+    memgraph.query(f"MATCH (n:{workspace_label}) WHERE NOT ({conforms_clause}) SET n.ontology_conformant = false")
+    memgraph.query(f"MATCH (n:{workspace_label}) WHERE {conforms_clause} REMOVE n.ontology_conformant")
 
 
 def link_nodes_in_order(

--- a/unstructured2graph/src/unstructured2graph/memgraph.py
+++ b/unstructured2graph/src/unstructured2graph/memgraph.py
@@ -95,7 +95,7 @@ def promote_entity_types_to_labels(memgraph: Memgraph, workspace_label: str, ont
         memgraph.query(
             f"""
             MATCH (n:{workspace_label})
-            WHERE toLower(n.entity_type) = toLower($label)
+            WHERE toLower(n.entity_type) = toLower($label) AND NOT n:{label}
             SET n:{label}
             """,
             params={"label": label},

--- a/unstructured2graph/src/unstructured2graph/ontology.py
+++ b/unstructured2graph/src/unstructured2graph/ontology.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -6,6 +7,12 @@ import yaml
 
 SCRIPT_DIR = Path(__file__).parent
 DEFAULT_ONTOLOGY_PATH = SCRIPT_DIR / "default_ontology.yaml"
+
+# A label gets f-string-interpolated directly into Cypher (SET n:{label}) in
+# promote_entity_types_to_labels(), so it's restricted to safe identifier
+# characters -- anything else (backticks, colons, whitespace, quotes) could
+# otherwise break or inject into the generated query.
+_VALID_LABEL_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 @dataclass(frozen=True)
@@ -62,16 +69,28 @@ def load_ontology(path: str | Path) -> Ontology:
     except yaml.YAMLError as e:
         raise ValueError(f"Invalid YAML in ontology file {resolved_path}: {e}") from e
 
-    if not isinstance(raw, dict) or "entity_types" not in raw:
-        raise ValueError(f"Ontology file {resolved_path} must be a YAML mapping with an 'entity_types' key")
+    if not isinstance(raw, dict) or not isinstance(raw.get("entity_types"), list):
+        raise ValueError(f"Ontology file {resolved_path} must be a YAML mapping with an 'entity_types' list")
 
     entity_types = []
     for index, item in enumerate(raw["entity_types"]):
-        if not isinstance(item, dict) or "label" not in item or "description" not in item:
+        if (
+            not isinstance(item, dict)
+            or not isinstance(item.get("label"), str)
+            or not isinstance(item.get("description"), str)
+        ):
             raise ValueError(
-                f"Ontology file {resolved_path}: entity_types[{index}] must be a mapping with 'label' and 'description'"
+                f"Ontology file {resolved_path}: entity_types[{index}] must be a mapping with "
+                "string 'label' and 'description'"
             )
-        entity_types.append(EntityType(label=item["label"], description=item["description"]))
+        label = item["label"]
+        if not _VALID_LABEL_PATTERN.match(label):
+            raise ValueError(
+                f"Ontology file {resolved_path}: entity_types[{index}] label {label!r} must be a valid "
+                "identifier (letters, digits, underscore, not starting with a digit) since it's used "
+                "directly as a Memgraph label"
+            )
+        entity_types.append(EntityType(label=label, description=item["description"]))
 
     return Ontology(entity_types=tuple(entity_types))
 

--- a/unstructured2graph/src/unstructured2graph/ontology.py
+++ b/unstructured2graph/src/unstructured2graph/ontology.py
@@ -1,4 +1,11 @@
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).parent
+DEFAULT_ONTOLOGY_PATH = SCRIPT_DIR / "default_ontology.yaml"
 
 
 @dataclass(frozen=True)
@@ -13,9 +20,9 @@ class Ontology:
     A vocabulary of entity types, used both to steer LightRAG's own
     extraction prompt (via addon_params()) and to gate which entity_type
     values get promoted to real Memgraph labels (via allowed_labels()).
-    Passing the same Ontology to both call sites keeps extraction and
-    label-promotion in sync; nothing enforces that automatically since the
-    two happen in different code (LightRAG init vs. ingestion).
+    Load one from a config file with load_ontology() rather than
+    constructing directly, so every consumer of a given ontology_path sees
+    the same vocabulary.
     """
 
     entity_types: tuple[EntityType, ...]
@@ -31,21 +38,45 @@ class Ontology:
         return tuple(t.label for t in self.entity_types)
 
 
-# Mirrors LightRAG's own built-in entity type vocabulary (lightrag.prompt's
-# default_entity_types_guidance), so label promotion matches what LightRAG
-# already extracts by default even before any caller wires addon_params().
-DEFAULT_ONTOLOGY = Ontology(
-    entity_types=(
-        EntityType("Person", "Human individuals, real or fictional"),
-        EntityType("Creature", "Non-human living beings (animals, mythical beings, etc.)"),
-        EntityType("Organization", "Companies, institutions, government bodies, groups"),
-        EntityType("Location", "Geographic places (cities, countries, buildings, regions)"),
-        EntityType("Event", "Occurrences, incidents, ceremonies, meetings"),
-        EntityType("Concept", "Abstract ideas, theories, principles, beliefs"),
-        EntityType("Method", "Procedures, techniques, algorithms, workflows"),
-        EntityType("Content", "Creative or informational works (books, articles, films, reports)"),
-        EntityType("Data", "Quantitative or structured information (statistics, datasets, measurements)"),
-        EntityType("Artifact", "Physical or digital objects created by humans (tools, software, devices)"),
-        EntityType("NaturalObject", "Natural non-living objects (minerals, celestial bodies, chemical compounds)"),
-    )
-)
+def load_ontology(path: str | Path) -> Ontology:
+    """
+    Load an Ontology from a YAML config file:
+
+        entity_types:
+          - label: Person
+            description: Human individuals, real or fictional
+          - label: Organization
+            description: Companies, institutions, government bodies, groups
+
+    This is the single source of truth an ontology_path is meant to name --
+    call it once per path at each call site (e.g. once when configuring
+    MemgraphLightRAGWrapper's addon_params, once when gating label
+    promotion) rather than passing a pre-built Ontology object between them,
+    so both sides always reflect the same file on disk.
+    """
+    resolved_path = Path(path)
+    try:
+        raw: Any = yaml.safe_load(resolved_path.read_text(encoding="utf-8"))
+    except OSError as e:
+        raise ValueError(f"Could not read ontology file {resolved_path}: {e}") from e
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML in ontology file {resolved_path}: {e}") from e
+
+    if not isinstance(raw, dict) or "entity_types" not in raw:
+        raise ValueError(f"Ontology file {resolved_path} must be a YAML mapping with an 'entity_types' key")
+
+    entity_types = []
+    for index, item in enumerate(raw["entity_types"]):
+        if not isinstance(item, dict) or "label" not in item or "description" not in item:
+            raise ValueError(
+                f"Ontology file {resolved_path}: entity_types[{index}] must be a mapping with 'label' and 'description'"
+            )
+        entity_types.append(EntityType(label=item["label"], description=item["description"]))
+
+    return Ontology(entity_types=tuple(entity_types))
+
+
+# Mirrors LightRAG's own built-in entity type vocabulary, so label promotion
+# matches what LightRAG extracts by default even for callers who pass no
+# ontology_path at all. See default_ontology.yaml for the actual vocabulary.
+DEFAULT_ONTOLOGY = load_ontology(DEFAULT_ONTOLOGY_PATH)

--- a/unstructured2graph/src/unstructured2graph/ontology.py
+++ b/unstructured2graph/src/unstructured2graph/ontology.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EntityType:
+    label: str
+    description: str
+
+
+@dataclass(frozen=True)
+class Ontology:
+    """
+    A vocabulary of entity types, used both to steer LightRAG's own
+    extraction prompt (via addon_params()) and to gate which entity_type
+    values get promoted to real Memgraph labels (via allowed_labels()).
+    Passing the same Ontology to both call sites keeps extraction and
+    label-promotion in sync; nothing enforces that automatically since the
+    two happen in different code (LightRAG init vs. ingestion).
+    """
+
+    entity_types: tuple[EntityType, ...]
+
+    def entity_types_guidance(self) -> str:
+        bullets = "\n".join(f"- {t.label}: {t.description}" for t in self.entity_types)
+        return f"Classify each entity using one of the following types. If no type fits, use `Other`.\n\n{bullets}"
+
+    def addon_params(self) -> dict[str, str]:
+        return {"entity_types_guidance": self.entity_types_guidance()}
+
+    def allowed_labels(self) -> tuple[str, ...]:
+        return tuple(t.label for t in self.entity_types)
+
+
+# Mirrors LightRAG's own built-in entity type vocabulary (lightrag.prompt's
+# default_entity_types_guidance), so label promotion matches what LightRAG
+# already extracts by default even before any caller wires addon_params().
+DEFAULT_ONTOLOGY = Ontology(
+    entity_types=(
+        EntityType("Person", "Human individuals, real or fictional"),
+        EntityType("Creature", "Non-human living beings (animals, mythical beings, etc.)"),
+        EntityType("Organization", "Companies, institutions, government bodies, groups"),
+        EntityType("Location", "Geographic places (cities, countries, buildings, regions)"),
+        EntityType("Event", "Occurrences, incidents, ceremonies, meetings"),
+        EntityType("Concept", "Abstract ideas, theories, principles, beliefs"),
+        EntityType("Method", "Procedures, techniques, algorithms, workflows"),
+        EntityType("Content", "Creative or informational works (books, articles, films, reports)"),
+        EntityType("Data", "Quantitative or structured information (statistics, datasets, measurements)"),
+        EntityType("Artifact", "Physical or digital objects created by humans (tools, software, devices)"),
+        EntityType("NaturalObject", "Natural non-living objects (minerals, celestial bodies, chemical compounds)"),
+    )
+)

--- a/unstructured2graph/tests/test_e2e_lightrag.py
+++ b/unstructured2graph/tests/test_e2e_lightrag.py
@@ -61,3 +61,19 @@ async def test_from_texts_extracts_real_entity_and_links_mentioned_in(memgraph, 
     workspace = lightrag_wrapper.get_lightrag().chunk_entity_relation_graph.workspace
     rows = memgraph.query(f"MATCH (e:{workspace})-[:MENTIONED_IN]->(c:Chunk) RETURN count(*) AS count")
     assert rows[0]["count"] > 0
+
+
+@requires_openai_key
+@pytest.mark.asyncio
+async def test_from_texts_promotes_entity_type_to_label_by_default(memgraph, lightrag_wrapper):
+    """DEFAULT_ONTOLOGY is applied automatically -- no ontology= needed to get
+    real Memgraph labels alongside the LightRAG workspace label."""
+    await from_texts(
+        ["Alice Johnson works at Acme Corp on the graph database engine."],
+        memgraph,
+        lightrag_wrapper,
+    )
+
+    workspace = lightrag_wrapper.get_lightrag().chunk_entity_relation_graph.workspace
+    rows = memgraph.query(f"MATCH (p:Person:{workspace}) RETURN count(*) AS count")
+    assert rows[0]["count"] > 0

--- a/unstructured2graph/tests/test_e2e_lightrag.py
+++ b/unstructured2graph/tests/test_e2e_lightrag.py
@@ -66,8 +66,9 @@ async def test_from_texts_extracts_real_entity_and_links_mentioned_in(memgraph, 
 @requires_openai_key
 @pytest.mark.asyncio
 async def test_from_texts_promotes_entity_type_to_label_by_default(memgraph, lightrag_wrapper):
-    """DEFAULT_ONTOLOGY is applied automatically -- no ontology= needed to get
-    real Memgraph labels alongside the LightRAG workspace label."""
+    """DEFAULT_ONTOLOGY_PATH is applied automatically -- no ontology_path
+    needed to get real Memgraph labels alongside the LightRAG workspace
+    label."""
     await from_texts(
         ["Alice Johnson works at Acme Corp on the graph database engine."],
         memgraph,
@@ -77,3 +78,38 @@ async def test_from_texts_promotes_entity_type_to_label_by_default(memgraph, lig
     workspace = lightrag_wrapper.get_lightrag().chunk_entity_relation_graph.workspace
     rows = memgraph.query(f"MATCH (p:Person:{workspace}) RETURN count(*) AS count")
     assert rows[0]["count"] > 0
+
+
+@requires_openai_key
+@pytest.mark.asyncio
+async def test_from_texts_flags_entities_outside_a_custom_ontology(memgraph, lightrag_wrapper, tmp_path):
+    """A narrow, project-specific ontology (here: only Location) still keeps
+    every extracted entity and its raw entity_type -- entities outside it
+    just don't get a real label, and are flagged ontology_conformant=false
+    instead of being rejected."""
+    ontology_file = tmp_path / "ontology.yaml"
+    ontology_file.write_text(
+        """
+        entity_types:
+          - label: Location
+            description: Geographic places (cities, countries, buildings, regions)
+        """
+    )
+
+    await from_texts(
+        ["Alice Johnson works at Acme Corp on the graph database engine."],
+        memgraph,
+        lightrag_wrapper,
+        ontology_path=str(ontology_file),
+    )
+
+    workspace = lightrag_wrapper.get_lightrag().chunk_entity_relation_graph.workspace
+    rows = memgraph.query(
+        f"MATCH (n:{workspace}) WHERE n.ontology_conformant = false RETURN n.entity_type AS entity_type, "
+        "n.entity_id AS entity_id"
+    )
+    assert len(rows) > 0
+    assert all(row["entity_type"] is not None for row in rows)
+
+    person_rows = memgraph.query(f"MATCH (n:Person:{workspace}) RETURN count(*) AS count")
+    assert person_rows[0]["count"] == 0

--- a/unstructured2graph/tests/test_e2e_lightrag.py
+++ b/unstructured2graph/tests/test_e2e_lightrag.py
@@ -65,14 +65,35 @@ async def test_from_texts_extracts_real_entity_and_links_mentioned_in(memgraph, 
 
 @requires_openai_key
 @pytest.mark.asyncio
-async def test_from_texts_promotes_entity_type_to_label_by_default(memgraph, lightrag_wrapper):
-    """DEFAULT_ONTOLOGY_PATH is applied automatically -- no ontology_path
-    needed to get real Memgraph labels alongside the LightRAG workspace
-    label."""
+async def test_from_texts_does_not_promote_labels_unless_enforced(memgraph, lightrag_wrapper):
+    """enforce_ontology defaults to False -- entities are left exactly as
+    LightRAG wrote them, no real label and no ontology_conformant property
+    at all, even against a real extraction."""
     await from_texts(
         ["Alice Johnson works at Acme Corp on the graph database engine."],
         memgraph,
         lightrag_wrapper,
+    )
+
+    workspace = lightrag_wrapper.get_lightrag().chunk_entity_relation_graph.workspace
+    rows = memgraph.query(f"MATCH (n:{workspace}) RETURN labels(n) AS labels, n.ontology_conformant AS conformant")
+    assert len(rows) > 0
+    for row in rows:
+        assert row["labels"] == [workspace]
+        assert row["conformant"] is None
+
+
+@requires_openai_key
+@pytest.mark.asyncio
+async def test_from_texts_promotes_entity_type_to_label_when_enforced(memgraph, lightrag_wrapper):
+    """With enforce_ontology=True and no ontology_path, DEFAULT_ONTOLOGY_PATH
+    is applied automatically to get real Memgraph labels alongside the
+    LightRAG workspace label."""
+    await from_texts(
+        ["Alice Johnson works at Acme Corp on the graph database engine."],
+        memgraph,
+        lightrag_wrapper,
+        enforce_ontology=True,
     )
 
     workspace = lightrag_wrapper.get_lightrag().chunk_entity_relation_graph.workspace
@@ -100,6 +121,7 @@ async def test_from_texts_flags_entities_outside_a_custom_ontology(memgraph, lig
         ["Alice Johnson works at Acme Corp on the graph database engine."],
         memgraph,
         lightrag_wrapper,
+        enforce_ontology=True,
         ontology_path=str(ontology_file),
     )
 

--- a/unstructured2graph/tests/test_loaders.py
+++ b/unstructured2graph/tests/test_loaders.py
@@ -286,6 +286,48 @@ async def test_from_texts_runs_entity_extraction_and_connects_chunks():
 
 
 @pytest.mark.asyncio
+async def test_from_texts_defaults_to_no_ontology_enforcement():
+    """enforce_ontology defaults to False -- entities are left exactly as
+    LightRAG wrote them, no label promotion queries at all."""
+    memgraph = MagicMock()
+    lightrag_wrapper = _lightrag_wrapper_with_workspace("base")
+
+    with patch("unstructured2graph.loaders.promote_entity_types_to_labels") as mock_promote:
+        await from_texts(["Alice works on the graph engine."], memgraph, lightrag_wrapper)
+
+    mock_promote.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_from_texts_enforce_ontology_true_promotes_labels():
+    memgraph = MagicMock()
+    lightrag_wrapper = _lightrag_wrapper_with_workspace("base")
+
+    with patch("unstructured2graph.loaders.promote_entity_types_to_labels") as mock_promote:
+        await from_texts(["Alice works on the graph engine."], memgraph, lightrag_wrapper, enforce_ontology=True)
+
+    mock_promote.assert_called_once()
+    assert mock_promote.call_args[0][1] == "base"
+
+
+@pytest.mark.asyncio
+async def test_from_texts_ontology_path_without_enforce_ontology_is_ignored(caplog):
+    memgraph = MagicMock()
+    lightrag_wrapper = _lightrag_wrapper_with_workspace("base")
+
+    with patch("unstructured2graph.loaders.promote_entity_types_to_labels") as mock_promote:
+        await from_texts(
+            ["Alice works on the graph engine."],
+            memgraph,
+            lightrag_wrapper,
+            ontology_path="/some/custom/ontology.yaml",
+        )
+
+    mock_promote.assert_not_called()
+    assert "ontology_path was provided but enforce_ontology=False" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_from_texts_preserves_grouping_for_empty_texts():
     """Empty inputs must still get an (empty) group, so callers can zip
     grouped results back against their original source list by index."""

--- a/unstructured2graph/tests/test_memgraph.py
+++ b/unstructured2graph/tests/test_memgraph.py
@@ -111,6 +111,19 @@ def test_promote_entity_types_to_labels_issues_one_query_per_ontology_type():
     assert second_kwargs["params"] == {"label": "Organization"}
 
 
+def test_promote_entity_types_to_labels_skips_already_labeled_nodes():
+    """The per-type SET must guard on NOT already having that label, so
+    re-running promotion over an already-processed workspace doesn't
+    needlessly rewrite every matching node on every call."""
+    memgraph = MagicMock()
+    ontology = Ontology(entity_types=(EntityType("Person", "..."),))
+
+    promote_entity_types_to_labels(memgraph, "base", ontology)
+
+    set_query = memgraph.query.call_args_list[0][0][0]
+    assert "AND NOT n:Person" in set_query
+
+
 def test_promote_entity_types_to_labels_never_removes_workspace_label():
     """Additive only -- must never strip the workspace label LightRAG's own
     upsert_node() relies on to re-MERGE this node on future updates. The

--- a/unstructured2graph/tests/test_memgraph.py
+++ b/unstructured2graph/tests/test_memgraph.py
@@ -98,7 +98,8 @@ def test_promote_entity_types_to_labels_issues_one_query_per_ontology_type():
 
     promote_entity_types_to_labels(memgraph, "base", ontology)
 
-    assert memgraph.query.call_count == 2
+    # 2 per-type SET queries + 2 ontology_conformant marker queries (flag / clear).
+    assert memgraph.query.call_count == 4
     first_query, first_kwargs = memgraph.query.call_args_list[0]
     assert "MATCH (n:base)" in first_query[0]
     assert "toLower(n.entity_type) = toLower($label)" in first_query[0]
@@ -112,20 +113,52 @@ def test_promote_entity_types_to_labels_issues_one_query_per_ontology_type():
 
 def test_promote_entity_types_to_labels_never_removes_workspace_label():
     """Additive only -- must never strip the workspace label LightRAG's own
-    upsert_node() relies on to re-MERGE this node on future updates."""
+    upsert_node() relies on to re-MERGE this node on future updates. The
+    ontology_conformant *property* removal (for entities that now conform)
+    is fine and expected -- this only guards the workspace label itself."""
     memgraph = MagicMock()
     ontology = Ontology(entity_types=(EntityType("Person", "..."),))
 
     promote_entity_types_to_labels(memgraph, "base", ontology)
 
-    query = memgraph.query.call_args[0][0]
-    assert "REMOVE" not in query
-    assert "DELETE" not in query
+    all_queries = [call.args[0] for call in memgraph.query.call_args_list]
+    assert not any("REMOVE n:base" in q or "DELETE" in q for q in all_queries)
 
 
-def test_promote_entity_types_to_labels_with_empty_ontology_issues_no_queries():
+def test_promote_entity_types_to_labels_flags_nonconforming_entities():
+    memgraph = MagicMock()
+    ontology = Ontology(entity_types=(EntityType("Person", "..."), EntityType("Organization", "...")))
+
+    promote_entity_types_to_labels(memgraph, "base", ontology)
+
+    flag_query = memgraph.query.call_args_list[2][0][0]
+    assert "MATCH (n:base)" in flag_query
+    assert "WHERE NOT (n:Person OR n:Organization)" in flag_query
+    assert "SET n.ontology_conformant = false" in flag_query
+
+
+def test_promote_entity_types_to_labels_clears_flag_for_conforming_entities():
+    """Re-running promotion (e.g. after the ontology grows a new type) must
+    clear a stale ontology_conformant=false left over from an earlier pass."""
+    memgraph = MagicMock()
+    ontology = Ontology(entity_types=(EntityType("Person", "..."),))
+
+    promote_entity_types_to_labels(memgraph, "base", ontology)
+
+    clear_query = memgraph.query.call_args_list[-1][0][0]
+    assert "MATCH (n:base)" in clear_query
+    assert "WHERE n:Person" in clear_query
+    assert "REMOVE n.ontology_conformant" in clear_query
+
+
+def test_promote_entity_types_to_labels_with_empty_ontology_flags_everything_nonconformant():
+    """An empty ontology means nothing conforms -- every entity under the
+    workspace label gets flagged, none rejected or deleted."""
     memgraph = MagicMock()
 
     promote_entity_types_to_labels(memgraph, "base", Ontology(entity_types=()))
 
-    memgraph.query.assert_not_called()
+    memgraph.query.assert_called_once()
+    query = memgraph.query.call_args[0][0]
+    assert "MATCH (n:base)" in query
+    assert "SET n.ontology_conformant = false" in query

--- a/unstructured2graph/tests/test_memgraph.py
+++ b/unstructured2graph/tests/test_memgraph.py
@@ -3,7 +3,13 @@
 from unittest.mock import MagicMock
 
 from lightrag_memgraph import DEFAULT_EMBEDDING_DIM
-from unstructured2graph.memgraph import create_nodes_from_list, create_unique_constraint, create_vector_search_index
+from unstructured2graph.memgraph import (
+    create_nodes_from_list,
+    create_unique_constraint,
+    create_vector_search_index,
+    promote_entity_types_to_labels,
+)
+from unstructured2graph.ontology import EntityType, Ontology
 
 
 def test_create_vector_search_index_defaults_match_embedding_dim():
@@ -84,3 +90,42 @@ def test_create_unique_constraint_is_idempotent_on_repeated_calls():
 
     create_unique_constraint(memgraph, "Chunk", "hash")
     create_unique_constraint(memgraph, "Chunk", "hash")  # should log a warning, not raise
+
+
+def test_promote_entity_types_to_labels_issues_one_query_per_ontology_type():
+    memgraph = MagicMock()
+    ontology = Ontology(entity_types=(EntityType("Person", "..."), EntityType("Organization", "...")))
+
+    promote_entity_types_to_labels(memgraph, "base", ontology)
+
+    assert memgraph.query.call_count == 2
+    first_query, first_kwargs = memgraph.query.call_args_list[0]
+    assert "MATCH (n:base)" in first_query[0]
+    assert "toLower(n.entity_type) = toLower($label)" in first_query[0]
+    assert "SET n:Person" in first_query[0]
+    assert first_kwargs["params"] == {"label": "Person"}
+
+    second_query, second_kwargs = memgraph.query.call_args_list[1]
+    assert "SET n:Organization" in second_query[0]
+    assert second_kwargs["params"] == {"label": "Organization"}
+
+
+def test_promote_entity_types_to_labels_never_removes_workspace_label():
+    """Additive only -- must never strip the workspace label LightRAG's own
+    upsert_node() relies on to re-MERGE this node on future updates."""
+    memgraph = MagicMock()
+    ontology = Ontology(entity_types=(EntityType("Person", "..."),))
+
+    promote_entity_types_to_labels(memgraph, "base", ontology)
+
+    query = memgraph.query.call_args[0][0]
+    assert "REMOVE" not in query
+    assert "DELETE" not in query
+
+
+def test_promote_entity_types_to_labels_with_empty_ontology_issues_no_queries():
+    memgraph = MagicMock()
+
+    promote_entity_types_to_labels(memgraph, "base", Ontology(entity_types=()))
+
+    memgraph.query.assert_not_called()

--- a/unstructured2graph/tests/test_ontology.py
+++ b/unstructured2graph/tests/test_ontology.py
@@ -114,6 +114,63 @@ def test_load_ontology_entry_missing_description_raises_value_error(tmp_path):
         load_ontology(ontology_file)
 
 
+def test_load_ontology_null_entity_types_raises_value_error(tmp_path):
+    """entity_types: null must raise a clear ValueError, not a TypeError from
+    iterating over None."""
+    ontology_file = tmp_path / "null_types.yaml"
+    ontology_file.write_text("entity_types:")
+
+    with pytest.raises(ValueError, match="entity_types"):
+        load_ontology(ontology_file)
+
+
+def test_load_ontology_entity_types_as_mapping_raises_value_error(tmp_path):
+    """entity_types as a YAML mapping (not a list) must raise a clear
+    ValueError rather than a confusing downstream error."""
+    ontology_file = tmp_path / "mapping_types.yaml"
+    ontology_file.write_text(
+        """
+        entity_types:
+          label: Person
+          description: Human individuals
+        """
+    )
+
+    with pytest.raises(ValueError, match="entity_types"):
+        load_ontology(ontology_file)
+
+
+def test_load_ontology_rejects_label_with_unsafe_characters(tmp_path):
+    """A label is interpolated directly into Cypher (SET n:{label}) --
+    anything outside safe identifier characters must be rejected up front
+    rather than risk breaking or injecting into the generated query."""
+    ontology_file = tmp_path / "unsafe_label.yaml"
+    ontology_file.write_text(
+        """
+        entity_types:
+          - label: "Person`) DETACH DELETE (m"
+            description: malicious
+        """
+    )
+
+    with pytest.raises(ValueError, match="identifier"):
+        load_ontology(ontology_file)
+
+
+def test_load_ontology_rejects_label_starting_with_digit(tmp_path):
+    ontology_file = tmp_path / "digit_label.yaml"
+    ontology_file.write_text(
+        """
+        entity_types:
+          - label: "1Person"
+            description: Human individuals
+        """
+    )
+
+    with pytest.raises(ValueError, match="identifier"):
+        load_ontology(ontology_file)
+
+
 def test_load_ontology_two_calls_on_same_path_produce_equal_ontologies(tmp_path):
     """Coordination between LightRAG's addon_params and Memgraph's label
     gating relies on independent load_ontology() calls against the same path

--- a/unstructured2graph/tests/test_ontology.py
+++ b/unstructured2graph/tests/test_ontology.py
@@ -1,0 +1,56 @@
+"""Unit tests for unstructured2graph.ontology."""
+
+from unstructured2graph.ontology import DEFAULT_ONTOLOGY, EntityType, Ontology
+
+
+def test_entity_types_guidance_lists_every_type_with_its_description():
+    ontology = Ontology(
+        entity_types=(
+            EntityType("Person", "Human individuals"),
+            EntityType("Location", "Geographic places"),
+        )
+    )
+
+    guidance = ontology.entity_types_guidance()
+
+    assert "- Person: Human individuals" in guidance
+    assert "- Location: Geographic places" in guidance
+    assert "If no type fits, use `Other`" in guidance
+
+
+def test_addon_params_wraps_entity_types_guidance():
+    ontology = Ontology(entity_types=(EntityType("Person", "Human individuals"),))
+
+    params = ontology.addon_params()
+
+    assert params == {"entity_types_guidance": ontology.entity_types_guidance()}
+
+
+def test_allowed_labels_returns_label_names_in_declared_order():
+    ontology = Ontology(
+        entity_types=(
+            EntityType("Person", "..."),
+            EntityType("Organization", "..."),
+        )
+    )
+
+    assert ontology.allowed_labels() == ("Person", "Organization")
+
+
+def test_default_ontology_mirrors_lightrags_builtin_vocabulary():
+    """Kept in sync with lightrag.prompt's default_entity_types_guidance so
+    label promotion matches what LightRAG extracts by default, even for
+    callers who never wire addon_params()."""
+    assert DEFAULT_ONTOLOGY.allowed_labels() == (
+        "Person",
+        "Creature",
+        "Organization",
+        "Location",
+        "Event",
+        "Concept",
+        "Method",
+        "Content",
+        "Data",
+        "Artifact",
+        "NaturalObject",
+    )

--- a/unstructured2graph/tests/test_ontology.py
+++ b/unstructured2graph/tests/test_ontology.py
@@ -1,6 +1,8 @@
 """Unit tests for unstructured2graph.ontology."""
 
-from unstructured2graph.ontology import DEFAULT_ONTOLOGY, EntityType, Ontology
+import pytest
+
+from unstructured2graph.ontology import DEFAULT_ONTOLOGY, DEFAULT_ONTOLOGY_PATH, EntityType, Ontology, load_ontology
 
 
 def test_entity_types_guidance_lists_every_type_with_its_description():
@@ -40,7 +42,7 @@ def test_allowed_labels_returns_label_names_in_declared_order():
 def test_default_ontology_mirrors_lightrags_builtin_vocabulary():
     """Kept in sync with lightrag.prompt's default_entity_types_guidance so
     label promotion matches what LightRAG extracts by default, even for
-    callers who never wire addon_params()."""
+    callers who never pass an ontology_path at all."""
     assert DEFAULT_ONTOLOGY.allowed_labels() == (
         "Person",
         "Creature",
@@ -54,3 +56,75 @@ def test_default_ontology_mirrors_lightrags_builtin_vocabulary():
         "Artifact",
         "NaturalObject",
     )
+
+
+def test_default_ontology_path_points_at_a_real_bundled_file():
+    assert DEFAULT_ONTOLOGY_PATH.is_file()
+
+
+def test_load_ontology_parses_label_and_description(tmp_path):
+    ontology_file = tmp_path / "ontology.yaml"
+    ontology_file.write_text(
+        """
+        entity_types:
+          - label: Person
+            description: Human individuals
+          - label: Location
+            description: Geographic places
+        """
+    )
+
+    ontology = load_ontology(ontology_file)
+
+    assert ontology.allowed_labels() == ("Person", "Location")
+    assert ontology.entity_types[0].description == "Human individuals"
+
+
+def test_load_ontology_missing_file_raises_value_error(tmp_path):
+    with pytest.raises(ValueError, match="Could not read ontology file"):
+        load_ontology(tmp_path / "does_not_exist.yaml")
+
+
+def test_load_ontology_invalid_yaml_raises_value_error(tmp_path):
+    ontology_file = tmp_path / "broken.yaml"
+    ontology_file.write_text("entity_types: [this is not: valid: yaml")
+
+    with pytest.raises(ValueError, match="Invalid YAML"):
+        load_ontology(ontology_file)
+
+
+def test_load_ontology_missing_entity_types_key_raises_value_error(tmp_path):
+    ontology_file = tmp_path / "no_types.yaml"
+    ontology_file.write_text("something_else: []")
+
+    with pytest.raises(ValueError, match="entity_types"):
+        load_ontology(ontology_file)
+
+
+def test_load_ontology_entry_missing_description_raises_value_error(tmp_path):
+    ontology_file = tmp_path / "incomplete.yaml"
+    ontology_file.write_text(
+        """
+        entity_types:
+          - label: Person
+        """
+    )
+
+    with pytest.raises(ValueError, match=r"label.*description"):
+        load_ontology(ontology_file)
+
+
+def test_load_ontology_two_calls_on_same_path_produce_equal_ontologies(tmp_path):
+    """Coordination between LightRAG's addon_params and Memgraph's label
+    gating relies on independent load_ontology() calls against the same path
+    always agreeing -- not on passing one Ontology object between them."""
+    ontology_file = tmp_path / "ontology.yaml"
+    ontology_file.write_text(
+        """
+        entity_types:
+          - label: Person
+            description: Human individuals
+        """
+    )
+
+    assert load_ontology(ontology_file) == load_ontology(ontology_file)


### PR DESCRIPTION
## Summary

LightRAG writes every extracted entity under a single workspace label (e.g. `:base`), with `entity_type` only as a flat property — so the graph never gets idiomatic Labeled-Property-Graph typing (`:Person`, `:Organization`, `:Location`, ...). This adds ontology-gated promotion of `entity_type` to a real Memgraph label, **opt-in** as part of ingestion:

- **`enforce_ontology: bool = False`.** Off by default — entities are left exactly as LightRAG wrote them, no label promotion, no `ontology_conformant` flagging, no behavior change for existing callers. When `True`, promotion runs using `ontology_path` (or a bundled default if omitted).
- **Ontology as a config file, not code.** `load_ontology(path)` parses a YAML file (`entity_types: [{label, description}, ...]`) into an `Ontology`. Both LightRAG's extraction-steering (`ontology.addon_params()`, wired into `MemgraphLightRAGWrapper.initialize()`) and Memgraph's label-gating load the same file independently, so they stay coordinated by "same file path" rather than by passing a shared in-memory object between two different call sites.
- **`promote_entity_types_to_labels()`**: additive only — `SET n:{Label}` for entities whose `entity_type` matches the ontology (skipping nodes that already carry the label), never touching the workspace label LightRAG's own `upsert_node()` relies on to re-`MERGE` future updates.
- **Ontology is a lens, not a filter.** Entities outside the ontology are never rejected — the node and raw `entity_type` are always kept, stamped `ontology_conformant: false` instead of being silently indistinguishable from an unprocessed node. Re-running promotion (e.g. after the ontology grows a new type) clears the flag on anything that now conforms.
- **Enforcement is entirely application-level.** Verified live against Memgraph 3.9: there's no value-membership constraint (`ASSERT n.prop IN [...]` isn't valid Cypher), and `CREATE ENUM` — while real and genuinely rejecting at write time — only engages for writes using an explicit `EnumName::Value` cast, which LightRAG never does, plus it's additive-only in this Memgraph version (`REMOVE VALUE`/`DROP ENUM` unimplemented).
- Deliberately out of scope for this iteration (see local ADRs 0002-0004 and `CONTEXT.md`): entity resolution (LightRAG's own merge is exact-name-match and destructively collapses conflicting `entity_type` values), a stable-core/volatile-extension ontology hierarchy, and standalone re-scan/retraction tooling for renamed or merged types.

**Also fixes two real bugs found while building this:**
- `MemgraphLightRAGWrapper.afinalize()` never reset LightRAG's process-global shared-storage locks, so a second real `LightRAG` instance in the same process reused locks bound to a closed event loop (`RuntimeError: ... bound to a different event loop`). Fixed by calling `finalize_share_data()` in a `finally` block, so it resets even if `finalize_storages()` itself raises (per GitHub Copilot's review).
- `load_ontology()` didn't validate that a `label` is a safe Cypher identifier before f-string-interpolating it into `SET n:{label}` — a malformed or malicious label could break or inject into the generated query. Now validated up front with a clear `ValueError` (per GitHub Copilot's review, along with a fix for `entity_types: null`/non-list values raising a confusing `TypeError` instead of a clear error).

Version bumps: `unstructured2graph` 0.4.0 → 0.5.0, `lightrag-memgraph` 0.3.0 → 0.3.1, `sessions-graph` 0.2.0 → 0.3.0 (floor bumped to `unstructured2graph>=0.5.0` — note sessions-graph's own reconciliation call doesn't pass `enforce_ontology=True` yet, so it won't get label promotion until that's wired up separately).

## Test plan
- [x] `unstructured2graph` unit tests — ontology YAML loading/validation (including the new label-safety and shape checks), label promotion (including the already-labeled skip guard), `ontology_conformant` flagging/clearing, `enforce_ontology` default-off/opt-in behavior.
- [x] `unstructured2graph` e2e tests against live Memgraph + real OpenAI calls — no promotion by default, default-ontology promotion when enforced, and a narrow custom-ontology file correctly flagging out-of-vocabulary entities.
- [x] `lightrag-memgraph` unit tests — `afinalize()` resets shared state both on success and when `finalize_storages()` raises.
- [x] Verified the bundled `default_ontology.yaml` ships inside the built wheel.
- [x] Full local suite (`scripts/dev-memgraph.sh test`) across all five packages — 49 passed.

Not yet merged — still open for further review/polish.