### PR TITLE
unstructured2graph: decouple label promotion from ontology enforcement

### DIFF
--- a/context-graph/sessions-graph/pyproject.toml
+++ b/context-graph/sessions-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sessions-graph"
-version = "0.3.0"
+version = "0.4.0"
 description = "Cross-session memory store for agents, backed by Memgraph"
 readme = "README.md"
 license = { text = "MIT" }
@@ -21,7 +21,7 @@ agent-context-graph = [
 ]
 reconciliation = [
     "actions-graph>=0.1.1",
-    "unstructured2graph>=0.5.0",
+    "unstructured2graph>=0.6.0",
 ]
 test = [
     "pytest>=9.0.3",

--- a/context-graph/sessions-graph/src/sessions_graph/cli.py
+++ b/context-graph/sessions-graph/src/sessions_graph/cli.py
@@ -94,7 +94,9 @@ async def _run_reconcile(parsed: argparse.Namespace) -> int:
     try:
         exit_code = 0
         for session_id in session_ids:
-            summary = await graph.reconcile_session(session_id, lightrag_wrapper=lightrag_wrapper)
+            summary = await graph.reconcile_session(
+                session_id, lightrag_wrapper=lightrag_wrapper, enforce_ontology=True
+            )
             if summary.status == "completed":
                 print(f"OK {session_id}: {summary.texts_deduped}/{summary.texts_considered} unique texts reconciled")
             else:

--- a/context-graph/sessions-graph/src/sessions_graph/core.py
+++ b/context-graph/sessions-graph/src/sessions_graph/core.py
@@ -30,6 +30,8 @@ from .reconciliation import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from actions_graph import ActionsGraph
 
 _FULLTEXT_INDEX = "memory_content_index"
@@ -271,6 +273,9 @@ class SessionsGraph:
         lightrag_wrapper: Any,
         actions_graph: ActionsGraph | None = None,
         entity_workspace: str | None = None,
+        promote_labels: bool = False,
+        enforce_ontology: bool = False,
+        ontology_path: str | Path | None = None,
     ) -> ReconciliationSummary:
         """Batch-extract entities from a session's Action + Memory content.
 
@@ -298,6 +303,19 @@ class SessionsGraph:
                 Defaults to whatever the LightRAG wrapper resolves to, so
                 session-derived entities land in the same workspace as
                 document-ingested ones and can merge.
+            promote_labels: Passed through to ``unstructured2graph.from_texts``.
+                Promotes every entity_type to a real Memgraph label with no fixed
+                vocabulary and no ontology_conformant flagging. Ignored if
+                enforce_ontology is also True. Both default to False, matching
+                unstructured2graph's own default: no label promotion unless
+                explicitly requested.
+            enforce_ontology: Passed through to ``unstructured2graph.from_texts``.
+                Restricts entity_type promotion to ontology_path's vocabulary (or
+                unstructured2graph's bundled default), flagging anything outside it
+                ontology_conformant=false instead of promoting a label. Takes
+                precedence over promote_labels.
+            ontology_path: Passed through to ``unstructured2graph.from_texts``. Only
+                consulted when enforce_ontology=True.
 
         Returns:
             An :class:`ReconciliationSummary` describing what happened. Never
@@ -334,6 +352,9 @@ class SessionsGraph:
                     memgraph=self._db,
                     lightrag_wrapper=lightrag_wrapper,
                     entity_workspace=entity_workspace,
+                    promote_labels=promote_labels,
+                    enforce_ontology=enforce_ontology,
+                    ontology_path=ontology_path,
                 )
                 chunks_by_text_hash = dict(zip(unique_texts.keys(), grouped_chunks, strict=True))
                 self._link_chunks_to_sources(sources, chunks_by_text_hash)

--- a/context-graph/sessions-graph/tests/test_cli.py
+++ b/context-graph/sessions-graph/tests/test_cli.py
@@ -53,6 +53,7 @@ def test_reconcile_single_session_success(capsys):
     assert exit_code == 0
     fake_graph.reconcile_session.assert_awaited_once()
     assert fake_graph.reconcile_session.call_args.args[0] == "s-1"
+    assert fake_graph.reconcile_session.call_args.kwargs["enforce_ontology"] is True
     assert "OK s-1" in capsys.readouterr().out
 
 

--- a/context-graph/sessions-graph/tests/test_reconciliation.py
+++ b/context-graph/sessions-graph/tests/test_reconciliation.py
@@ -147,6 +147,32 @@ async def test_reconcile_session_success_marks_completed_and_links_chunks():
 
 
 @pytest.mark.asyncio
+async def test_reconcile_session_passes_promotion_and_ontology_kwargs_through_to_from_texts():
+    db = _stub_db()
+    g = _graph(db)
+    actions = [Message(session_id="s-1", role=MessageRole.ASSISTANT, content="Alice works on the graph engine.")]
+    actions_graph = _fake_actions_graph(actions)
+    lightrag_wrapper = MagicMock()
+
+    fake_chunk = Chunk(text="Alice works on the graph engine.", hash=content_hash("Alice works on the graph engine."))
+    with patch("unstructured2graph.from_texts", new=AsyncMock(return_value=[[fake_chunk]])) as mock_from_texts:
+        await g.reconcile_session(
+            "s-1",
+            lightrag_wrapper=lightrag_wrapper,
+            actions_graph=actions_graph,
+            promote_labels=True,
+            enforce_ontology=True,
+            ontology_path="/some/ontology.yaml",
+        )
+
+    mock_from_texts.assert_awaited_once()
+    call_kwargs = mock_from_texts.call_args.kwargs
+    assert call_kwargs["promote_labels"] is True
+    assert call_kwargs["enforce_ontology"] is True
+    assert call_kwargs["ontology_path"] == "/some/ontology.yaml"
+
+
+@pytest.mark.asyncio
 async def test_reconcile_session_dedupes_identical_text_before_calling_lightrag():
     db = _stub_db()
     g = _graph(db)

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unstructured2graph"
-version = "0.5.0"
+version = "0.6.0"
 description = "Convert unstructured documents into knowledge graphs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -26,6 +26,12 @@ dependencies = [
     "lightrag-memgraph>=0.3.0",
     "memgraph-toolbox>=0.1.11",
     "pyyaml>=6.0",
+    # unstructured depends on nltk with no version bound. Capped below 3.10:
+    # 3.10.1 (2026-08-01) added a CWD-import security check (nltk/inisec.py)
+    # that raises ImportError during pytest collection in CI (uv pip install
+    # -e resolves nltk live, ignoring the lockfile). Bump once that's no
+    # longer a false positive under pytest's test-collection working dir.
+    "nltk<3.10",
 ]
 [project.optional-dependencies]
 all-docs = [

--- a/unstructured2graph/pyproject.toml
+++ b/unstructured2graph/pyproject.toml
@@ -26,11 +26,6 @@ dependencies = [
     "lightrag-memgraph>=0.3.0",
     "memgraph-toolbox>=0.1.11",
     "pyyaml>=6.0",
-    # unstructured depends on nltk with no version bound. Capped below 3.10:
-    # 3.10.1 (2026-08-01) added a CWD-import security check (nltk/inisec.py)
-    # that raises ImportError during pytest collection in CI (uv pip install
-    # -e resolves nltk live, ignoring the lockfile). Bump once that's no
-    # longer a false positive under pytest's test-collection working dir.
     "nltk<3.10",
 ]
 [project.optional-dependencies]

--- a/unstructured2graph/src/unstructured2graph/__init__.py
+++ b/unstructured2graph/src/unstructured2graph/__init__.py
@@ -23,11 +23,12 @@ from .memgraph import (
     create_unique_constraint,
     create_vector_search_index,
     link_nodes_in_order,
+    promote_all_entity_types_to_labels,
     promote_entity_types_to_labels,
 )
 from .ontology import DEFAULT_ONTOLOGY, DEFAULT_ONTOLOGY_PATH, EntityType, Ontology, load_ontology
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __all__ = [
     "DEFAULT_ONTOLOGY",
     "DEFAULT_ONTOLOGY_PATH",
@@ -49,5 +50,6 @@ __all__ = [
     "make_chunks",
     "parse_source",
     "parse_text",
+    "promote_all_entity_types_to_labels",
     "promote_entity_types_to_labels",
 ]

--- a/unstructured2graph/src/unstructured2graph/loaders.py
+++ b/unstructured2graph/src/unstructured2graph/loaders.py
@@ -19,6 +19,7 @@ from .memgraph import (
     create_nodes_from_list,
     create_unique_constraint,
     link_nodes_in_order,
+    promote_all_entity_types_to_labels,
     promote_entity_types_to_labels,
 )
 from .ontology import DEFAULT_ONTOLOGY, load_ontology
@@ -167,6 +168,7 @@ async def _ingest_chunks(
     only_chunks: bool = False,
     link_chunks: bool = False,
     entity_workspace: str | None = None,
+    promote_labels: bool = False,
     enforce_ontology: bool = False,
     ontology_path: str | Path | None = None,
 ) -> list[Chunk]:
@@ -174,8 +176,8 @@ async def _ingest_chunks(
     Ingest an already-produced flat list of chunks into Memgraph: upsert Chunk
     nodes, optionally chain them with NEXT, and (unless only_chunks) run
     LightRAG entity extraction, connect the resulting entities back to their
-    chunks via MENTIONED_IN, and (if enforce_ontology) promote entity_type to
-    a real label for entities that match the ontology.
+    chunks via MENTIONED_IN, and promote entity_type to a real label per
+    promote_labels/enforce_ontology.
 
     Internal helper shared by from_unstructured() and from_texts(). Not
     exported: it relies on its caller having already ensured the Chunk.hash
@@ -193,9 +195,15 @@ async def _ingest_chunks(
         only_chunks: If True, only create chunk nodes without LightRAG processing.
         link_chunks: If True, link chunks in order with NEXT relationship.
         entity_workspace: Node label LightRAG entities were written under.
-        enforce_ontology: If True, promote entity_type to labels per ontology_path (or
-            DEFAULT_ONTOLOGY_PATH). If False (default), entities are left exactly as
-            LightRAG wrote them -- no label promotion, no ontology_conformant flagging.
+        promote_labels: If True, promote every entity_type to a real Memgraph label,
+            with no fixed vocabulary -- no ontology_conformant flagging, since there's
+            no ontology to be non-conformant relative to. Ignored if enforce_ontology
+            is also True (enforce_ontology is the stricter, ontology-gated mode).
+        enforce_ontology: If True, promote entity_type to labels restricted to
+            ontology_path's vocabulary (or DEFAULT_ONTOLOGY_PATH), and flag anything
+            outside it as ontology_conformant=false. Takes precedence over
+            promote_labels. If both are False (default), entities are left exactly as
+            LightRAG wrote them -- no label promotion at all.
         ontology_path: Path to an ontology YAML config file. Only consulted when
             enforce_ontology=True; defaults to DEFAULT_ONTOLOGY_PATH.
     Returns:
@@ -230,6 +238,8 @@ async def _ingest_chunks(
         if enforce_ontology:
             ontology = load_ontology(ontology_path) if ontology_path else DEFAULT_ONTOLOGY
             promote_entity_types_to_labels(memgraph, entity_workspace, ontology)
+        elif promote_labels:
+            promote_all_entity_types_to_labels(memgraph, entity_workspace)
 
     return chunks
 
@@ -240,6 +250,7 @@ async def from_texts(
     lightrag_wrapper: MemgraphLightRAGWrapper | None = None,
     only_chunks: bool = False,
     entity_workspace: str | None = None,
+    promote_labels: bool = False,
     enforce_ontology: bool = False,
     ontology_path: str | Path | None = None,
 ) -> list[list[Chunk]]:
@@ -259,11 +270,18 @@ async def from_texts(
         entity_workspace: Node label LightRAG entities were written under. If None
             (default), auto-derived from lightrag_wrapper's resolved LightRAG
             workspace, falling back to "base" if that fails.
-        enforce_ontology: If False (default), entities are left exactly as LightRAG
-            wrote them -- no label promotion, no ontology_conformant flagging. If True,
-            entity_type gets promoted to a real Memgraph label (e.g. entity_type="person"
-            -> :Person) in addition to the entity_workspace label every entity already
-            gets, per ontology_path.
+        promote_labels: Label promotion and ontology enforcement are separate concerns.
+            If True, every entity_type gets promoted to a real Memgraph label (e.g.
+            entity_type="person" -> :Person), with no fixed vocabulary restricting
+            which ones -- and no ontology_conformant flagging, since there's no
+            ontology to be non-conformant relative to. Ignored if enforce_ontology is
+            also True.
+        enforce_ontology: If True, entity_type promotion is restricted to
+            ontology_path's vocabulary (or DEFAULT_ONTOLOGY_PATH if omitted), and
+            anything outside it is flagged ontology_conformant=false instead of
+            getting a label -- this is the stricter, gated mode, and takes precedence
+            over promote_labels. If both promote_labels and enforce_ontology are False
+            (the default for both), no label promotion happens at all.
         ontology_path: Path to an ontology YAML config file (see load_ontology()). Only
             consulted when enforce_ontology=True; defaults to DEFAULT_ONTOLOGY_PATH,
             which mirrors LightRAG's own built-in type vocabulary. entity_type values
@@ -301,6 +319,7 @@ async def from_texts(
         only_chunks=only_chunks,
         link_chunks=False,
         entity_workspace=resolved_entity_workspace,
+        promote_labels=promote_labels,
         enforce_ontology=enforce_ontology,
         ontology_path=ontology_path,
     )
@@ -315,6 +334,7 @@ async def from_unstructured(
     link_chunks: bool = False,
     entity_workspace: str | None = None,
     partition_kwargs: dict[str, Any] | None = None,
+    promote_labels: bool = False,
     enforce_ontology: bool = False,
     ontology_path: str | Path | None = None,
 ) -> list[list[Chunk]]:
@@ -333,9 +353,13 @@ async def from_unstructured(
         partition_kwargs: Additional keyword arguments to pass to unstructured's
             partition function (e.g., strategy, languages, pdf_infer_table_structure,
             ocr_languages, headers, ssl_verify, etc.)
-        enforce_ontology: If False (default), no label promotion or ontology_conformant
-            flagging happens. If True, entity_type gets promoted to a real Memgraph
-            label per ontology_path. See from_texts() for details.
+        promote_labels: If True, promote every entity_type to a real Memgraph label
+            with no fixed vocabulary and no ontology_conformant flagging. Ignored if
+            enforce_ontology is also True. See from_texts() for details.
+        enforce_ontology: If True, restrict entity_type promotion to ontology_path's
+            vocabulary and flag anything outside it ontology_conformant=false; takes
+            precedence over promote_labels. If both are False (default), no label
+            promotion happens at all. See from_texts() for details.
         ontology_path: Path to an ontology YAML config file. Only consulted when
             enforce_ontology=True; defaults to DEFAULT_ONTOLOGY_PATH.
     Returns:
@@ -369,6 +393,7 @@ async def from_unstructured(
             only_chunks=only_chunks,
             link_chunks=link_chunks,
             entity_workspace=resolved_entity_workspace,
+            promote_labels=promote_labels,
             enforce_ontology=enforce_ontology,
             ontology_path=ontology_path,
         )

--- a/unstructured2graph/src/unstructured2graph/memgraph.py
+++ b/unstructured2graph/src/unstructured2graph/memgraph.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,26 @@ if TYPE_CHECKING:
     from .ontology import Ontology
 
 logger = logging.getLogger(__name__)
+
+# A derived label gets f-string-interpolated directly into Cypher
+# (SET n:{label}), so it's restricted to safe identifier characters.
+_VALID_LABEL_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_LABEL_WORD_SPLIT_PATTERN = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _entity_type_to_label(entity_type: str) -> str | None:
+    """
+    Convert a raw entity_type value (e.g. "natural object") into a
+    PascalCase Memgraph label ("NaturalObject"). Returns None if nothing
+    safe can be derived -- e.g. empty after stripping non-alphanumeric
+    characters, or the result would start with a digit -- so callers can
+    skip promoting that entity_type rather than risk an invalid label.
+    """
+    words = [w for w in _LABEL_WORD_SPLIT_PATTERN.split(entity_type.strip()) if w]
+    if not words:
+        return None
+    label = "".join(word[:1].upper() + word[1:].lower() for word in words)
+    return label if _VALID_LABEL_PATTERN.match(label) else None
 
 
 def create_nodes_from_list(
@@ -108,6 +129,38 @@ def promote_entity_types_to_labels(memgraph: Memgraph, workspace_label: str, ont
     conforms_clause = " OR ".join(f"n:{label}" for label in labels)
     memgraph.query(f"MATCH (n:{workspace_label}) WHERE NOT ({conforms_clause}) SET n.ontology_conformant = false")
     memgraph.query(f"MATCH (n:{workspace_label}) WHERE {conforms_clause} REMOVE n.ontology_conformant")
+
+
+def promote_all_entity_types_to_labels(memgraph: Memgraph, workspace_label: str) -> None:
+    """
+    Promote every entity's entity_type to a real Memgraph label, with no
+    fixed vocabulary to restrict against -- unlike
+    promote_entity_types_to_labels(), there's no ontology_conformant
+    flagging here, since without an ontology there's nothing to be
+    non-conformant relative to; an entity_type is either promoted or
+    skipped, never flagged.
+
+    entity_type values that don't sanitize into a safe label (see
+    _entity_type_to_label) are skipped and logged; the node, its workspace
+    label, and its raw entity_type are always left as-is either way.
+    """
+    rows = memgraph.query(
+        f"MATCH (n:{workspace_label}) WHERE n.entity_type IS NOT NULL RETURN DISTINCT n.entity_type AS entity_type"
+    )
+    for row in rows:
+        entity_type = row["entity_type"]
+        label = _entity_type_to_label(entity_type)
+        if label is None:
+            logger.warning(f"Skipping entity_type {entity_type!r}: could not derive a safe Memgraph label from it")
+            continue
+        memgraph.query(
+            f"""
+            MATCH (n:{workspace_label})
+            WHERE toLower(n.entity_type) = toLower($entity_type) AND NOT n:{label}
+            SET n:{label}
+            """,
+            params={"entity_type": entity_type},
+        )
 
 
 def link_nodes_in_order(

--- a/unstructured2graph/tests/test_e2e_lightrag.py
+++ b/unstructured2graph/tests/test_e2e_lightrag.py
@@ -85,6 +85,28 @@ async def test_from_texts_does_not_promote_labels_unless_enforced(memgraph, ligh
 
 @requires_openai_key
 @pytest.mark.asyncio
+async def test_from_texts_promote_labels_true_promotes_without_ontology_gate(memgraph, lightrag_wrapper):
+    """promote_labels=True promotes entity_type to a real label with no
+    fixed vocabulary -- unlike enforce_ontology=True, nothing gets flagged
+    ontology_conformant, since there's no ontology to be non-conformant
+    relative to."""
+    await from_texts(
+        ["Alice Johnson works at Acme Corp on the graph database engine."],
+        memgraph,
+        lightrag_wrapper,
+        promote_labels=True,
+    )
+
+    workspace = lightrag_wrapper.get_lightrag().chunk_entity_relation_graph.workspace
+    person_rows = memgraph.query(f"MATCH (p:Person:{workspace}) RETURN count(*) AS count")
+    assert person_rows[0]["count"] > 0
+
+    rows = memgraph.query(f"MATCH (n:{workspace}) RETURN n.ontology_conformant AS conformant")
+    assert all(row["conformant"] is None for row in rows)
+
+
+@requires_openai_key
+@pytest.mark.asyncio
 async def test_from_texts_promotes_entity_type_to_label_when_enforced(memgraph, lightrag_wrapper):
     """With enforce_ontology=True and no ontology_path, DEFAULT_ONTOLOGY_PATH
     is applied automatically to get real Memgraph labels alongside the

