### PR TITLE
context-graph: propagate resolved Memgraph/LLM config to the reconcile subprocess

### DIFF
--- a/context-graph/agent-context-graph/docs/command-hooks.md
+++ b/context-graph/agent-context-graph/docs/command-hooks.md
@@ -51,6 +51,37 @@ The generated hook command does not embed any Memgraph connection values. At run
 
 If Memgraph requires a password, provide `MEMGRAPH_PASSWORD` to the Codex process environment. `.codex/hooks.json` should not contain Memgraph credentials.
 
+For the Claude Code plugin, connection settings instead come from
+`~/.config/context-graph/config.toml` (see "Persistent hook configuration"
+below) rather than from the hook process's environment.
+
+### Persistent hook configuration
+
+`agent-context-graph config set/get/show` read and write
+`~/.config/context-graph/config.toml`, which hook subprocesses consult
+directly (CLI flag > config file > default; see ADR 0002). Supported keys:
+
+```text
+identity.user_id
+memgraph.url
+memgraph.user
+memgraph.password
+memgraph.database
+llm.openai_api_key
+llm.anthropic_api_key
+```
+
+The `llm.*` keys are only needed if you enable the `sessions-graph` connector
+with `auto_reconcile` (`SESSIONS_GRAPH_AUTO_RECONCILE=1` at connector
+construction time): reconciliation shells out to a detached
+`sessions-graph reconcile` subprocess that does LLM-backed entity extraction
+via LightRAG, and needs an `OPENAI_API_KEY` (or `ANTHROPIC_API_KEY`) the same
+way it needs Memgraph credentials — resolved from this config file and
+injected into that subprocess's environment explicitly, not inherited from
+ambient shell env (see ADR 0003). `agent-context-graph bootstrap` captures
+`OPENAI_API_KEY`/`ANTHROPIC_API_KEY` from its own environment into the config
+file automatically, the same way it already does for `MEMGRAPH_*`.
+
 To smoke test the generated command, copy the `"command"` value from `.codex/hooks.json` and run:
 
 ```bash

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
@@ -2,8 +2,10 @@
 
 Agent runtimes (Claude Code, Codex) spawn hook commands as non-interactive
 subprocesses that do not inherit shell profile environment variables.  This
-module provides a config-file-only resolution path so hook subprocesses can
-reliably access identity and Memgraph connection settings.
+module provides a config-file-only resolution path so hook subprocesses (and
+subprocesses they in turn spawn, e.g. sessions-graph's detached
+reconciliation process) can reliably access identity, Memgraph connection,
+and LLM API key settings.
 
 Resolution order (per ADR 0002):
   CLI flag > config file > hardcoded default
@@ -32,6 +34,11 @@ _MEMGRAPH_DEFAULTS = {
     "database": "memgraph",
 }
 
+_LLM_DEFAULTS = {
+    "openai_api_key": "",
+    "anthropic_api_key": "",
+}
+
 _sentinel = object()
 _cached_config: object = _sentinel
 
@@ -45,6 +52,8 @@ class HookConfig:
     memgraph_user: str = _MEMGRAPH_DEFAULTS["user"]
     memgraph_password: str = _MEMGRAPH_DEFAULTS["password"]
     memgraph_database: str = _MEMGRAPH_DEFAULTS["database"]
+    openai_api_key: str = _LLM_DEFAULTS["openai_api_key"]
+    anthropic_api_key: str = _LLM_DEFAULTS["anthropic_api_key"]
 
 
 def load_config() -> HookConfig:
@@ -95,6 +104,22 @@ def resolve_memgraph_env(
     }
 
 
+def resolve_llm_env() -> dict[str, str]:
+    """Resolve LLM API key settings for hook subprocesses.
+
+    Config file only — mirrors :func:`resolve_memgraph_env`, but there is no
+    CLI-flag override path for these since nothing resolves them from argparse.
+    Values are empty strings when not configured; callers should treat an
+    empty value as "not configured" rather than overlaying it onto a child
+    process's environment.
+    """
+    config = load_config()
+    return {
+        "OPENAI_API_KEY": config.openai_api_key,
+        "ANTHROPIC_API_KEY": config.anthropic_api_key,
+    }
+
+
 def write_config(
     *,
     user_id: str | None = None,
@@ -102,6 +127,8 @@ def write_config(
     memgraph_user: str | None = None,
     memgraph_password: str | None = None,
     memgraph_database: str | None = None,
+    openai_api_key: str | None = None,
+    anthropic_api_key: str | None = None,
 ) -> Path:
     """Write or update the config file. Returns the path written to.
 
@@ -118,6 +145,8 @@ def write_config(
     final_user = memgraph_user if memgraph_user is not None else existing.memgraph_user
     final_password = memgraph_password if memgraph_password is not None else existing.memgraph_password
     final_database = memgraph_database if memgraph_database is not None else existing.memgraph_database
+    final_openai_api_key = openai_api_key if openai_api_key is not None else existing.openai_api_key
+    final_anthropic_api_key = anthropic_api_key if anthropic_api_key is not None else existing.anthropic_api_key
 
     content = _render_config(
         user_id=final_user_id or "",
@@ -125,6 +154,8 @@ def write_config(
         user=final_user,
         password=final_password,
         database=final_database,
+        openai_api_key=final_openai_api_key,
+        anthropic_api_key=final_anthropic_api_key,
     )
 
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -143,6 +174,8 @@ def write_full_config(
     memgraph_user: str = _MEMGRAPH_DEFAULTS["user"],
     memgraph_password: str = _MEMGRAPH_DEFAULTS["password"],
     memgraph_database: str = _MEMGRAPH_DEFAULTS["database"],
+    openai_api_key: str = _LLM_DEFAULTS["openai_api_key"],
+    anthropic_api_key: str = _LLM_DEFAULTS["anthropic_api_key"],
 ) -> Path:
     """Write a complete config file with all sections (used by bootstrap).
 
@@ -156,6 +189,8 @@ def write_full_config(
         user=memgraph_user,
         password=memgraph_password,
         database=memgraph_database,
+        openai_api_key=openai_api_key,
+        anthropic_api_key=anthropic_api_key,
     )
 
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -191,6 +226,7 @@ def _read_config_file() -> HookConfig:
 
     identity = sections.get("identity", {})
     memgraph = sections.get("memgraph", {})
+    llm = sections.get("llm", {})
 
     return HookConfig(
         user_id=identity.get("user_id") or None,
@@ -198,6 +234,8 @@ def _read_config_file() -> HookConfig:
         memgraph_user=memgraph.get("user", _MEMGRAPH_DEFAULTS["user"]),
         memgraph_password=memgraph.get("password", _MEMGRAPH_DEFAULTS["password"]),
         memgraph_database=memgraph.get("database") or _MEMGRAPH_DEFAULTS["database"],
+        openai_api_key=llm.get("openai_api_key", _LLM_DEFAULTS["openai_api_key"]),
+        anthropic_api_key=llm.get("anthropic_api_key", _LLM_DEFAULTS["anthropic_api_key"]),
     )
 
 
@@ -233,6 +271,8 @@ def _render_config(
     user: str,
     password: str,
     database: str,
+    openai_api_key: str,
+    anthropic_api_key: str,
 ) -> str:
     """Render the full config file content."""
     lines = [
@@ -248,6 +288,10 @@ def _render_config(
         f'user = "{user}"',
         f'password = "{password}"',
         f'database = "{database}"',
+        "",
+        "[llm]",
+        f'openai_api_key = "{openai_api_key}"',
+        f'anthropic_api_key = "{anthropic_api_key}"',
         "",
     ]
     return "\n".join(lines)

--- a/context-graph/agent-context-graph/src/agent_context_graph/cli.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/cli.py
@@ -80,7 +80,10 @@ def _config(argv: list[str]) -> int:
         "memgraph.user": "memgraph_user",
         "memgraph.password": "memgraph_password",
         "memgraph.database": "memgraph_database",
+        "llm.openai_api_key": "openai_api_key",
+        "llm.anthropic_api_key": "anthropic_api_key",
     }
+    _SECRET_KEYS = {"memgraph.password", "llm.openai_api_key", "llm.anthropic_api_key"}
 
     if not argv or argv[0] in {"-h", "--help"}:
         print("usage: agent-context-graph config set <key> <value>")
@@ -103,6 +106,8 @@ def _config(argv: list[str]) -> int:
         print(f"memgraph.user = {config.memgraph_user!r}")
         print(f"memgraph.password = {'***' if config.memgraph_password else repr('')}")
         print(f"memgraph.database = {config.memgraph_database!r}")
+        print(f"llm.openai_api_key = {'***' if config.openai_api_key else repr('')}")
+        print(f"llm.anthropic_api_key = {'***' if config.anthropic_api_key else repr('')}")
         return 0
 
     if action == "set":
@@ -115,12 +120,12 @@ def _config(argv: list[str]) -> int:
             print(f"Supported keys: {', '.join(_CONFIG_KEYS)}", file=sys.stderr)
             return 2
 
-        # Password: read from stdin if value not provided.
+        # Secrets: read from stdin if value not provided.
         if len(argv) < 3:
-            if key == "memgraph.password":
+            if key in _SECRET_KEYS:
                 import getpass
 
-                value = getpass.getpass("Enter memgraph password: ")
+                value = getpass.getpass(f"Enter {key}: ")
             else:
                 print(f"usage: agent-context-graph config set {key} <value>", file=sys.stderr)
                 return 2
@@ -128,7 +133,7 @@ def _config(argv: list[str]) -> int:
             value = argv[2]
 
         write_config(**{_CONFIG_KEYS[key]: value})
-        display_value = "***" if key == "memgraph.password" else repr(value)
+        display_value = "***" if key in _SECRET_KEYS else repr(value)
         print(f"Wrote {key} = {display_value} to {config_path}")
         return 0
 
@@ -147,8 +152,8 @@ def _config(argv: list[str]) -> int:
         if value is None:
             print(f"{key} is not set in {config_path}", file=sys.stderr)
             return 1
-        # Don't print password to stdout unless explicitly requested.
-        if key == "memgraph.password":
+        # Don't print secrets to stdout unless explicitly requested.
+        if key in _SECRET_KEYS:
             print("***")
         else:
             print(value)
@@ -265,6 +270,8 @@ def _bootstrap(argv: list[str]) -> int:
     memgraph_user = os.environ.get("MEMGRAPH_USER", "")
     memgraph_password = os.environ.get("MEMGRAPH_PASSWORD", "")
     memgraph_database = os.environ.get("MEMGRAPH_DATABASE", "memgraph")
+    openai_api_key = os.environ.get("OPENAI_API_KEY", "")
+    anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY", "")
 
     config_path = write_full_config(
         user_id=user_id,
@@ -272,6 +279,8 @@ def _bootstrap(argv: list[str]) -> int:
         memgraph_user=memgraph_user,
         memgraph_password=memgraph_password,
         memgraph_database=memgraph_database,
+        openai_api_key=openai_api_key,
+        anthropic_api_key=anthropic_api_key,
     )
     print(f"OK config: wrote {config_path}")
     if user_id:
@@ -279,6 +288,18 @@ def _bootstrap(argv: list[str]) -> int:
     else:
         print("   identity.user_id is empty — set it with: agent-context-graph config set identity.user_id <your-name>")
     print(f"   memgraph.url = {memgraph_url!r}")
+    if openai_api_key or anthropic_api_key:
+        found = ", ".join(
+            name
+            for name, value in (("llm.openai_api_key", openai_api_key), ("llm.anthropic_api_key", anthropic_api_key))
+            if value
+        )
+        print(f"   {found} captured from environment")
+    else:
+        print(
+            "   no LLM API key found in environment — sessions-graph reconciliation needs one; "
+            "set with: agent-context-graph config set llm.openai_api_key"
+        )
 
     doctor_args = ["--runtime", args.runtime]
     for connector in connectors:
@@ -344,6 +365,10 @@ def _check_config() -> dict[str, object]:
     else:
         parts.append("user_id=NOT SET")
     parts.append(f"memgraph.url={config.memgraph_url!r}")
+    llm_key_set = bool(config.openai_api_key or config.anthropic_api_key)
+    parts.append(
+        "llm_key=SET" if llm_key_set else "llm_key=NOT SET (needed only for sessions-graph auto-reconciliation)"
+    )
     return {"name": "config", "ok": bool(config.user_id), "detail": f"{path} — {'; '.join(parts)}"}
 
 

--- a/context-graph/agent-context-graph/tests/test_identity.py
+++ b/context-graph/agent-context-graph/tests/test_identity.py
@@ -76,6 +76,33 @@ def test_cli_flag_overrides_config(config_dir):
     assert env["MEMGRAPH_URL"] == "bolt://flag:9999"
 
 
+# --- resolve_llm_env ---
+
+
+def test_llm_defaults_when_no_config(config_dir):
+    env = _identity.resolve_llm_env()
+    assert env["OPENAI_API_KEY"] == ""
+    assert env["ANTHROPIC_API_KEY"] == ""
+
+
+def test_llm_from_config_file(config_dir):
+    _identity.write_full_config(openai_api_key="sk-openai-secret", anthropic_api_key="sk-anthropic-secret")
+    _identity._reset_cache()
+    env = _identity.resolve_llm_env()
+    assert env["OPENAI_API_KEY"] == "sk-openai-secret"
+    assert env["ANTHROPIC_API_KEY"] == "sk-anthropic-secret"
+
+
+def test_write_config_preserves_llm_keys(config_dir):
+    _identity.write_full_config(openai_api_key="sk-openai-secret")
+    _identity._reset_cache()
+    _identity.write_config(user_id="someone")
+    _identity._reset_cache()
+    config = _identity.load_config()
+    assert config.openai_api_key == "sk-openai-secret"
+    assert config.user_id == "someone"
+
+
 # --- write_config ---
 
 

--- a/context-graph/sessions-graph/src/sessions_graph/cli.py
+++ b/context-graph/sessions-graph/src/sessions_graph/cli.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -77,7 +78,28 @@ def _reconcile(argv: list[str]) -> int:
     return asyncio.run(_run_reconcile(parsed))
 
 
+def _fill_env_from_context_graph_config() -> None:
+    """Best-effort fallback for standalone (manual/cron) ``reconcile`` runs.
+
+    When spawned by the SESSION_END hook, the parent process already overlays
+    context-graph's config.toml onto this subprocess's environment (see
+    sessions_graph.connector._reconciliation_env). Run standalone, there's no
+    such parent, so fill in the same values here -- only for keys not already
+    set, so explicit ambient env always wins. agent-context-graph is an
+    optional extra; silently skip if it isn't installed.
+    """
+    try:
+        from agent_context_graph.adapters._identity import resolve_llm_env, resolve_memgraph_env
+    except ImportError:
+        return
+    for key, value in {**resolve_memgraph_env(), **resolve_llm_env()}.items():
+        if value:
+            os.environ.setdefault(key, value)
+
+
 async def _run_reconcile(parsed: argparse.Namespace) -> int:
+    _fill_env_from_context_graph_config()
+
     from lightrag_memgraph import MemgraphLightRAGWrapper
     from sessions_graph import SessionsGraph
 

--- a/context-graph/sessions-graph/src/sessions_graph/connector.py
+++ b/context-graph/sessions-graph/src/sessions_graph/connector.py
@@ -171,6 +171,28 @@ class SessionsGraphConnector(GraphConnector):
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
+                env=_reconciliation_env(),
             )
         except OSError as e:
             logger.warning(f"Could not spawn detached reconciliation process for session {session_id}: {e}")
+
+
+def _reconciliation_env() -> dict[str, str]:
+    """Build the environment for the detached ``sessions-graph reconcile`` subprocess.
+
+    This hook process resolves Memgraph connection settings from
+    ``~/.config/context-graph/config.toml`` (per ADR 0002) purely as constructor
+    kwargs -- never writing them into ``os.environ``. A plain ``Popen`` without an
+    explicit ``env=`` would therefore leave the detached reconciliation subprocess
+    with ambient ``os.environ`` only, missing both the configured Memgraph
+    connection and any LLM API key LightRAG needs. Overlay the same config-file
+    resolution onto a copy of the ambient environment so the child gets what this
+    process would have used, without discarding real ambient values (e.g. an
+    OPENAI_API_KEY already exported) when config-file values are unset.
+    """
+    from agent_context_graph.adapters._identity import resolve_llm_env, resolve_memgraph_env
+
+    env = dict(os.environ)
+    env.update({k: v for k, v in resolve_memgraph_env().items() if v})
+    env.update({k: v for k, v in resolve_llm_env().items() if v})
+    return env

--- a/context-graph/sessions-graph/tests/test_sessions_graph.py
+++ b/context-graph/sessions-graph/tests/test_sessions_graph.py
@@ -118,6 +118,22 @@ class TestSessionsGraphCore:
 
 
 class TestSessionsGraphConnector:
+    @pytest.fixture()
+    def context_graph_config(self, monkeypatch, tmp_path):
+        """Point agent_context_graph's hook config at a temp dir so tests never
+        touch a real ~/.config/context-graph/config.toml on the host running them.
+        """
+        pytest.importorskip("agent_context_graph", reason="agent-context-graph not installed")
+        from agent_context_graph.adapters import _identity
+
+        config_dir = tmp_path / "context-graph"
+        config_file = config_dir / "config.toml"
+        monkeypatch.setattr(_identity, "_CONFIG_DIR", config_dir)
+        monkeypatch.setattr(_identity, "_CONFIG_FILE", config_file)
+        _identity._reset_cache()
+        yield _identity
+        _identity._reset_cache()
+
     def _make(self):
         pytest.importorskip("agent_context_graph", reason="agent-context-graph not installed")
         from sessions_graph.connector import SessionsGraphConnector
@@ -173,8 +189,17 @@ class TestSessionsGraphConnector:
 
         mock_popen.assert_not_called()
 
-    def test_auto_reconcile_true_spawns_detached_process(self):
+    def test_auto_reconcile_true_spawns_detached_process(self, context_graph_config):
         from sessions_graph.connector import SessionsGraphConnector
+
+        context_graph_config.write_full_config(
+            memgraph_url="bolt://remote:7687",
+            memgraph_user="admin",
+            memgraph_password="secret",
+            memgraph_database="mydb",
+            openai_api_key="sk-test",
+        )
+        context_graph_config._reset_cache()
 
         _connector, graph, _db, SessionStartEvent, SessionEndEvent = self._make()
         connector = SessionsGraphConnector(graph, auto_reconcile=True)
@@ -187,8 +212,14 @@ class TestSessionsGraphConnector:
         command = mock_popen.call_args.args[0]
         assert command[-3:] == ["reconcile", "--session", "s-1"]
         assert mock_popen.call_args.kwargs["start_new_session"] is True
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["MEMGRAPH_URL"] == "bolt://remote:7687"
+        assert env["MEMGRAPH_USER"] == "admin"
+        assert env["MEMGRAPH_PASSWORD"] == "secret"
+        assert env["MEMGRAPH_DATABASE"] == "mydb"
+        assert env["OPENAI_API_KEY"] == "sk-test"
 
-    def test_auto_reconcile_env_var_enables_spawn_when_not_passed_explicitly(self, monkeypatch):
+    def test_auto_reconcile_env_var_enables_spawn_when_not_passed_explicitly(self, monkeypatch, context_graph_config):
         from sessions_graph.connector import SessionsGraphConnector
 
         monkeypatch.setenv("SESSIONS_GRAPH_AUTO_RECONCILE", "1")
@@ -208,3 +239,45 @@ class TestSessionsGraphConnector:
         assert connector.supports(SessionStartEvent(session_id="s-1"))
         assert connector.supports(SessionEndEvent(session_id="s-1"))
         assert not connector.supports(ToolStartEvent(session_id="s-1", tool_name="read_file"))
+
+
+class TestReconciliationEnv:
+    """Unit tests for connector._reconciliation_env(), the fix for the detached
+    ``sessions-graph reconcile`` subprocess never seeing resolved Memgraph/LLM config.
+    """
+
+    @pytest.fixture()
+    def context_graph_config(self, monkeypatch, tmp_path):
+        pytest.importorskip("agent_context_graph", reason="agent-context-graph not installed")
+        from agent_context_graph.adapters import _identity
+
+        config_dir = tmp_path / "context-graph"
+        config_file = config_dir / "config.toml"
+        monkeypatch.setattr(_identity, "_CONFIG_DIR", config_dir)
+        monkeypatch.setattr(_identity, "_CONFIG_FILE", config_file)
+        _identity._reset_cache()
+        yield _identity
+        _identity._reset_cache()
+
+    def test_merges_config_onto_ambient_env(self, context_graph_config, monkeypatch):
+        from sessions_graph.connector import _reconciliation_env
+
+        monkeypatch.setenv("PATH", "/usr/bin")
+        context_graph_config.write_full_config(memgraph_url="bolt://remote:7687", openai_api_key="sk-test")
+        context_graph_config._reset_cache()
+
+        env = _reconciliation_env()
+
+        assert env["PATH"] == "/usr/bin"  # ambient env preserved
+        assert env["MEMGRAPH_URL"] == "bolt://remote:7687"
+        assert env["OPENAI_API_KEY"] == "sk-test"
+
+    def test_ambient_llm_key_preserved_when_config_empty(self, context_graph_config, monkeypatch):
+        from sessions_graph.connector import _reconciliation_env
+
+        monkeypatch.setenv("OPENAI_API_KEY", "ambient-key")
+
+        env = _reconciliation_env()
+
+        # config.toml has no openai_api_key set -> must not clobber the ambient value
+        assert env["OPENAI_API_KEY"] == "ambient-key"


### PR DESCRIPTION
## Summary

- `SessionsGraphConnector._spawn_reconciliation` spawns a detached `sessions-graph reconcile` subprocess on `SESSION_END` (when `auto_reconcile` is on) via a bare `subprocess.Popen` with no explicit `env=`. Per ADR 0002, the parent hook process resolves Memgraph credentials from `~/.config/context-graph/config.toml` purely as constructor kwargs — never writing them to `os.environ` — so the spawned subprocess silently fell back to Memgraph defaults, and had no path at all to an LLM API key (LightRAG's default `llm_model_func` reads `OPENAI_API_KEY` from `os.environ` and raises if it's missing).
- Extends the config-file-only resolution mechanism from ADR 0002 with an `[llm]` section (`openai_api_key`, `anthropic_api_key`) and `resolve_llm_env()`, mirroring `resolve_memgraph_env()`. `bootstrap` captures `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` from the environment into the config file the same way it already does for Memgraph credentials.
- `_spawn_reconciliation` now builds an explicit `env=` for the child: ambient `os.environ` overlaid with non-empty resolved Memgraph + LLM values, so the detached subprocess gets what the hook process resolved regardless of the harness's own ambient environment.
- `sessions-graph reconcile` (run standalone via cron/manually) does the same best-effort fill-in at startup via an optional import, so it behaves consistently whether spawned by the hook or invoked directly.
- `agent-context-graph config set/get/show` and `doctor` gain the new `llm.*` keys; `command-hooks.md` documents them.

## Test plan

- [x] `uv run --package agent-context-graph --extra test pytest tests/ -v` — 83 passed
- [x] `uv run --package sessions-graph --extra test --extra agent-context-graph --extra reconciliation pytest tests/ -v` — 50 passed, 1 skipped (live-Memgraph e2e test)
- [x] `ruff check` / `ruff format --check` on changed files
- [x] Manual smoke test: `agent-context-graph config set llm.openai_api_key`, `config show`, `config get`, and `doctor` all reflect the new `[llm]` section correctly in an isolated `$HOME`