### PR TITLE
docs: refresh Context Graph READMEs for the getting-started user

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -331,7 +331,20 @@ jobs:
       - name: Start Memgraph container
         run: |
           docker run -d -p 7687:7687 --name memgraph memgraph/memgraph-mage:latest --schema-info-enabled=True --telemetry-enabled=false
-          sleep 5
+
+      - name: Wait for Memgraph to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if (echo > /dev/tcp/localhost/7687) 2>/dev/null; then
+              echo "Memgraph is accepting Bolt connections"
+              exit 0
+            fi
+            echo "Waiting for Memgraph (attempt $i)..."
+            sleep 2
+          done
+          echo "Memgraph did not become ready in time" >&2
+          docker logs memgraph || true
+          exit 1
 
       - name: Install uv
         run: python -m pip install uv
@@ -361,7 +374,20 @@ jobs:
       - name: Start Memgraph container
         run: |
           docker run -d -p 7687:7687 --name memgraph memgraph/memgraph-mage:latest --schema-info-enabled=True --telemetry-enabled=false
-          sleep 5
+
+      - name: Wait for Memgraph to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if (echo > /dev/tcp/localhost/7687) 2>/dev/null; then
+              echo "Memgraph is accepting Bolt connections"
+              exit 0
+            fi
+            echo "Waiting for Memgraph (attempt $i)..."
+            sleep 2
+          done
+          echo "Memgraph did not become ready in time" >&2
+          docker logs memgraph || true
+          exit 1
 
       - name: Install uv
         run: python -m pip install uv

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -335,8 +335,8 @@ jobs:
       - name: Wait for Memgraph to be ready
         run: |
           for i in $(seq 1 30); do
-            if (echo > /dev/tcp/localhost/7687) 2>/dev/null; then
-              echo "Memgraph is accepting Bolt connections"
+            if echo "RETURN 1;" | docker exec -i memgraph mgconsole --host 127.0.0.1 --port 7687 >/dev/null 2>&1; then
+              echo "Memgraph is ready to serve queries"
               exit 0
             fi
             echo "Waiting for Memgraph (attempt $i)..."
@@ -378,8 +378,8 @@ jobs:
       - name: Wait for Memgraph to be ready
         run: |
           for i in $(seq 1 30); do
-            if (echo > /dev/tcp/localhost/7687) 2>/dev/null; then
-              echo "Memgraph is accepting Bolt connections"
+            if echo "RETURN 1;" | docker exec -i memgraph mgconsole --host 127.0.0.1 --port 7687 >/dev/null 2>&1; then
+              echo "Memgraph is ready to serve queries"
               exit 0
             fi
             echo "Waiting for Memgraph (attempt $i)..."

--- a/README.md
+++ b/README.md
@@ -39,6 +39,38 @@ pip install unstructured2graph
 
 ## 📚 Usage Examples
 
+### Context Graph - Capture Your Agent Sessions
+
+Turn your Claude Code and Codex sessions into a queryable knowledge graph. Install the plugin and every session records the tools it called, the skills it used, and the memories it wrote — all joined on a shared `(:Session)` node in Memgraph.
+
+Inside Claude Code:
+
+```text
+/plugin marketplace add memgraph/ai-toolkit
+/plugin install context-graph@context-graph-plugins
+```
+
+Then bootstrap, set your identity, and verify:
+
+```bash
+agent-context-graph bootstrap --runtime claude-code \
+  --connector skills-graph --connector actions-graph --connector sessions-graph
+agent-context-graph config set identity.user_id "your-name"
+agent-context-graph doctor --runtime claude-code \
+  --connector skills-graph --connector actions-graph --connector sessions-graph
+```
+
+Query across every session — e.g. which skills a user has used:
+
+```cypher
+MATCH (:User {user_id: "your-name"})-[:HAD_SESSION]->(:Session)-[:USED_SKILL]->(s:Skill)
+RETURN s.name, count(*) AS uses ORDER BY uses DESC;
+```
+
+👉 [Context Graph guide](/context-graph/) — components, Codex setup, SDK usage, and reconciling sessions into an entity graph.
+
+---
+
 ### unstructured2graph - Build Knowledge Graphs from Documents
 
 Transform PDFs, URLs, and documents into queryable knowledge graphs:
@@ -47,12 +79,11 @@ Transform PDFs, URLs, and documents into queryable knowledge graphs:
 import asyncio
 from memgraph_toolbox.api.memgraph import Memgraph
 from lightrag_memgraph import MemgraphLightRAGWrapper
-from unstructured2graph import from_unstructured, create_property_index
+from unstructured2graph import from_unstructured
 
 
 async def main():
     memgraph = Memgraph()
-    create_property_index(memgraph, "Chunk", "hash")
 
     lightrag = MemgraphLightRAGWrapper()
     await lightrag.initialize(working_dir="./lightrag_storage")
@@ -63,6 +94,7 @@ async def main():
         memgraph=memgraph,
         lightrag_wrapper=lightrag,
         link_chunks=True,
+        enforce_ontology=True,  # promote entity_type to real labels (:Person, :Organization, ...)
     )
     await lightrag.afinalize()
 
@@ -163,7 +195,19 @@ uv run main.py
 | [langchain-memgraph](/integrations/langchain-memgraph/) | LangChain tools and chains   | `pip install langchain-memgraph` |
 | [mcp-memgraph](/integrations/mcp-memgraph/)             | MCP server for LLMs          | `pip install mcp-memgraph`       |
 | [unstructured2graph](/unstructured2graph/)              | Document to graph conversion | `pip install unstructured2graph` |
+| [lightrag-memgraph](/integrations/lightrag-memgraph/)   | LightRAG storage on Memgraph | `pip install lightrag-memgraph`  |
 | [sql2graph](/agents/sql2graph/)                         | Database migration agent     | See docs                         |
+
+### Context Graph — capture agent sessions
+
+A family of components that persist your Claude Code / Codex sessions into one Memgraph graph. See the [Context Graph guide](/context-graph/).
+
+| Package                                                          | Description                                    | Install                             |
+| --------------------------------------------------------------- | ---------------------------------------------- | ----------------------------------- |
+| [agent-context-graph](/context-graph/agent-context-graph/)      | Event hub: routes runtime hooks to connectors  | `pip install agent-context-graph`   |
+| [actions-graph](/context-graph/actions-graph/)                  | Tool calls, results, messages as action nodes  | `pip install actions-graph`         |
+| [skills-graph](/context-graph/skills-graph/)                    | Skill definitions and per-session skill usage  | `pip install skills-graph`          |
+| [sessions-graph](/context-graph/sessions-graph/)                | User/session provenance, memories, reconciliation | `pip install sessions-graph`     |
 
 ---
 
@@ -217,17 +261,22 @@ uv pip install -e integrations/mcp-memgraph[test]
 pytest -s integrations/mcp-memgraph/tests
 ```
 
-### Agent integration tests
+### Context Graph tests
+
+The Context Graph components (and unstructured2graph) test against a live Memgraph. `scripts/dev-memgraph.sh` owns that lifecycle — it starts an isolated instance, runs each component's suite against it, and tears down:
 
 ```bash
-uv pip install -e integrations/agents[test]
-pytest -s integrations/agents/tests
+./scripts/dev-memgraph.sh up
+./scripts/dev-memgraph.sh test          # all components; or e.g. `test sessions-graph`
+./scripts/dev-memgraph.sh down
 ```
 
-To run a complete migration workflow with the agent:
+### sql2graph agent
+
+To run a complete database migration workflow with the agent:
 
 ```bash
