### PR TITLE
ci(unstructured2graph): download NLTK data explicitly

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -291,11 +291,6 @@ jobs:
 
       - name: Download NLTK data
         run: |
-          # unstructured.nlp.tokenize auto-downloads these on first import
-          # (AUTO_DOWNLOAD_NLTK, quiet=True by default), which failed silently
-          # in CI and surfaced as 22 unrelated-looking pytest failures instead
-          # of a clear error -- see #257. Downloading explicitly here, with
-          # real output, makes a real failure loud instead of silent.
           .venv/bin/python -m nltk.downloader averaged_perceptron_tagger_eng punkt_tab
 
       - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -273,7 +273,21 @@ jobs:
         run: python -m pip install uv
         working-directory: .
 
-      - name: Install dependencies and run tests
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -e .[test]
+
+      - name: Download NLTK data
+        run: |
+          # unstructured.nlp.tokenize auto-downloads these on first import
+          # (AUTO_DOWNLOAD_NLTK, quiet=True by default), which failed silently
+          # in CI and surfaced as 22 unrelated-looking pytest failures instead
+          # of a clear error -- see #257. Downloading explicitly here, with
+          # real output, makes a real failure loud instead of silent.
+          .venv/bin/python -m nltk.downloader averaged_perceptron_tagger_eng punkt_tab
+
+      - name: Run tests
         env:
           # Explicit env vars, not just memgraph-toolbox's Python-level
           # defaults: LightRAG's own storage backends (exercised by
@@ -284,10 +298,7 @@ jobs:
           MEMGRAPH_PASSWORD: ""
           MEMGRAPH_DATABASE: memgraph
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          uv venv
-          uv pip install -e .[test]
-          .venv/bin/python -m pytest .
+        run: .venv/bin/python -m pytest .
 
   test-agent-context-graph:
     needs: changes

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,7 @@ on:
       - "context-graph/actions-graph/**"
       - "context-graph/agent-context-graph/**"
       - "context-graph/sessions-graph/**"
+      - ".github/workflows/tests.yaml"
   pull_request:
     paths:
       - "memgraph-toolbox/**"
@@ -25,6 +26,7 @@ on:
       - "context-graph/actions-graph/**"
       - "context-graph/agent-context-graph/**"
       - "context-graph/sessions-graph/**"
+      - ".github/workflows/tests.yaml"
 
 jobs:
   changes:
@@ -50,34 +52,43 @@ jobs:
           filters: |
             memgraph-toolbox:
               - 'memgraph-toolbox/**'
+              - '.github/workflows/tests.yaml'
             mcp-memgraph:
               - 'integrations/mcp-memgraph/**'
               - 'memgraph-toolbox/**'
+              - '.github/workflows/tests.yaml'
             langchain-memgraph:
               - 'integrations/langchain-memgraph/**'
               - 'memgraph-toolbox/**'
+              - '.github/workflows/tests.yaml'
             lightrag-memgraph:
               - 'integrations/lightrag-memgraph/**'
               - 'memgraph-toolbox/**'
+              - '.github/workflows/tests.yaml'
             unstructured2graph:
               - 'unstructured2graph/**'
               - 'memgraph-toolbox/**'
+              - '.github/workflows/tests.yaml'
             agent-context-graph:
               - 'context-graph/agent-context-graph/**'
+              - '.github/workflows/tests.yaml'
             skills-graph:
               - 'context-graph/skills-graph/**'
               - 'context-graph/agent-context-graph/**'
               - 'memgraph-toolbox/**'
+              - '.github/workflows/tests.yaml'
             actions-graph:
               - 'context-graph/actions-graph/**'
               - 'context-graph/agent-context-graph/**'
               - 'memgraph-toolbox/**'
+              - '.github/workflows/tests.yaml'
             sessions-graph:
               - 'context-graph/sessions-graph/**'
               - 'context-graph/actions-graph/**'
               - 'context-graph/agent-context-graph/**'
               - 'unstructured2graph/**'
               - 'memgraph-toolbox/**'
+              - '.github/workflows/tests.yaml'
 
   test-memgraph-toolbox:
     needs: changes


### PR DESCRIPTION
## Summary

Fixes #257.

`unstructured.nlp.tokenize` auto-downloads `averaged_perceptron_tagger_eng` and `punkt_tab` on first import (`AUTO_DOWNLOAD_NLTK`, defaults to on, `quiet=True`). In the `test-unstructured2graph` CI job this wasn't succeeding, and since `quiet=True` suppresses `nltk.download()`'s own diagnostic output, the failure was silent — it only surfaced later as 22 unrelated-looking pytest failures (`LookupError` deep inside `unstructured`'s text-partitioning path via `pos_tag`/`contains_verb`), not as a clear "download failed" error.

Splits the previous single `Install dependencies and run tests` step into three: **Install dependencies**, **Download NLTK data** (new — explicit `python -m nltk.downloader averaged_perceptron_tagger_eng punkt_tab`, no `quiet` flag), and **Run tests**. If the download ever fails again, this step now fails loudly on its own instead of masquerading as broken test logic across 22 different test failures.

**What I couldn't pin down**: the exact reason the silent auto-download wasn't succeeding *in CI specifically*. I verified the download mechanism itself works fine given a real network path — reproduced it locally against a fully isolated `HOME` (no pre-existing `nltk_data`, matching CI's fresh-runner conditions) and it succeeded cleanly. So this doesn't look like a fundamental incompatibility with the `nltk<3.10` pin from #251, more likely a runner-specific network/timing hiccup. Either way, the actual problem — a silent failure surfacing as 22 confusing, unrelated-looking test failures — is fixed regardless of the exact CI-side trigger, and any future recurrence will now fail loudly on its own step.

## Test plan
- [x] Reproduced the CI job's exact command sequence locally (`uv venv` → `uv pip install -e .[test]` → download → `pytest .`) in a from-scratch venv with an isolated `HOME`, faithfully simulating a fresh runner with no cached NLTK data.
- [x] Full suite passes: 74 passed, 1 skipped, against a live Memgraph + real OpenAI calls.
- [x] YAML validated; diff scoped to only the `test-unstructured2graph` job's steps.