--- a/unstructured2graph/tests/test_loaders.py
+++ b/unstructured2graph/tests/test_loaders.py
@@ -328,6 +328,46 @@ async def test_from_texts_ontology_path_without_enforce_ontology_is_ignored(capl
 
 
 @pytest.mark.asyncio
+async def test_from_texts_promote_labels_true_promotes_without_ontology_gate():
+    """promote_labels is a separate, weaker concern from enforce_ontology --
+    it must call the unrestricted promotion path, not the ontology-gated one."""
+    memgraph = MagicMock()
+    lightrag_wrapper = _lightrag_wrapper_with_workspace("base")
+
+    with (
+        patch("unstructured2graph.loaders.promote_all_entity_types_to_labels") as mock_promote_all,
+        patch("unstructured2graph.loaders.promote_entity_types_to_labels") as mock_promote_gated,
+    ):
+        await from_texts(["Alice works on the graph engine."], memgraph, lightrag_wrapper, promote_labels=True)
+
+    mock_promote_all.assert_called_once_with(memgraph, "base")
+    mock_promote_gated.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_from_texts_enforce_ontology_takes_precedence_over_promote_labels():
+    """When both are set, enforce_ontology (the stricter, gated mode) wins --
+    promote_labels doesn't also run the unrestricted path on top."""
+    memgraph = MagicMock()
+    lightrag_wrapper = _lightrag_wrapper_with_workspace("base")
+
+    with (
+        patch("unstructured2graph.loaders.promote_all_entity_types_to_labels") as mock_promote_all,
+        patch("unstructured2graph.loaders.promote_entity_types_to_labels") as mock_promote_gated,
+    ):
+        await from_texts(
+            ["Alice works on the graph engine."],
+            memgraph,
+            lightrag_wrapper,
+            promote_labels=True,
+            enforce_ontology=True,
+        )
+
+    mock_promote_gated.assert_called_once()
+    mock_promote_all.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_from_texts_preserves_grouping_for_empty_texts():
     """Empty inputs must still get an (empty) group, so callers can zip
     grouped results back against their original source list by index."""

--- a/unstructured2graph/tests/test_memgraph.py
+++ b/unstructured2graph/tests/test_memgraph.py
@@ -4,9 +4,11 @@ from unittest.mock import MagicMock
 
 from lightrag_memgraph import DEFAULT_EMBEDDING_DIM
 from unstructured2graph.memgraph import (
+    _entity_type_to_label,
     create_nodes_from_list,
     create_unique_constraint,
     create_vector_search_index,
+    promote_all_entity_types_to_labels,
     promote_entity_types_to_labels,
 )
 from unstructured2graph.ontology import EntityType, Ontology
@@ -175,3 +177,63 @@ def test_promote_entity_types_to_labels_with_empty_ontology_flags_everything_non
     query = memgraph.query.call_args[0][0]
     assert "MATCH (n:base)" in query
     assert "SET n.ontology_conformant = false" in query
+
+
+def test_entity_type_to_label_converts_multi_word_snake_and_space_forms():
+    assert _entity_type_to_label("person") == "Person"
+    assert _entity_type_to_label("natural object") == "NaturalObject"
+    assert _entity_type_to_label("natural_object") == "NaturalObject"
+    assert _entity_type_to_label("  Organization  ") == "Organization"
+
+
+def test_entity_type_to_label_returns_none_for_unsalvageable_values():
+    assert _entity_type_to_label("") is None
+    assert _entity_type_to_label("   ") is None
+    assert _entity_type_to_label("---") is None
+
+
+def test_entity_type_to_label_returns_none_when_result_starts_with_digit():
+    assert _entity_type_to_label("3d model") is None
+
+
+def test_promote_all_entity_types_to_labels_discovers_distinct_values_and_promotes_each():
+    memgraph = MagicMock()
+    memgraph.query.return_value = [{"entity_type": "person"}, {"entity_type": "natural object"}]
+
+    promote_all_entity_types_to_labels(memgraph, "base")
+
+    discover_query = memgraph.query.call_args_list[0][0][0]
+    assert "MATCH (n:base)" in discover_query
+    assert "RETURN DISTINCT n.entity_type" in discover_query
+
+    assert memgraph.query.call_count == 3  # 1 discovery + 2 promotions
+    person_query, person_kwargs = memgraph.query.call_args_list[1]
+    assert "SET n:Person" in person_query[0]
+    assert "AND NOT n:Person" in person_query[0]
+    assert person_kwargs["params"] == {"entity_type": "person"}
+
+    object_query, object_kwargs = memgraph.query.call_args_list[2]
+    assert "SET n:NaturalObject" in object_query[0]
+    assert object_kwargs["params"] == {"entity_type": "natural object"}
+
+
+def test_promote_all_entity_types_to_labels_skips_unsanitizable_values():
+    memgraph = MagicMock()
+    memgraph.query.return_value = [{"entity_type": "person"}, {"entity_type": "---"}]
+
+    promote_all_entity_types_to_labels(memgraph, "base")
+
+    # 1 discovery query + only 1 promotion (for "person"); "---" is skipped entirely.
+    assert memgraph.query.call_count == 2
+
+
+def test_promote_all_entity_types_to_labels_never_flags_ontology_conformant():
+    """Without a fixed vocabulary there's nothing to be non-conformant
+    relative to -- this path must never touch ontology_conformant."""
+    memgraph = MagicMock()
+    memgraph.query.return_value = [{"entity_type": "person"}]
+
+    promote_all_entity_types_to_labels(memgraph, "base")
+
+    all_queries = [call.args[0] for call in memgraph.query.call_args_list]
+    assert not any("ontology_conformant" in q for q in all_queries)

--- a/uv.lock
+++ b/uv.lock
@@ -4544,7 +4544,8 @@ dependencies = [
     { name = "click" },
     { name = "joblib" },
     { name = "regex" },
-    { name = "tqdm", version = "4.67.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "tqdm", version = "4.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tqdm", version = "4.67.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
 wheels = [
@@ -8340,7 +8341,7 @@ wheels = [
 
 [[package]]
 name = "sessions-graph"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "context-graph/sessions-graph" }
 dependencies = [
     { name = "memgraph-toolbox" },
@@ -9826,11 +9827,12 @@ wheels = [
 
 [[package]]
 name = "unstructured2graph"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "unstructured2graph" }
 dependencies = [
     { name = "lightrag-memgraph" },
     { name = "memgraph-toolbox" },
+    { name = "nltk" },
     { name = "pyyaml" },
     { name = "unstructured", version = "0.18.32", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "unstructured", version = "0.22.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -9850,6 +9852,7 @@ test = [
 requires-dist = [
     { name = "lightrag-memgraph", editable = "integrations/lightrag-memgraph" },
     { name = "memgraph-toolbox", editable = "memgraph-toolbox" },
+    { name = "nltk", specifier = "<3.10" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary

Closes #249.

`enforce_ontology` (introduced in #248) previously conflated two different concerns under one flag: promoting `entity_type` to a real Memgraph label, and restricting/validating that promotion against a fixed vocabulary. This splits them into two independent parameters on `from_texts()`/`from_unstructured()`:

- **`promote_labels: bool = False`** — promote every `entity_type` to a real Memgraph label, sanitized into a safe Cypher identifier (e.g. `"natural object"` → `:NaturalObject`), with no fixed vocabulary and no `ontology_conformant` flagging (there's nothing to be non-conformant relative to).
- **`enforce_ontology: bool = False`** — restrict promotion to `ontology_path`'s vocabulary (or the bundled default), flagging anything outside it `ontology_conformant: false`. Takes precedence over `promote_labels` when both are set — it's the stricter, ontology-gated mode.

New `promote_all_entity_types_to_labels()` in `memgraph.py` implements the unrestricted path: since there's no fixed vocabulary to iterate over, it discovers distinct `entity_type` values actually present under the workspace label, then sanitizes each into a PascalCase label via `_entity_type_to_label()` — skipping (and logging) any value that can't be turned into a safe identifier.

**sessions-graph wiring**: `reconcile_session()` now accepts and forwards `promote_labels`/`enforce_ontology`/`ontology_path`. Its CLI (the actual production entry point) now passes `enforce_ontology=True` — previously it called `from_texts()` with neither, so reconciled session content got zero label promotion despite #248 landing.

**Also opened #250**: while verifying this, found that `unstructured2graph`'s and `sessions-graph`'s real-LLM e2e suites currently fail against live Memgraph for an unrelated, pre-existing reason — `MemgraphDocStatusStorage` is missing 4 abstract methods that `lightrag-hku==1.5.5` (already pinned on `main`) requires. Confirmed this reproduces identically on a clean `main` checkout before touching any code here, so it's not something this PR introduced or something in scope to fix here.

## Test plan
- [x] `unstructured2graph` unit tests — `_entity_type_to_label()` sanitization (multi-word, snake_case, digit-leading rejection), `promote_all_entity_types_to_labels()` (distinct-value discovery, per-value promotion, unsanitizable-value skipping, no `ontology_conformant` touching), `promote_labels`/`enforce_ontology` precedence in the loader layer.
- [x] `sessions-graph` unit tests — `reconcile_session()` forwards all three new kwargs to `from_texts()`; CLI passes `enforce_ontology=True`.
- [x] Full local suite (`scripts/dev-memgraph.sh test`) — 218 passed across all five packages; the only failures are the 6 real-LLM e2e tests blocked by #250 (verified pre-existing, unrelated).