-cd integrations/agents
+cd agents/sql2graph
 uv run main.py
 ```
 

--- a/context-graph/README.md
+++ b/context-graph/README.md
@@ -1,0 +1,144 @@
+# Context Graph
+
+**Turn your Claude Code and Codex sessions into a queryable knowledge graph in [Memgraph](https://memgraph.com/).**
+
+Context Graph is a family of components that capture what your coding agents actually do — the tools they call, the skills they use, the memories they record — and persist it into a single Memgraph graph you can query across every session. Install it as a plugin, and every session your agent runs quietly builds up a graph of your work.
+
+```text
+Claude Code / Codex  ──hooks──▶  agent-context-graph  ──▶  Memgraph
+                                   (routes events)          (:User)-[:HAD_SESSION]->(:Session)
+                                                              ├─[:HAS_ACTION]->(:Action)   ← actions-graph
+                                                              ├─[:USED_SKILL]->(:Skill)    ← skills-graph
+                                                              └─[:PRODUCED_MEMORY]->(:Memory) ← sessions-graph
+```
+
+## Why
+
+Every agent session today is ephemeral — it scrolls off and the context is gone. Context Graph makes that context durable and connected:
+
+- **Observability** — see which tools and skills a session used, and how actions followed one another.
+- **Cross-session recall** — agents write **Memories** (durable free-form assertions) they can search in future sessions.
+- **A knowledge graph of your work** — optionally reconcile session content into extracted entities (people, projects, files, concepts) linked back to the sessions that mentioned them.
+
+Everything is joined by a shared `(:Session {session_id})` node, so one graph answers questions that span tools, skills, memories, and entities.
+
+## The components
+
+| Component | What it captures | Owns |
+|---|---|---|
+| **[agent-context-graph](./agent-context-graph/)** | The event hub. Normalizes runtime hooks/SDK activity into a shared event stream and routes it to the connectors below. | Adapters + connectors wiring |
+| **[actions-graph](./actions-graph/)** | Tool calls, tool results, messages, subagent/error events — the raw activity of a session. | `(:Action)`, `(:Tool)` |
+| **[skills-graph](./skills-graph/)** | Which reusable [Agent Skills](https://docs.claude.com/en/docs/claude-code/skills) a session used, and stored skill definitions. | `(:Skill)` |
+| **[sessions-graph](./sessions-graph/)** | User/session provenance, durable **Memories**, and session **reconciliation** into entities. | `(:User)`, `(:Session)`, `(:Memory)` |
+
+> `(:Session)` is a shared coordination point — every component `MERGE`s it idempotently, but only sessions-graph owns `(:User)` and the `HAD_SESSION` edge. Entity extraction is powered by [unstructured2graph](../unstructured2graph/), which lives outside this family.
+
+## Getting started (Claude Code)
+
+The fastest path is the plugin — it wires all three connectors into Claude Code's hooks so capture is automatic.
+
+### 1. Start Memgraph
+
+```bash
+docker run --rm -p 7687:7687 memgraph/memgraph-mage:latest --schema-info-enabled=true
+```
+
+Requires **Memgraph ≥ 3.6** (sessions-graph uses text search, stable from that release). The MAGE image is recommended if you'll also use reconciliation.
+
+### 2. Install the plugin
+
+Inside Claude Code:
+
+```text
+/plugin marketplace add memgraph/ai-toolkit
+/plugin install context-graph@context-graph-plugins
+```
+
+### 3. Bootstrap and configure
+
+The plugin's first run installs the `agent-context-graph` tool (with all three connector extras), writes `~/.config/context-graph/config.toml`, and runs `doctor`:
+
+```bash
+agent-context-graph bootstrap --runtime claude-code \
+  --connector skills-graph --connector actions-graph --connector sessions-graph
+```
+
+Set your identity — **required** for sessions-graph to attach sessions to a user:
+
+```bash
+agent-context-graph config set identity.user_id "your-name"
+```
+
+The default Memgraph connection is `bolt://localhost:7687`. To point at a remote or HA instance, set it in the config file (hooks read this file, **not** environment variables, at runtime — see [ADR 0002](./agent-context-graph/docs/adr/0002-config-file-only-hook-resolution.md)):
+
+```bash
+agent-context-graph config set memgraph.url "neo4j://<coordinator-host>:7687"
+agent-context-graph config set memgraph.user "<user>"
+agent-context-graph config set memgraph.password        # prompts; stored 0600
+agent-context-graph config set memgraph.database "memgraph"
+```
+
+### 4. Verify
+
+```bash
+agent-context-graph config show
+agent-context-graph doctor --runtime claude-code \
+  --connector skills-graph --connector actions-graph --connector sessions-graph
+```
+
+You want every line `OK` — config (user_id set), Memgraph reachable, each connector, and the strict hook smoke test.
+
+### 5. Use Claude Code normally
+
+From here, every session writes to the graph automatically: `(:User)-[:HAD_SESSION]->(:Session)`, tool actions, skill usage, and any Memories the agent records.
+
+> **Codex** follows the same flow with `--runtime codex` and `codex plugin marketplace add memgraph/ai-toolkit --sparse .agents/plugins`. See [agent-context-graph](./agent-context-graph/) for both runtimes and for the in-process SDK path (no plugin).
+
+## Turning sessions into an entity graph (reconciliation)
+
+By default, a finished session is marked `reconciliation_status = 'pending'` — its content is captured but not yet extracted into entities (LLM extraction is too slow/costly to run inside a hook). Run it out-of-band to build the entity graph:
+
+```bash
+pip install "sessions-graph[reconciliation]"    # actions-graph + unstructured2graph + LightRAG
+export OPENAI_API_KEY=...                        # or ANTHROPIC_API_KEY
+
+# extract entities from every pending session
+sessions-graph reconcile --pending
+```
+
+This pulls each session's actions and memories, runs them through [unstructured2graph](../unstructured2graph/)'s LightRAG pipeline, and writes extracted entities (with typed labels like `:Person`, `:Organization`) linked back via `(:Action|:Memory)-[:HAS_CHUNK]->(:Chunk)<-[:MENTIONED_IN]-(:Entity)`. See [sessions-graph § reconciliation](./sessions-graph/README.md#session-reconciliation).
+
+## Querying the graph
+
+Because every component writes to the same `(:Session {session_id})`, one query language spans all of them:
+
+| Question | Cypher path |
+|---|---|
+| All actions a user triggered | `(:User)-[:HAD_SESSION]->(:Session)-[:HAS_ACTION]->(:Action)` |
+| Which skills a user has used | `(:User)-[:HAD_SESSION]->(:Session)-[:USED_SKILL]->(:Skill)` |
+| Memories produced during a session | `(:Session)-[:PRODUCED_MEMORY]->(:Memory)` |
+| All memories owned by a user | `(:User)-[:HAS_MEMORY]->(:Memory)` |
+| Sessions where a specific tool was called | `(:Session)-[:HAS_ACTION]->(:Action {tool_name: "..."})` |
+| Entities surfaced across a user's sessions | `(:User)-[:HAD_SESSION]->(:Session)-[:HAS_ACTION]->(:Action)-[:HAS_CHUNK]->(:Chunk)<-[:MENTIONED_IN]-(:Entity)` |
+
+Run these in [Memgraph Lab](https://memgraph.com/docs/data-visualization) or any Bolt client.
+
+## Using components directly (without a plugin)
+
+Each component is a standalone Python library with its own README and can be used on its own or wired into `agent-context-graph` for the SDK path (Claude Agent SDK, OpenAI Agents SDK):
+
+- [agent-context-graph](./agent-context-graph/) — the adapter/connector layer and SDK quick starts
+- [actions-graph](./actions-graph/) — record and query session actions
+- [skills-graph](./skills-graph/) — persist and track skills
+- [sessions-graph](./sessions-graph/) — memories and reconciliation
+
+## Local development
+
+`scripts/dev-memgraph.sh` (repo root) starts an isolated Memgraph, runs each component's test suite against it, and can point your live plugin at it for dogfooding:
+
+```bash
+./scripts/dev-memgraph.sh up        # start an isolated local Memgraph
+./scripts/dev-memgraph.sh test      # run all component test suites against it
+./scripts/dev-memgraph.sh reconcile # run reconciliation on pending sessions
+./scripts/dev-memgraph.sh down      # tear it down
+```

--- a/context-graph/actions-graph/README.md
+++ b/context-graph/actions-graph/README.md
@@ -2,6 +2,8 @@
 
 Store and track LLM actions, tool calls, and sessions in Memgraph.
 
+> Part of the [Context Graph](../README.md) family — usually wired into `agent-context-graph` to capture Claude Code / Codex sessions automatically. This README covers using it directly.
+
 Actions Graph provides a graph-based storage system for tracking all LLM interactions, including:
 - **Tool Calls**: Function/tool invocations by the LLM
 - **Tool Results**: Outputs from tool executions
@@ -30,15 +32,21 @@ For Agent Context Graph integration:
 pip install "actions-graph[agent-context-graph]"
 ```
 
+Needs a running Memgraph (default `bolt://localhost:7687`); `ActionsGraph()` reads `MEMGRAPH_URL`, `MEMGRAPH_USER`, `MEMGRAPH_PASSWORD`, `MEMGRAPH_DATABASE` (or takes them as kwargs):
+
+```bash
+docker run --rm -p 7687:7687 memgraph/memgraph
+```
+
 ## Quick Start
 
 ### Basic Usage
 
 ```python
-from actions_graph import ActionsGraph, Session, ToolCall
+from actions_graph import ActionsGraph, Session
 
 # Initialize the graph
-graph = ActionsGraph()
+graph = ActionsGraph()  # reads MEMGRAPH_URL / MEMGRAPH_USER / MEMGRAPH_PASSWORD
 graph.setup()  # Create indexes and constraints
 
 # Create a session
@@ -98,8 +106,9 @@ Actions Graph should consume runtime activity through Agent Context Graph when p
   - Properties: `session_id`, `started_at`, `ended_at`, `status`, `model`, `total_cost_usd`, etc.
 
 - **Action**: Individual actions with type-specific labels
-  - Labels: `ToolCall`, `ToolResult`, `Message`, `StructuredOutput`, `SubagentEvent`, etc.
-  - Properties: `action_id`, `session_id`, `action_type`, `timestamp`, `status`, etc.
+  - Labels: `ToolCall`, `ToolResult`, `Message` (plus a role label `UserMessage`/`AssistantMessage`/`SystemMessage`), `StructuredOutput`, `SubagentEvent`, `PermissionRequest`, `ErrorEvent`, `RateLimitEvent`
+  - Properties: `action_id`, `action_type`, `timestamp`, `status`, `duration_ms`, `parent_action_id`, `tool_name`, `is_error`, `is_mcp`, `properties` (type-specific), `metadata`
+  - The session link is the `HAS_ACTION` edge, not a property — there is no `session_id` on `(:Action)`.
 
 - **Tool**: Tool definitions
   - Properties: `name`, `is_mcp`, `mcp_server`
@@ -108,11 +117,10 @@ Actions Graph should consume runtime activity through Agent Context Graph when p
 
 ```
 (:Session)-[:HAS_ACTION]->(:Action)
-(:Action)-[:FOLLOWED_BY]->(:Action)
-(:Action)-[:PARENT_OF]->(:Action)
+(:Action)-[:FOLLOWED_BY]->(:Action)   # temporal sequence
+(:Action)-[:PARENT_OF]->(:Action)     # nested, e.g. subagent
 (:Session)-[:FORKED_FROM]->(:Session)
-(:Action)-[:USED_TOOL]->(:Tool)
-(:Session)-[:HAS_TAG]->(:Tag)
+(:Action)-[:USED_TOOL]->(:Tool)       # ToolCall actions only
 ```
 
 ## API Reference
@@ -133,7 +141,7 @@ graph.clear()  # Clear all data
 graph.create_session(session)
 graph.get_session(session_id)
 graph.end_session(session_id, status=ActionStatus.COMPLETED)
-graph.list_sessions(limit=100, status=None, tag=None)
+graph.list_sessions(limit=100, status=None)  # keyword-only args
 
 # Actions
 graph.record_action(action)

--- a/context-graph/actions-graph/src/actions_graph/__init__.py
+++ b/context-graph/actions-graph/src/actions_graph/__init__.py
@@ -69,4 +69,4 @@ __all__ = [
     "ToolResult",
 ]
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/context-graph/actions-graph/src/actions_graph/__init__.py
+++ b/context-graph/actions-graph/src/actions_graph/__init__.py
@@ -33,6 +33,8 @@ Integration with Agent Context Graph:
     link.add_connector(ActionsGraphConnector(graph))
 """
 
+from importlib import metadata
+
 from .core import ActionsGraph
 from .models import (
     Action,
@@ -51,6 +53,13 @@ from .models import (
     ToolResult,
 )
 
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    # Case where package metadata is not available.
+    __version__ = ""
+del metadata  # optional, avoids polluting the results of dir(__package__)
+
 __all__ = [
     "Action",
     "ActionStatus",
@@ -67,6 +76,5 @@ __all__ = [
     "SubagentEvent",
     "ToolCall",
     "ToolResult",
+    "__version__",
 ]
-
-__version__ = "0.1.2"

--- a/context-graph/agent-context-graph/README.md
+++ b/context-graph/agent-context-graph/README.md
@@ -12,6 +12,8 @@ Runtime Adapter  ->  Event Protocol  ->  Graph Connector(s)
 
 Runtime plugins are the distribution layer for host-specific hook wiring. They install hooks, skills, and setup helpers for a runtime, then call Agent Context Graph. They are not graph components and should not encode graph-specific meaning.
 
+> **Just want to capture your Claude Code / Codex sessions?** Start with the [Context Graph guide](../README.md) — it walks through installing the plugin and wiring all the connectors end to end. This README covers the adapter layer itself and the in-process SDK path.
+
 ## Installation
 
 For command-hook runtimes such as Codex and Claude Code, prefer a user-level tool install:
@@ -145,63 +147,97 @@ Implemented:
 
 ### First-Time Plugin Setup
 
-For Codex and Claude Code plugins, the recommended first-run path is the bootstrap command. It installs the runtime package, checks Memgraph, installs the graph connector extra, and runs `doctor`.
+For Codex and Claude Code plugins, the recommended first-run path is the bootstrap command. It installs the runtime package (with the connector extras), checks Memgraph, and runs `doctor`.
 
 Prerequisites:
 
-- `uv` on `PATH`.
-- Memgraph running and reachable over Bolt. Defaults are `bolt://localhost:7687`, empty user/password, and database `memgraph`.
+- `uv` on `PATH`. (`uv` manages Python for the tool; if uv-managed Python downloads are blocked, install Python 3.10+ and rerun bootstrap.)
+- Memgraph running and reachable over Bolt. Defaults are `bolt://localhost:7687`, empty user/password, database `memgraph`. If it isn't running locally:
 
-**Environment variables:**
+  ```bash
+  docker run --rm -p 7687:7687 memgraph/memgraph
+  ```
 
-| Variable | Default | Description |
-|---|---|---|
-| `MEMGRAPH_URL` | `bolt://localhost:7687` | Bolt URL — set to a remote host for non-local Memgraph |
-| `MEMGRAPH_USER` | `""` | Bolt username (service account) |
-| `MEMGRAPH_PASSWORD` | `""` | Bolt password or OAuth token |
-| `MEMGRAPH_DATABASE` | `memgraph` | Target database name |
-| `AGENT_CONTEXT_GRAPH_USER_ID` | _(none)_ | Human identity stored on Memory nodes — required for sessions-graph to associate memories with a user |
-
-If Memgraph is not running locally, start it first:
+**1. Bootstrap all three connectors** (this is what the installed plugin wires into its hooks):
 
 ```bash
-docker run --rm -p 7687:7687 memgraph/memgraph
+# Codex
+agent-context-graph bootstrap --runtime codex \
+  --connector skills-graph --connector actions-graph --connector sessions-graph
+
+# Claude Code
+agent-context-graph bootstrap --runtime claude-code \
+  --connector skills-graph --connector actions-graph --connector sessions-graph
 ```
 
-`uv` manages Python for the tool. If uv-managed Python downloads are blocked in your environment, install Python 3.10+ and rerun bootstrap.
-
-For Codex:
-
-```bash
-agent-context-graph bootstrap --runtime codex --connector skills-graph
-```
-
-For Claude Code:
-
-```bash
-agent-context-graph bootstrap --runtime claude-code --connector skills-graph
-```
-
-Expected successful doctor output looks like:
-
-```text
-OK agent-context-graph executable: ...
-OK agent-context-graph: ...
-OK connector:skills-graph: installed=...; memgraph=reachable
-OK runtime:codex: strict hook smoke passed
-```
-
-Use the matching runtime value when checking Claude Code:
-
-```text
-OK runtime:claude-code: strict hook smoke passed
-```
-
-The plugin wrapper scripts call the same bootstrap command. If `agent-context-graph` is not installed yet, they fall back to `uvx`:
+The plugin wrapper script runs the same command (and falls back to `uvx` if the tool isn't installed yet):
 
 ```bash
 ./scripts/bootstrap.sh
 ```
+
+**2. Configure identity and connection.** Bootstrap writes `~/.config/context-graph/config.toml`; hooks read their configuration from that file at runtime (see [Configuration](#configuration) — env vars are **not** read at hook time). Set your identity, which sessions-graph requires:
+
+```bash
+agent-context-graph config set identity.user_id "your-name"
+```
+
+The Memgraph connection defaults to `bolt://localhost:7687`. For a remote or HA instance:
+
+```bash
+agent-context-graph config set memgraph.url "neo4j://<coordinator-host>:7687"
+agent-context-graph config set memgraph.user "<user>"
+agent-context-graph config set memgraph.password        # prompts; stored 0600
+agent-context-graph config set memgraph.database "memgraph"
+```
+
+**3. Verify:**
+
+```bash
+agent-context-graph config show
+agent-context-graph doctor --runtime claude-code \
+  --connector skills-graph --connector actions-graph --connector sessions-graph
+```
+
+Expected successful doctor output (use `--runtime codex` for Codex):
+
+```text
+OK agent-context-graph executable: ...
+OK agent-context-graph: ...
+OK config: identity.user_id set
+OK memgraph: reachable
+OK connector:skills-graph: installed=...; memgraph=reachable
+OK connector:actions-graph: installed=...; memgraph=reachable
+OK connector:sessions-graph: installed=...; memgraph=reachable
+OK runtime:claude-code: strict hook smoke passed
+```
+
+> **Reconciliation is a separate step.** The connectors capture session activity, but turning a session's text into extracted entities (a `:Person`/`:Organization` graph) is done out-of-band — see [sessions-graph § reconciliation](../sessions-graph/README.md#session-reconciliation). By default a finished session is marked `reconciliation_status = 'pending'` and `sessions-graph reconcile --pending` extracts it.
+
+### Configuration
+
+Bootstrap and the `config` command write `~/.config/context-graph/config.toml` (mode `0600`). **Hook subprocesses resolve their configuration from CLI flags and this file only — never from environment variables** (they don't inherit your shell), per [ADR 0002](docs/adr/0002-config-file-only-hook-resolution.md).
+
+```toml
+[identity]
+user_id = "your-name"
+
+[memgraph]
+url = "bolt://localhost:7687"
+user = ""
+password = ""
+database = "memgraph"
+```
+
+Manage it with:
+
+```bash
+agent-context-graph config show
+agent-context-graph config get memgraph.url
+agent-context-graph config set <key> <value>   # keys: identity.user_id, memgraph.{url,user,password,database}
+```
+
+Environment variables (`MEMGRAPH_URL`, `MEMGRAPH_USER`, `MEMGRAPH_PASSWORD`, `MEMGRAPH_DATABASE`, `AGENT_CONTEXT_GRAPH_USER_ID`) are consulted **only at bootstrap time** — if set, `bootstrap` persists them into the config file. Exporting them later has no effect on running hooks; use `config set` instead.
 
 ### OpenAI Codex Plugin
 
@@ -235,7 +271,7 @@ Check the installed hook environment with:
 agent-context-graph doctor --runtime codex --connector skills-graph --connector actions-graph --connector sessions-graph
 ```
 
-Keep graph credentials in the process environment, not in plugin hook files. Runtime hooks use `memgraph-toolbox` defaults unless the Codex process has `MEMGRAPH_*` variables set.
+Graph credentials live in `~/.config/context-graph/config.toml` (written by `bootstrap`/`config set`), not in plugin hook files or the process environment — hooks read that file at runtime. See [Configuration](#configuration).
 
 ### Claude Code Plugin
 
@@ -334,9 +370,11 @@ All runtime adapters emit runtime-agnostic `Event` dataclasses:
 
 | Connector | Graph Component | Events Handled |
 |-----------|----------------|----------------|
-| `SkillGraphConnector` | skills-graph | Tool events matching skill access/search operations |
+| `SkillGraphConnector` | [skills-graph](../skills-graph/) | Tool/message events matching skill access/search operations |
+| `ActionsGraphConnector` | [actions-graph](../actions-graph/) | Session, tool, message, subagent, and error events → action nodes |
+| `SessionsGraphConnector` | [sessions-graph](../sessions-graph/) | `SessionStartEvent`/`SessionEndEvent` → `(:User)`, `(:Session)`, `HAD_SESSION`; marks sessions for reconciliation on end |
 
-Additional graph connectors should live in the packages that own those graph schemas.
+The installed plugin wires **all three** (`--connector skills-graph --connector actions-graph --connector sessions-graph`). Each connector lives in the package that owns its graph schema; additional connectors should too.
 
 ### Adding a New Runtime Adapter
 

--- a/context-graph/agent-context-graph/src/agent_context_graph/__init__.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/__init__.py
@@ -21,6 +21,8 @@ Quick Start::
     hooks = adapter.get_runtime_hooks()
 """
 
+from importlib import metadata
+
 from .events import (
     AgentEndEvent,
     AgentStartEvent,
@@ -39,6 +41,13 @@ from .events import (
 from .link import AgentLink
 from .protocols import GraphConnector, RuntimeAdapter
 
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    # Case where package metadata is not available.
+    __version__ = ""
+del metadata  # optional, avoids polluting the results of dir(__package__)
+
 __all__ = [
     "AgentEndEvent",
     "AgentLink",
@@ -56,6 +65,5 @@ __all__ = [
     "SessionStartEvent",
     "ToolEndEvent",
     "ToolStartEvent",
+    "__version__",
 ]
-
-__version__ = "0.1.0"

--- a/context-graph/plugins/agent-context-graph-claude/README.md
+++ b/context-graph/plugins/agent-context-graph-claude/README.md
@@ -38,6 +38,26 @@ Bootstrap installs and verifies:
 agent-context-graph bootstrap --runtime claude-code --connector skills-graph --connector actions-graph --connector sessions-graph
 ```
 
+## Configure
+
+Bootstrap writes `~/.config/context-graph/config.toml`; hooks read it at runtime (not environment variables). Set your identity — **required** for sessions-graph to attach sessions to a user:
+
+```bash
+agent-context-graph config set identity.user_id "your-name"
+```
+
+For a remote/HA Memgraph, also `agent-context-graph config set memgraph.url "neo4j://<host>:7687"` (and `memgraph.user`/`memgraph.password`/`memgraph.database`). The default is `bolt://localhost:7687`. See the [agent-context-graph README](../../agent-context-graph/README.md#configuration).
+
+## Reconciliation (optional)
+
+Captured sessions are marked `reconciliation_status = 'pending'` on end. To extract entities from that content into the graph:
+
+```bash
+pip install "sessions-graph[reconciliation]"
+export OPENAI_API_KEY=...    # or ANTHROPIC_API_KEY
+sessions-graph reconcile --pending
+```
+
 ## Prerequisites
 
 - Memgraph running and reachable over Bolt.

--- a/context-graph/plugins/agent-context-graph-codex/README.md
+++ b/context-graph/plugins/agent-context-graph-codex/README.md
@@ -38,6 +38,26 @@ Bootstrap installs and verifies:
 agent-context-graph bootstrap --runtime codex --connector skills-graph --connector actions-graph --connector sessions-graph
 ```
 
+## Configure
+
+Bootstrap writes `~/.config/context-graph/config.toml`; hooks read it at runtime (not environment variables). Set your identity — **required** for sessions-graph to attach sessions to a user:
+
+```bash
+agent-context-graph config set identity.user_id "your-name"
+```
+
+For a remote/HA Memgraph, also `agent-context-graph config set memgraph.url "neo4j://<host>:7687"` (and `memgraph.user`/`memgraph.password`/`memgraph.database`). The default is `bolt://localhost:7687`. See the [agent-context-graph README](../../agent-context-graph/README.md#configuration).
+
+## Reconciliation (optional)
+
+Captured sessions are marked `reconciliation_status = 'pending'` on end. To extract entities from that content into the graph:
+
+```bash
+pip install "sessions-graph[reconciliation]"
+export OPENAI_API_KEY=...    # or ANTHROPIC_API_KEY
+sessions-graph reconcile --pending
+```
+
 ## Prerequisites
 
 - Memgraph running and reachable over Bolt.

--- a/context-graph/sessions-graph/README.md
+++ b/context-graph/sessions-graph/README.md
@@ -27,7 +27,7 @@ pip install sessions-graph[reconciliation]
 ```python
 from sessions_graph import SessionsGraph
 
-graph = SessionsGraph()  # connects via MEMGRAPH_HOST / MEMGRAPH_PORT env vars
+graph = SessionsGraph()  # connects via MEMGRAPH_URL / MEMGRAPH_USER / MEMGRAPH_PASSWORD env vars
 graph.setup()  # creates constraints and the text index (run once)
 
 # Write a memory
@@ -83,13 +83,13 @@ graph.save_memory(
 
 ```
 (:User {user_id})
-    └─[:HAS_MEMORY]─▶ (:Memory {memory_id, user_id, content, created_at})
-                              ▲                        │
-              [:PRODUCED_MEMORY]              [:HAS_CHUNK]
-                              │                        ▼
-                      (:Session {session_id,   (:Chunk {hash, text})
-                                 reconciliation_status,     ▲
-                                 reconciled_at})  [:HAS_CHUNK]
+    ├─[:HAS_MEMORY]──▶ (:Memory {memory_id, user_id, content, created_at})
+    │                          ▲                        │
+    │            [:PRODUCED_MEMORY]              [:HAS_CHUNK]
+    │                          │                        ▼
+    └─[:HAD_SESSION]─▶ (:Session {session_id,   (:Chunk {hash, text})
+                                  reconciliation_status,     ▲
+                                  reconciled_at})  [:HAS_CHUNK]
                               │                        │
                         [:HAS_ACTION]                  │
                               ▼                        │
@@ -97,6 +97,9 @@ graph.save_memory(
                               │
                                               (:Entity)-[:MENTIONED_IN]->(:Chunk)
 ```
+
+`(:User)-[:HAD_SESSION]->(:Session)` is written by `SessionsGraphConnector` on
+session start; it is the join key other Context Graph components hang off of.
 
 `(:Action)` is owned by [Actions Graph](../actions-graph/); `(:Chunk)` and the
 extracted entity nodes are owned by
@@ -152,7 +155,15 @@ Codex) enforce a timeout on hook commands. Instead:
 
   # Sweep every session still marked 'pending' (e.g. from cron)
   sessions-graph reconcile --pending --limit 50
+
+  # Optional: override LightRAG's working dir (default ./lightrag_storage)
+  sessions-graph reconcile --pending --working-dir ./lightrag_storage
   ```
+
+  The CLI runs with **`enforce_ontology=True`**: extracted entities get real
+  type labels (`:Person`, `:Organization`, …) gated by unstructured2graph's
+  default ontology, and anything outside it is kept but flagged
+  `ontology_conformant = false`. See [entity typing](../../unstructured2graph/README.md#entity-typing--ontology).
 
 - Or, if you want it triggered automatically without a manual/cron step, opt
   in to a **best-effort detached background process** spawned right after a
@@ -175,9 +186,20 @@ graph.setup()
 lightrag_wrapper = MemgraphLightRAGWrapper()
 await lightrag_wrapper.initialize(working_dir="./lightrag_storage")
 
-summary = await graph.reconcile_session("s-abc123", lightrag_wrapper=lightrag_wrapper)
+summary = await graph.reconcile_session(
+    "s-abc123",
+    lightrag_wrapper=lightrag_wrapper,
+    enforce_ontology=True,   # match the CLI: promote entity_type to real labels
+)
 print(summary.status, summary.texts_considered, summary.texts_deduped)
 ```
+
+Label promotion is opt-in and mirrors unstructured2graph's flags: the default
+(`enforce_ontology=False, promote_labels=False`) leaves entities under the
+LightRAG workspace label with an `entity_type` property only; `enforce_ontology=True`
+restricts promotion to an ontology (pass `ontology_path=` for a custom one);
+`promote_labels=True` promotes every `entity_type` with no vocabulary. See
+[unstructured2graph § entity typing](../../unstructured2graph/README.md#entity-typing--ontology).
 
 Extracted entities land in the same LightRAG workspace as any documents
 ingested via unstructured2graph by default, so a person or concept mentioned
@@ -185,10 +207,11 @@ both in a session and in an ingested document merges into one node. Pass
 `entity_workspace=` explicitly to `reconcile_session()` to isolate them instead.
 
 Content is deduplicated by hash before ever reaching the LLM, so re-running a
-sweep over already-processed content never re-bills it — but session content
-is pulled *in full*, including tool output, so the first run over a chatty
-session can still be substantial. Consider this before enabling
-`auto_reconcile` broadly.
+sweep over already-processed content never re-bills it. Each reconcilable unit
+(a message, tool call, tool result, or memory) is truncated to
+`MAX_RECONCILABLE_CHARS` (8000) before extraction, but a chatty session still
+has many units, so the first run can be substantial. Consider this before
+enabling `auto_reconcile` broadly.
 
 ## API reference
 
@@ -202,5 +225,5 @@ session can still be substantial. Consider this before enabling
 | `search_memories(user_id, query, *, limit=10)` | Full-text search over Memory content. |
 | `update_memory(memory_id, content)` | Replace the content of an existing Memory. Returns `None` if not found. |
 | `delete_memory(memory_id)` | Remove a Memory and all its relationships. |
-| `reconcile_session(session_id, *, lightrag_wrapper, actions_graph=None, entity_workspace=None)` | Run session reconciliation for one session. Returns an `ReconciliationSummary`. Requires the `reconciliation` extra. |
+| `async reconcile_session(session_id, *, lightrag_wrapper, actions_graph=None, entity_workspace=None, promote_labels=False, enforce_ontology=False, ontology_path=None)` | Run session reconciliation for one session. `promote_labels`/`enforce_ontology`/`ontology_path` control entity-type label promotion (see above). Returns a `ReconciliationSummary`. Requires the `reconciliation` extra. |
 | `get_pending_reconciliation_sessions(*, limit=100)` | Return session IDs marked `reconciliation_status = 'pending'`. |

--- a/context-graph/sessions-graph/README.md
+++ b/context-graph/sessions-graph/README.md
@@ -189,7 +189,7 @@ await lightrag_wrapper.initialize(working_dir="./lightrag_storage")
 summary = await graph.reconcile_session(
     "s-abc123",
     lightrag_wrapper=lightrag_wrapper,
-    enforce_ontology=True,   # match the CLI: promote entity_type to real labels
+    enforce_ontology=True,  # match the CLI: promote entity_type to real labels
 )
 print(summary.status, summary.texts_considered, summary.texts_deduped)
 ```

--- a/context-graph/skills-graph/README.md
+++ b/context-graph/skills-graph/README.md
@@ -2,13 +2,18 @@
 
 A small library to persist, retrieve and evolve AI skills in [Memgraph](https://memgraph.com).
 
+> Part of the [Context Graph](../README.md) family — usually wired into `agent-context-graph` so that skill usage across Claude Code / Codex sessions is recorded automatically. This README covers using it directly.
+
 ## Graph Model
 
 ```
-(:Skill {name, description, content, created_at, updated_at})
+(:Skill {name, description, content, license, compatibility,
+         allowed_tools, metadata, created_at, updated_at, source_path?})
 (:Skill)-[:DEPENDS_ON]->(:Skill)
-(:Session)-[:USED_SKILL]->(:Skill)
+(:Session)-[:USED_SKILL {first_access, last_access, access_count, actions}]->(:Skill)
 ```
+
+`USED_SKILL` is written from a `MERGE (:Session {session_id})` — skills-graph MERGEs the shared Session node it does not own (see the [Context Graph map](../CONTEXT-MAP.md)). `source_path` is set only when a skill is created by observing a local `SKILL.md` read.
 
 ## Quick Start
 
@@ -21,7 +26,9 @@ sg = SkillGraph()
 # Prepare the database schema (constraints + indexes)
 sg.setup()
 
-# Store a skill
+# Store a skill.
+# name: lowercase letters/digits/hyphens only, 1-64 chars, no leading/trailing/
+# consecutive hyphens (an invalid name raises SkillValidationError).
 sg.add_skill(
     Skill(
         name="memgraph-cypher",
@@ -50,19 +57,41 @@ sg.update_skill("memgraph-cypher", content="updated content")
 sg.delete_skill("memgraph-cypher")
 ```
 
-## Codex Hook Integration
+## Agent Context Graph integration
 
-When used through `agent-context-graph`'s Codex hook adapter, `SkillGraphConnector` records direct tool names like `get_skill` and Codex MCP-style names like `mcp__skills__get_skill`.
+Wire `SkillGraphConnector` into an `AgentLink` and skill usage is recorded automatically from any runtime adapter's event stream (Claude Code, Codex, OpenAI SDK):
 
-It also records local reads of valid Agent Skills definitions, such as `/skills/<name>/SKILL.md`, as skill usage. This supports runtimes where using a skill appears as a filesystem or shell tool reading the skill's `SKILL.md` file rather than as a dedicated `get_skill` tool call.
+```python
+from skills_graph import SkillGraph
+from skills_graph.connector import SkillGraphConnector
+from agent_context_graph import AgentLink
+from agent_context_graph.adapters.claude import ClaudeAdapter
 
-Search/list tool results can be Python lists or JSON tool content containing skill objects with `name` fields. Today those results are recorded through `USED_SKILL` with result actions; future work will split weaker surfacing signals into a separate relationship.
+link = AgentLink()
+link.add_connector(SkillGraphConnector(SkillGraph()))
+
+adapter = ClaudeAdapter(link, session_id="s-1")
+hooks = adapter.get_runtime_hooks()
+```
+
+Requires the `agent-context-graph` extra: `pip install "skills-graph[agent-context-graph]"`.
+
+The connector detects skill usage from `TOOL_START`/`TOOL_END`/`MESSAGE` events — direct tool names like `get_skill`, MCP-style names like `mcp__skills__get_skill`, and local reads of an Agent Skills definition (`.../skills/<name>/SKILL.md`), which covers runtimes where using a skill appears as a file read rather than a dedicated tool call. Search/list results that surface skill objects are also recorded through `USED_SKILL`.
 
 ## Installation
 
 ```bash
-uv sync
+pip install skills-graph
+# or, for the connector:  pip install "skills-graph[agent-context-graph]"
 ```
+
+Needs a running Memgraph (default `bolt://localhost:7687`):
+
+```bash
+docker run --rm -p 7687:7687 memgraph/memgraph
+```
+
+From a workspace checkout, `uv sync` installs it with its siblings.
 
 ## Testing
 

--- a/integrations/lightrag-memgraph/README.md
+++ b/integrations/lightrag-memgraph/README.md
@@ -52,6 +52,12 @@ asyncio.run(main())
 
 See `example.py` in this repo for a full run with sample texts and graph output.
 
+`initialize(**lightrag_kwargs)` forwards anything to `LightRAG(...)`, and explicit
+values override the Memgraph-storage defaults — e.g. `max_parallel_insert=8`, or
+`addon_params={"entity_types_guidance": "..."}` to steer entity extraction toward a
+specific vocabulary. [unstructured2graph](../../unstructured2graph/README.md#entity-typing--ontology)
+produces that `addon_params` from an ontology file via `Ontology.addon_params()`.
+
 ## Storage / persistence
 
 By default the wrapper persists **LightRAG's entire working state** into
@@ -151,7 +157,7 @@ https://platform.claude.com/docs/en/about-claude/models.
    await wrapper.initialize(
        working_dir="./lightrag_storage",
        llm_model_func=anthropic_complete,
-       llm_model_name="claude-3-5-sonnet-20241022",  # or claude-3-haiku-20240307, etc.
+       llm_model_name="claude-sonnet-4-20250514",  # any current Claude model id
        # embedding_func omitted: defaults to Memgraph's local sentence-transformer,
        # see Embeddings above. Anthropic itself has no embeddings API.
    )

--- a/unstructured2graph/README.md
+++ b/unstructured2graph/README.md
@@ -46,8 +46,8 @@ async def main():
         sources=["https://example.com/doc.pdf", "./local_file.md"],
         memgraph=memgraph,
         lightrag_wrapper=lightrag,
-        link_chunks=True,        # create NEXT relationships between chunks
-        enforce_ontology=True,   # promote entity_type to real labels (:Person, :Organization, ...)
+        link_chunks=True,  # create NEXT relationships between chunks
+        enforce_ontology=True,  # promote entity_type to real labels (:Person, :Organization, ...)
     )
     await lightrag.afinalize()
 
@@ -108,7 +108,7 @@ await from_unstructured(
     memgraph=memgraph,
     lightrag_wrapper=lightrag,
     enforce_ontology=True,
-    ontology_path="my_ontology.yaml",   # omit to use the bundled default
+    ontology_path="my_ontology.yaml",  # omit to use the bundled default
 )
 ```
 
@@ -120,7 +120,7 @@ from unstructured2graph import load_ontology
 ontology = load_ontology("my_ontology.yaml")
 await lightrag.initialize(
     working_dir="./lightrag_storage",
-    addon_params=ontology.addon_params(),   # {"entity_types_guidance": "..."}
+    addon_params=ontology.addon_params(),  # {"entity_types_guidance": "..."}
 )
 await from_unstructured(..., enforce_ontology=True, ontology_path="my_ontology.yaml")
 ```

--- a/unstructured2graph/README.md
+++ b/unstructured2graph/README.md
@@ -32,12 +32,11 @@ pip install -e ".[all-docs]"
 import asyncio
 from memgraph_toolbox.api.memgraph import Memgraph
 from lightrag_memgraph import MemgraphLightRAGWrapper
-from unstructured2graph import from_unstructured, create_property_index
+from unstructured2graph import from_unstructured
 
 
 async def main():
     memgraph = Memgraph(user_agent="unstructured2graph")
-    create_property_index(memgraph, "Chunk", "hash")
 
     lightrag = MemgraphLightRAGWrapper()
     await lightrag.initialize(working_dir="./lightrag_storage")
@@ -47,12 +46,30 @@ async def main():
         sources=["https://example.com/doc.pdf", "./local_file.md"],
         memgraph=memgraph,
         lightrag_wrapper=lightrag,
-        link_chunks=True,  # Create NEXT relationships between chunks
+        link_chunks=True,        # create NEXT relationships between chunks
+        enforce_ontology=True,   # promote entity_type to real labels (:Person, :Organization, ...)
     )
     await lightrag.afinalize()
 
 
 asyncio.run(main())
+```
+
+The `Chunk.hash` uniqueness constraint is created for you inside `from_unstructured()` / `from_texts()` — no manual index step is needed.
+
+### Ingesting raw text
+
+For in-memory strings (no file or URL), use `from_texts`. It returns one `Chunk` group per input string, so you can trace an output chunk back to the text that produced it:
+
+```python
+from unstructured2graph import from_texts
+
+grouped = await from_texts(
+    texts=["Ada Lovelace collaborated with Charles Babbage in London."],
+    memgraph=memgraph,
+    lightrag_wrapper=lightrag,
+    enforce_ontology=True,
+)
 ```
 
 > **Persistence:** `MemgraphLightRAGWrapper` now persists LightRAG's *full*
@@ -64,6 +81,50 @@ asyncio.run(main())
 > [lightrag-memgraph README](../integrations/lightrag-memgraph/README.md#storage--persistence)
 > for the label/index schema and opt-out flags.
 
+## Entity typing / ontology
+
+LightRAG writes every extracted entity under a single **workspace** label (default `base`) with its type only as an `entity_type` *property* — so out of the box you get `(:base {entity_type: "person"})`, not `(:Person)`. unstructured2graph can promote that type into a real Memgraph label. Two independent, opt-in flags on `from_unstructured()` / `from_texts()` (both default `False`):
+
+| Flag | Behavior |
+|---|---|
+| `promote_labels=True` | Promote **every** `entity_type` to a PascalCase label (`"natural object"` → `:NaturalObject`). No fixed vocabulary, no conformance flagging. |
+| `enforce_ontology=True` | Promote only types in an **ontology**; entities outside it are kept but flagged `ontology_conformant = false`. Takes precedence over `promote_labels`. |
+
+Neither flag ever deletes or rejects a node — the workspace label and raw `entity_type` are always preserved. Re-running after growing the ontology clears the flag on entities that now conform.
+
+The ontology is a YAML file. `ontology_path` defaults to a bundled `default_ontology.yaml` that mirrors LightRAG's built-in vocabulary (Person, Creature, Organization, Location, Event, Concept, Method, Content, Data, Artifact, NaturalObject). A custom one looks like:
+
+```yaml
+entity_types:
+  - label: Person
+    description: Human individuals, real or fictional
+  - label: Organization
+    description: Companies, institutions, government bodies, groups
+```
+
+```python
+await from_unstructured(
+    sources=["./local_file.pdf"],
+    memgraph=memgraph,
+    lightrag_wrapper=lightrag,
+    enforce_ontology=True,
+    ontology_path="my_ontology.yaml",   # omit to use the bundled default
+)
+```
+
+**Steering extraction with the same vocabulary (optional).** The flags above gate *promotion* after extraction. To also steer what LightRAG *extracts*, load the same YAML and pass its `addon_params()` into the wrapper — using one path at both sites keeps them in sync:
+
+```python
+from unstructured2graph import load_ontology
+
+ontology = load_ontology("my_ontology.yaml")
+await lightrag.initialize(
+    working_dir="./lightrag_storage",
+    addon_params=ontology.addon_params(),   # {"entity_types_guidance": "..."}
+)
+await from_unstructured(..., enforce_ontology=True, ontology_path="my_ontology.yaml")
+```
+
 ## Key Features
 
 | Feature                  | Description                                                       |
@@ -71,6 +132,7 @@ asyncio.run(main())
 | **Multi-format parsing** | PDFs, URLs, HTML, Markdown, DOCX, and more via Unstructured       |
 | **Automatic chunking**   | Smart document chunking with configurable options                 |
 | **Entity extraction**    | LLM-powered entity and relationship extraction via LightRAG       |
+| **Typed entities**       | Promote `entity_type` to real labels (`:Person`, ...), optionally gated by an ontology |
 | **Vector search**        | Built-in support for embedding generation and vector indices      |
 | **GraphRAG queries**     | Combine vector search with graph traversal for enhanced retrieval |
 
@@ -78,19 +140,27 @@ asyncio.run(main())
 
 ### Document Processing
 
-- `parse_source(source, partition_kwargs)` - Parse a single file or URL into chunks
-- `parse_text(text, partition_kwargs)` - Chunk a raw in-memory string (no file/URL involved)
-- `make_chunks(sources, partition_kwargs)` - Process multiple sources into `ChunkedDocument` objects
-- `from_unstructured(sources, memgraph, lightrag_wrapper, ...)` - Full ingestion pipeline for files/URLs; returns one Chunk group per source
-- `from_texts(texts, memgraph, lightrag_wrapper, ...)` - Full ingestion pipeline for raw strings; returns one Chunk group per input text
+- `parse_source(source, partition_kwargs=None)` — parse a single file or URL into a list of `Chunk`s
+- `parse_text(text, partition_kwargs=None)` — chunk a raw in-memory string (no file/URL involved)
+- `make_chunks(sources, partition_kwargs=None)` — process multiple sources into `ChunkedDocument` objects
+- `from_unstructured(sources, memgraph, lightrag_wrapper=None, only_chunks=False, link_chunks=False, entity_workspace=None, partition_kwargs=None, promote_labels=False, enforce_ontology=False, ontology_path=None)` — full ingestion for files/URLs; returns `list[list[Chunk]]`, one group per source
+- `from_texts(texts, memgraph, lightrag_wrapper=None, only_chunks=False, entity_workspace=None, promote_labels=False, enforce_ontology=False, ontology_path=None)` — full ingestion for raw strings; returns `list[list[Chunk]]`, one group per input text (no `link_chunks`/`partition_kwargs`)
+
+### Ontology
+
+- `load_ontology(path)` → `Ontology` — parse an ontology YAML file
+- `Ontology`, `EntityType` — the vocabulary types; `Ontology.addon_params()` renders LightRAG extraction guidance
+- `DEFAULT_ONTOLOGY`, `DEFAULT_ONTOLOGY_PATH` — the bundled default vocabulary
+- `promote_entity_types_to_labels(memgraph, workspace_label, ontology)` — the ontology-gated promotion (what `enforce_ontology` calls)
+- `promote_all_entity_types_to_labels(memgraph, workspace_label)` — unrestricted promotion (what `promote_labels` calls)
 
 ### Graph Operations
 
-- `create_nodes_from_list(memgraph, nodes, label, batch_size)` - Batch insert nodes
-- `connect_chunks_to_entities(memgraph, chunk_label, entity_label)` - Link entities to source chunks
-- `link_nodes_in_order(memgraph, ...)` - Create sequential relationships between chunks
-- `create_vector_search_index(memgraph, label, property)` - Create vector index for similarity search
-- `compute_embeddings(memgraph, label)` - Generate embeddings for nodes
+- `create_nodes_from_list(memgraph, nodes, label, batch_size, merge_key=None)` — batch insert; pass `merge_key` to upsert (`MERGE`) instead of `CREATE`
+- `connect_chunks_to_entities(memgraph, chunk_label, entity_label)` — link entities to source chunks (`entity_label` is the LightRAG workspace label, e.g. `base`)
+- `link_nodes_in_order(memgraph, find_label, find_property, from_to_dicts, create_edge_type)` — create sequential relationships between nodes
+- `create_vector_search_index(memgraph, label, property, dimension=384, index_name="vs_name")` — create a vector index for similarity search
+- `compute_embeddings(memgraph, label)` — generate embeddings for nodes
 
 ## Documentation
 

--- a/unstructured2graph/examples/loading.py
+++ b/unstructured2graph/examples/loading.py
@@ -7,7 +7,7 @@ import sources as SOURCES
 
 from lightrag_memgraph import MemgraphLightRAGWrapper
 from memgraph_toolbox.api.memgraph import Memgraph
-from unstructured2graph import create_property_index, from_unstructured
+from unstructured2graph import from_unstructured
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 LIGHTRAG_DIR = os.path.join(SCRIPT_DIR, "..", "lightrag_storage.out")
@@ -23,10 +23,10 @@ async def from_unstructured_with_prep():
     if not os.path.exists(LIGHTRAG_DIR):
         os.mkdir(LIGHTRAG_DIR)
 
-    # Cleanup Memgraph database.
+    # Cleanup Memgraph database. (from_unstructured creates the Chunk.hash
+    # uniqueness constraint itself, so no manual index step is needed here.)
     memgraph = Memgraph(user_agent="unstructured2graph")
     memgraph.query("MATCH (n) DETACH DELETE n;")
-    create_property_index(memgraph, "Chunk", "hash")
 
     lightrag_wrapper = MemgraphLightRAGWrapper(log_level="WARNING")
     await lightrag_wrapper.initialize(working_dir=LIGHTRAG_DIR)
@@ -37,6 +37,7 @@ async def from_unstructured_with_prep():
         lightrag_wrapper,
         only_chunks=False,
         link_chunks=True,
+        enforce_ontology=True,  # promote entity_type to real labels (:Person, :Organization, ...)
     )
     await lightrag_wrapper.afinalize()
 

--- a/unstructured2graph/src/unstructured2graph/__init__.py
+++ b/unstructured2graph/src/unstructured2graph/__init__.py
@@ -5,6 +5,8 @@ This package provides utilities for parsing various document formats and
 ingesting them into Memgraph knowledge graphs using LightRAG.
 """
 
+from importlib import metadata
+
 from .loaders import (
     Chunk,
     ChunkedDocument,
@@ -28,7 +30,13 @@ from .memgraph import (
 )
 from .ontology import DEFAULT_ONTOLOGY, DEFAULT_ONTOLOGY_PATH, EntityType, Ontology, load_ontology
 
-__version__ = "0.6.0"
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    # Case where package metadata is not available.
+    __version__ = ""
+del metadata  # optional, avoids polluting the results of dir(__package__)
+
 __all__ = [
     "DEFAULT_ONTOLOGY",
     "DEFAULT_ONTOLOGY_PATH",
@@ -36,6 +44,7 @@ __all__ = [
     "ChunkedDocument",
     "EntityType",
     "Ontology",
+    "__version__",
     "compute_embeddings",
     "connect_chunks_to_entities",
     "create_label_index",


### PR DESCRIPTION
## Summary

A lot changed recently around the Context Graph — session reconciliation, the unstructured2graph ontology / entity-type-to-label promotion, the plugin config flow — but the docs hadn't caught up, and a new user couldn't actually discover or stand up the capability. This pass rewrites the READMEs around **the user who wants to start capturing their Claude Code / Codex sessions into Memgraph**, and brings every example in line with the current code.

Before writing, I surveyed each component's README against its actual code (public API, CLI, connectors) so the commands and signatures here are verified, not guessed.

### New landing page
- **`context-graph/README.md`** (new) — the missing front door: what the family is, the four components + their division of labor, the end-to-end plugin flow (`install → bootstrap → config set identity.user_id → doctor`), the reconciliation step, and the cross-component Cypher query patterns that work because everything shares `(:Session)`.

### Root README
- Add a **Context Graph** usage section and the four components + `lightrag-memgraph` to the Packages Overview.
- Fix the dead `integrations/agents` dev path (→ `agents/sql2graph`) and document `scripts/dev-memgraph.sh`.
- Show `enforce_ontology=True` in the unstructured2graph example; drop the now-redundant `create_property_index`.

### Getting-started correctness (the important fixes)
- **agent-context-graph**: bootstrap now wires **all three** connectors (was skills-only); document `config set identity.user_id` (required for sessions — `doctor` fails without it) and `~/.config/context-graph/config.toml`; **correct the wrong "hooks read `MEMGRAPH_*` env vars at runtime" claim** — per ADR 0002 hooks read the config file only; list all three connectors; add a reconciliation pointer.
- **Both plugin READMEs**: add the config/identity and reconciliation steps, so a plugin user actually gets an entity graph instead of just `pending` sessions.

### Component accuracy
- **sessions-graph**: document `promote_labels`/`enforce_ontology`/`ontology_path` on `reconcile_session`, note the CLI runs `enforce_ontology=True`, add `--working-dir`, add the `HAD_SESSION` edge, fix the `MEMGRAPH_HOST/PORT` env comment, correct the "pulled in full" claim (`MAX_RECONCILABLE_CHARS`).
- **unstructured2graph** (+ `examples/loading.py`): document the whole 0.6.0 ontology / label-promotion feature (`promote_labels` vs `enforce_ontology`, ontology YAML, `addon_params` steering) and `from_texts`; correct every stale signature; drop the redundant `create_property_index`.
- **actions-graph**: delete the fictional `HAS_TAG`/`Tag` relationship, fix `list_sessions` (keyword-only, no `tag`), drop `session_id` from `Action` props, add Memgraph connection setup. Also bumps a stale `__version__` (0.1.1 → 0.1.2) to match `pyproject.toml`.
- **skills-graph**: real `SkillGraphConnector` wiring code, full `Skill` schema + `USED_SKILL` edge props, skill-name validation rules, connection setup.
- **lightrag-memgraph**: note `initialize()` passes `addon_params` through for ontology steering; refresh a legacy Claude model id.

## Notes
- Two non-README code touches, both incidental to the docs: the actions-graph `__version__` string fix, and the unstructured2graph example (`enforce_ontology=True`, remove redundant index call).

## Test plan
- [x] Script-checked every internal Markdown link and heading anchor across all edited files — all resolve.
- [x] Verified documented CLI flags (`config set` keys, `reconcile --session/--pending/--limit/--working-dir`) and function signatures (`from_unstructured`/`from_texts`/`create_vector_search_index`/promotion helpers) against the code.
- [x] `py_compile` + `ruff check` pass on the two changed Python files.