### PR TITLE
agent-context-graph: entry_points-based runtime plugin registry

### DIFF
--- a/context-graph/agent-context-graph/README.md
+++ b/context-graph/agent-context-graph/README.md
@@ -406,29 +406,30 @@ class MyRuntimeAdapter(RuntimeAdapter):
 
 ### Adding a New Command-Hook Runtime Adapter
 
-The pattern above fits **in-process** runtimes — something that calls your Python code directly (an SDK callback, an embedded framework). **Command-hook** runtimes are different: the harness invokes an external command with a JSON payload on stdin (Claude Code, Codex), rather than calling into your process. That needs three extra pieces beyond `RuntimeAdapter` itself, all shown in full in `adapters/claude_code.py` and `adapters/codex.py`:
+The pattern above fits **in-process** runtimes — something that calls your Python code directly (an SDK callback, an embedded framework). **Command-hook** runtimes are different: the harness invokes an external command with a JSON payload on stdin (Claude Code, Codex), rather than calling into your process.
 
-1. **A payload translator.** Same idea as `RuntimeAdapter.get_runtime_hooks()`, but the input is the harness's raw JSON payload (read from stdin) rather than a native callback. Map each of the harness's hook event names to the matching `Event` subclass and call `link.emit(...)` — see `ClaudeCodeHooksAdapter._events_from_payload` for the full mapping.
-2. **A hook-config generator.** A plain function that builds whatever config shape the harness expects for wiring hooks (a `hooks.json`-style block, a plugin manifest, ...), pointing every hook at your CLI entry point. See `build_hooks_config` in `adapters/claude_code.py`.
-3. **A CLI entry point.** Reads one JSON payload from stdin (`load_payload`), constructs an `AgentLink` with the requested connectors, feeds the payload through your adapter, and — if the harness expects one — writes a JSON response to stdout (`response_for_payload`). This is what the generated hook config actually invokes.
+Three pieces beyond `RuntimeAdapter` itself, exactly as `adapters/claude_code.py` and `adapters/codex.py` implement them:
 
-Skeleton:
+1. **A payload translator.** Same idea as `RuntimeAdapter.get_runtime_hooks()`, but the input is the harness's raw JSON payload rather than a native callback. Map each of the harness's hook event names to the matching `Event` subclass and call `link.emit(...)`.
+2. **A hook-config generator** (`build_hooks_config(command)`). Builds whatever config shape the harness expects for wiring hooks, pointing every hook at your CLI entry point.
+3. **A response function** (`response_for_payload(payload)`). Returns the JSON the harness expects back on stdout, or `None`.
+
+The stdin-loading, connector-construction, and CLI-argument-parsing scaffolding around those three pieces is **shared** — `hooks/runner.py`'s `run_hook(plugin, argv)` does that for every registered runtime, so a new adapter doesn't write its own `main()` at all. Register your runtime as a **plugin** and the generic runner (plus `bootstrap`/`doctor`/`hook run`/`hook init`) picks it up automatically — no changes to `agent-context-graph` itself:
 
 ```python
-import json
-import sys
+# my_package/adapter.py
+from dataclasses import dataclass
 
-from agent_context_graph.link import AgentLink
 from agent_context_graph.protocols import RuntimeAdapter
 
 
 class MyCommandHookAdapter(RuntimeAdapter):
-    def __init__(self, link: AgentLink, session_id: str | None = None):
+    def __init__(self, link, session_id: str | None = None):
         self._link = link
         self._session_id = session_id
 
     def get_runtime_hooks(self):
-        return build_hooks_config("my-adapter hook run")
+        return build_hooks_config("my-runtime hook run my-runtime")
 
     def handle_payload(self, payload: dict) -> None:
         for event in self._events_from_payload(payload):
@@ -439,21 +440,43 @@ class MyCommandHookAdapter(RuntimeAdapter):
         ...
 
 
-def build_hooks_config(command: str) -> dict:
-    # Return whatever config format your harness expects, every hook
-    # pointing at `command`.
+def build_hooks_config(command: str, *, timeout: int = 30) -> dict:
+    # Return whatever config format your harness expects, every hook pointing at `command`.
     ...
 
 
-def main() -> int:
-    payload = json.loads(sys.stdin.read() or "{}")
-    link = AgentLink()
-    # ... add_connector(...) per --connector flags, as in claude_code.py's create_link
-    MyCommandHookAdapter(link).handle_payload(payload)
-    return 0
+def response_for_payload(payload: dict) -> dict | None:
+    # Return the JSON your harness expects back, or None.
+    ...
+
+
+@dataclass(frozen=True)
+class MyRuntimePlugin:
+    name: str = "my-runtime"
+    adapter_class: type = MyCommandHookAdapter
+
+    def response_for_payload(self, payload: dict) -> dict | None:
+        return response_for_payload(payload)
+
+    def build_hooks_config(self, command: str, *, timeout: int = 30) -> dict:
+        return build_hooks_config(command, timeout=timeout)
+
+    # init(project_dir, connectors, **kwargs) is optional -- omit it if your
+    # runtime has no project-local hook-config file to generate (matching
+    # ClaudeCodeHooksAdapter's own plugin, which doesn't define one yet).
+
+
+PLUGIN = MyRuntimePlugin()
 ```
 
-Note: `claude_code.py` and `codex.py` currently duplicate the stdin-loading/connector-construction/CLI-runner scaffolding rather than sharing a helper module for it (flagged in a `# TODO` in `codex.py`) — a third adapter is a good trigger to finally extract that shared plumbing, but isn't required to add one today.
+Then register it in your own package's `pyproject.toml` — this is the entire integration, no fork or PR against this repo required:
+
+```toml
+[project.entry-points."agent_context_graph.runtimes"]
+my-runtime = "my_package.adapter:PLUGIN"
+```
+
+Once installed, `agent-context-graph bootstrap --runtime my-runtime`, `doctor --runtime my-runtime`, `hook run my-runtime`, and `hook init my-runtime` (if `init` is implemented) all work exactly like the built-in Codex and Claude Code plugins — see `runtime_plugin.py` for the full protocol and `pyproject.toml`'s own `[project.entry-points."agent_context_graph.runtimes"]` for how Codex/Claude Code register themselves.
 
 ### Adding a New Graph Component
 

--- a/context-graph/agent-context-graph/pyproject.toml
+++ b/context-graph/agent-context-graph/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
 [project.scripts]
 agent-context-graph = "agent_context_graph.cli:main"
 
+[project.entry-points."agent_context_graph.runtimes"]
+codex = "agent_context_graph.adapters.codex:PLUGIN"
+claude-code = "agent_context_graph.adapters.claude_code:PLUGIN"
+
 [project.optional-dependencies]
 claude = [
     "claude-agent-sdk>=0.1.0",

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/claude_code.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/claude_code.py
@@ -7,10 +7,7 @@ the common Event protocol used by AgentLink.
 
 from __future__ import annotations
 
-import argparse
-import json
-import os
-import sys
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from agent_context_graph.events import (
@@ -23,13 +20,14 @@ from agent_context_graph.events import (
     ToolEndEvent,
     ToolStartEvent,
 )
-from agent_context_graph.link import AgentLink
+from agent_context_graph.hooks.runner import create_link, load_payload  # noqa: F401 (re-exported for callers)
 from agent_context_graph.protocols import RuntimeAdapter
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Sequence
 
     from agent_context_graph.events import Event
+    from agent_context_graph.link import AgentLink
 
 _SOURCE = "claude-code"
 _DEFAULT_COMMAND = "agent-context-graph hook run claude-code"
@@ -239,46 +237,6 @@ def build_hooks_config(command: str, *, timeout: int = 30) -> dict[str, list[dic
     return config
 
 
-def load_payload(stream: Any | None = None) -> dict[str, Any]:
-    """Read one Claude Code hook payload from a text stream."""
-    if stream is None:
-        stream = sys.stdin
-    raw = stream.read()
-    if not raw.strip():
-        return {}
-    payload = json.loads(raw)
-    if not isinstance(payload, dict):
-        msg = "Claude Code hook payload must be a JSON object"
-        raise TypeError(msg)
-    return payload
-
-
-def create_link(connector_names: Iterable[str] = (), *, memgraph_env: dict[str, str] | None = None) -> AgentLink:
-    """Create an AgentLink with optional connectors named by CLI/config.
-
-    Args:
-        connector_names: Which graph connectors to attach.
-        memgraph_env: Resolved Memgraph connection dict (keys: MEMGRAPH_URL,
-            MEMGRAPH_USER, MEMGRAPH_PASSWORD, MEMGRAPH_DATABASE).  When None,
-            connectors fall back to their own default resolution.
-    """
-    link = AgentLink()
-    for connector_name in connector_names:
-        normalized = connector_name.strip().replace("-", "_")
-        if not normalized:
-            continue
-        if normalized == "skills_graph":
-            _add_skills_graph_connector(link, memgraph_env)
-        elif normalized == "actions_graph":
-            _add_actions_graph_connector(link, memgraph_env)
-        elif normalized == "sessions_graph":
-            _add_sessions_graph_connector(link, memgraph_env)
-        else:
-            msg = f"Unsupported connector: {connector_name}"
-            raise ValueError(msg)
-    return link
-
-
 def response_for_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     """Return hook JSON response, when Claude Code benefits from one."""
     hook_event_name = payload.get("hook_event_name")
@@ -287,133 +245,32 @@ def response_for_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+@dataclass(frozen=True)
+class _ClaudeCodePlugin:
+    """Registered under the ``agent_context_graph.runtimes`` entry point as ``PLUGIN``.
+
+    No ``init`` -- Claude Code project-local hook setup isn't implemented yet
+    (see ``hooks/cli.py``'s generic ``_init`` dispatch, which reports that
+    clearly rather than assuming every runtime supports it).
+    """
+
+    name: str = "claude-code"
+    adapter_class: type[RuntimeAdapter] = ClaudeCodeHooksAdapter
+
+    def response_for_payload(self, payload: dict[str, Any]) -> dict[str, Any] | None:
+        return response_for_payload(payload)
+
+    def build_hooks_config(self, command: str, *, timeout: int = 30) -> dict[str, Any]:
+        return build_hooks_config(command, timeout=timeout)
+
+
+PLUGIN = _ClaudeCodePlugin()
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Bridge Claude Code hooks to agent-context-graph.")
-    parser.add_argument(
-        "--connector",
-        action="append",
-        default=None,
-        help="Graph connector to enable. Currently supported: skills-graph, actions-graph, sessions-graph.",
-    )
-    parser.add_argument(
-        "--session-id",
-        default=None,
-        help="Override the session id from the Claude Code hook payload.",
-    )
-    parser.add_argument(
-        "--memgraph-url",
-        default=None,
-        help="Memgraph Bolt URL. Overrides config file value.",
-    )
-    parser.add_argument(
-        "--memgraph-user",
-        default=None,
-        help="Memgraph username. Overrides config file value.",
-    )
-    parser.add_argument(
-        "--memgraph-password",
-        default=None,
-        help="Memgraph password. Overrides config file value.",
-    )
-    parser.add_argument(
-        "--memgraph-database",
-        default=None,
-        help="Memgraph database. Overrides config file value.",
-    )
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Return a non-zero status if the hook payload cannot be recorded.",
-    )
-    args = parser.parse_args(argv)
+    from agent_context_graph.hooks.runner import run_hook
 
-    connector_names = args.connector
-    if connector_names is None:
-        connector_names = _connectors_from_env()
-
-    # Resolve Memgraph connection: CLI flag > config file > default.
-    from agent_context_graph.adapters._identity import resolve_memgraph_env
-
-    memgraph_env = resolve_memgraph_env(
-        url=args.memgraph_url,
-        user=args.memgraph_user,
-        password=args.memgraph_password,
-        database=args.memgraph_database,
-    )
-
-    payload: dict[str, Any] = {}
-    try:
-        payload = load_payload()
-        link = create_link(connector_names, memgraph_env=memgraph_env)
-        adapter = ClaudeCodeHooksAdapter(link, session_id=args.session_id)
-        adapter.handle_payload(payload)
-        response = response_for_payload(payload)
-        if response is not None:
-            print(json.dumps(response))
-    except Exception as exc:
-        if args.strict or os.environ.get("AGENT_CONTEXT_GRAPH_CLAUDE_CODE_STRICT") == "1":
-            raise
-        response = response_for_payload(payload)
-        if response is not None:
-            print(json.dumps(response))
-        _debug_log(f"agent-context-graph Claude Code hook skipped: {exc}")
-    return 0
-
-
-def _add_skills_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
-    try:
-        from skills_graph import SkillGraph
-        from skills_graph.connector import SkillGraphConnector
-    except ImportError as exc:
-        msg = "skills-graph is required for the skills-graph Claude Code connector"
-        raise ImportError(msg) from exc
-
-    kwargs = _memgraph_kwargs(memgraph_env)
-    graph = SkillGraph(**kwargs)
-    link.add_connector(SkillGraphConnector(graph))
-
-
-def _add_sessions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
-    try:
-        from sessions_graph import SessionsGraph
-        from sessions_graph.connector import SessionsGraphConnector
-    except ImportError as exc:
-        msg = "sessions-graph is required for the sessions-graph Claude Code connector"
-        raise ImportError(msg) from exc
-
-    kwargs = _memgraph_kwargs(memgraph_env)
-    graph = SessionsGraph(**kwargs)
-    link.add_connector(SessionsGraphConnector(graph))
-
-
-def _add_actions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
-    try:
-        from actions_graph import ActionsGraph
-        from actions_graph.connector import ActionsGraphConnector
-    except ImportError as exc:
-        msg = "actions-graph is required for the actions-graph Claude Code connector"
-        raise ImportError(msg) from exc
-
-    kwargs = _memgraph_kwargs(memgraph_env)
-    graph = ActionsGraph(**kwargs)
-    link.add_connector(ActionsGraphConnector(graph))
-
-
-def _memgraph_kwargs(memgraph_env: dict[str, str] | None) -> dict[str, str]:
-    """Convert resolved memgraph env dict to kwargs for graph component constructors."""
-    if memgraph_env is None:
-        return {}
-    return {
-        "url": memgraph_env["MEMGRAPH_URL"],
-        "username": memgraph_env["MEMGRAPH_USER"],
-        "password": memgraph_env["MEMGRAPH_PASSWORD"],
-        "database": memgraph_env["MEMGRAPH_DATABASE"],
-    }
-
-
-def _connectors_from_env() -> list[str]:
-    value = os.environ.get("AGENT_CONTEXT_GRAPH_CLAUDE_CODE_CONNECTORS", "")
-    return [part.strip() for part in value.split(",") if part.strip()]
+    return run_hook(PLUGIN, argv)
 
 
 def _metadata_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -462,11 +319,6 @@ def _resolve_user_id(payload: dict[str, Any]) -> str | None:
     from agent_context_graph.adapters._identity import resolve_user_id
 
     return resolve_user_id(payload)
-
-
-def _debug_log(message: str) -> None:
-    if os.environ.get("AGENT_CONTEXT_GRAPH_CLAUDE_CODE_DEBUG") == "1":
-        print(message, file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/codex.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/codex.py
@@ -7,10 +7,12 @@ common Event protocol used by AgentLink.
 
 from __future__ import annotations
 
-import argparse
 import json
 import os
+import shlex
+import shutil
 import sys
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from agent_context_graph.events import (
@@ -20,13 +22,16 @@ from agent_context_graph.events import (
     ToolEndEvent,
     ToolStartEvent,
 )
-from agent_context_graph.link import AgentLink
+from agent_context_graph.hooks.runner import create_link, load_payload  # noqa: F401 (re-exported for callers)
 from agent_context_graph.protocols import RuntimeAdapter
+from memgraph_toolbox.api.memgraph import MEMGRAPH_ENV_KEYS, memgraph_env
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Sequence
+    from pathlib import Path
 
     from agent_context_graph.events import Event
+    from agent_context_graph.link import AgentLink
 
 _SOURCE = "codex"
 _DEFAULT_COMMAND = "agent-context-graph hook run codex"
@@ -38,11 +43,6 @@ _SUPPORTED_HOOKS = (
     "PermissionRequest",
     "Stop",
 )
-
-# TODO: When adding Claude Code command hooks, extract the shared stdin
-# loading, connector construction, and CLI runner into a command-hook helper
-# module. Keep product-specific payload mapping and stdout response semantics
-# in each runtime adapter.
 
 
 class CodexHooksAdapter(RuntimeAdapter):
@@ -173,46 +173,6 @@ def build_hooks_config(command: str, *, timeout: int = 30) -> dict[str, list[dic
     return config
 
 
-def load_payload(stream: Any | None = None) -> dict[str, Any]:
-    """Read one Codex hook payload from a text stream."""
-    if stream is None:
-        stream = sys.stdin
-    raw = stream.read()
-    if not raw.strip():
-        return {}
-    payload = json.loads(raw)
-    if not isinstance(payload, dict):
-        msg = "Codex hook payload must be a JSON object"
-        raise TypeError(msg)
-    return payload
-
-
-def create_link(connector_names: Iterable[str] = (), *, memgraph_env: dict[str, str] | None = None) -> AgentLink:
-    """Create an AgentLink with optional connectors named by CLI/config.
-
-    Args:
-        connector_names: Which graph connectors to attach.
-        memgraph_env: Resolved Memgraph connection dict (keys: MEMGRAPH_URL,
-            MEMGRAPH_USER, MEMGRAPH_PASSWORD, MEMGRAPH_DATABASE).  When None,
-            connectors fall back to their own default resolution.
-    """
-    link = AgentLink()
-    for connector_name in connector_names:
-        normalized = connector_name.strip().replace("-", "_")
-        if not normalized:
-            continue
-        if normalized == "skills_graph":
-            _add_skills_graph_connector(link, memgraph_env)
-        elif normalized == "actions_graph":
-            _add_actions_graph_connector(link, memgraph_env)
-        elif normalized == "sessions_graph":
-            _add_sessions_graph_connector(link, memgraph_env)
-        else:
-            msg = f"Unsupported connector: {connector_name}"
-            raise ValueError(msg)
-    return link
-
-
 def response_for_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     """Return hook JSON response, when Codex expects one."""
     if payload.get("hook_event_name") == "Stop":
@@ -220,133 +180,104 @@ def response_for_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def init(project_dir: Path, connectors: list[str], **kwargs: Any) -> None:
+    """Generate a private Codex hook config (``.codex/config.toml`` + ``.codex/hooks.json``).
+
+    Extracted from what was ``hooks/cli.py``'s ``_init_codex`` -- kwargs mirror
+    its former CLI flags: hook_command, memgraph_url/user/password/database,
+    setup_schema, timeout, force.
+    """
+    hook_command = kwargs.get("hook_command")
+    timeout = kwargs.get("timeout", 30)
+    force = kwargs.get("force", False)
+    setup_schema = kwargs.get("setup_schema", False)
+
+    codex_dir = project_dir / ".codex"
+    config_path = codex_dir / "config.toml"
+    hooks_path = codex_dir / "hooks.json"
+
+    existing = [path for path in (config_path, hooks_path) if path.exists()]
+    if existing and not force:
+        names = ", ".join(str(path) for path in existing)
+        msg = f"Refusing to overwrite existing Codex config: {names} (pass force=True to replace)"
+        raise FileExistsError(msg)
+
+    resolved_memgraph_env = memgraph_env(
+        url=kwargs.get("memgraph_url"),
+        username=kwargs.get("memgraph_user"),
+        password=kwargs.get("memgraph_password"),
+        database=kwargs.get("memgraph_database"),
+    )
+
+    if hook_command is None:
+        executable = shutil.which("agent-context-graph")
+        base = [executable] if executable else [sys.executable, "-m", "agent_context_graph.cli"]
+        command_parts = [*base, "hook", "run", "codex"]
+        for connector in connectors:
+            command_parts.extend(["--connector", connector])
+        hook_command = shlex.join(command_parts)
+
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("[features]\ncodex_hooks = true\n", encoding="utf-8")
+    hooks_path.write_text(
+        json.dumps({"hooks": build_hooks_config(hook_command, timeout=timeout)}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    if setup_schema:
+        previous = {key: os.environ.get(key) for key in MEMGRAPH_ENV_KEYS}
+        os.environ.update(resolved_memgraph_env)
+        try:
+            for connector in connectors:
+                normalized = connector.strip().replace("-", "_")
+                if normalized == "skills_graph":
+                    from skills_graph import SkillGraph
+
+                    SkillGraph().setup()
+                elif normalized == "actions_graph":
+                    from actions_graph import ActionsGraph
+
+                    ActionsGraph().setup()
+        finally:
+            for key, value in previous.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    print(f"Wrote {config_path}")
+    print(f"Wrote {hooks_path}")
+    print(f"Memgraph URL: {resolved_memgraph_env['MEMGRAPH_URL']}")
+    print(f"Memgraph database: {resolved_memgraph_env['MEMGRAPH_DATABASE']}")
+    secret = resolved_memgraph_env["MEMGRAPH_PASSWORD"]
+    masked = hook_command.replace(shlex.quote(secret), "'****'").replace(secret, "****") if secret else hook_command
+    print(f"Hook command: {masked}")
+
+
+@dataclass(frozen=True)
+class _CodexPlugin:
+    """Registered under the ``agent_context_graph.runtimes`` entry point as ``PLUGIN``."""
+
+    name: str = "codex"
+    adapter_class: type[RuntimeAdapter] = CodexHooksAdapter
+
+    def response_for_payload(self, payload: dict[str, Any]) -> dict[str, Any] | None:
+        return response_for_payload(payload)
+
+    def build_hooks_config(self, command: str, *, timeout: int = 30) -> dict[str, Any]:
+        return build_hooks_config(command, timeout=timeout)
+
+    def init(self, project_dir: Path, connectors: list[str], **kwargs: Any) -> None:
+        init(project_dir, connectors, **kwargs)
+
+
+PLUGIN = _CodexPlugin()
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Bridge OpenAI Codex hooks to agent-context-graph.")
-    parser.add_argument(
-        "--connector",
-        action="append",
-        default=None,
-        help="Graph connector to enable. Currently supported: skills-graph, actions-graph, sessions-graph.",
-    )
-    parser.add_argument(
-        "--session-id",
-        default=None,
-        help="Override the session id from the Codex hook payload.",
-    )
-    parser.add_argument(
-        "--memgraph-url",
-        default=None,
-        help="Memgraph Bolt URL. Overrides config file value.",
-    )
-    parser.add_argument(
-        "--memgraph-user",
-        default=None,
-        help="Memgraph username. Overrides config file value.",
-    )
-    parser.add_argument(
-        "--memgraph-password",
-        default=None,
-        help="Memgraph password. Overrides config file value.",
-    )
-    parser.add_argument(
-        "--memgraph-database",
-        default=None,
-        help="Memgraph database. Overrides config file value.",
-    )
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Return a non-zero status if the hook payload cannot be recorded.",
-    )
-    args = parser.parse_args(argv)
+    from agent_context_graph.hooks.runner import run_hook
 
-    connector_names = args.connector
-    if connector_names is None:
-        connector_names = _connectors_from_env()
-
-    # Resolve Memgraph connection: CLI flag > config file > default.
-    from agent_context_graph.adapters._identity import resolve_memgraph_env
-
-    memgraph_env = resolve_memgraph_env(
-        url=args.memgraph_url,
-        user=args.memgraph_user,
-        password=args.memgraph_password,
-        database=args.memgraph_database,
-    )
-
-    payload: dict[str, Any] = {}
-    try:
-        payload = load_payload()
-        link = create_link(connector_names, memgraph_env=memgraph_env)
-        adapter = CodexHooksAdapter(link, session_id=args.session_id)
-        adapter.handle_payload(payload)
-        response = response_for_payload(payload)
-        if response is not None:
-            print(json.dumps(response))
-    except Exception as exc:
-        if args.strict or os.environ.get("AGENT_CONTEXT_GRAPH_CODEX_STRICT") == "1":
-            raise
-        response = response_for_payload(payload)
-        if response is not None:
-            print(json.dumps(response))
-        _debug_log(f"agent-context-graph Codex hook skipped: {exc}")
-    return 0
-
-
-def _add_skills_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
-    try:
-        from skills_graph import SkillGraph
-        from skills_graph.connector import SkillGraphConnector
-    except ImportError as exc:
-        msg = "skills-graph is required for the skills-graph Codex connector"
-        raise ImportError(msg) from exc
-
-    kwargs = _memgraph_kwargs(memgraph_env)
-    graph = SkillGraph(**kwargs)
-    link.add_connector(SkillGraphConnector(graph))
-
-
-def _add_sessions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
-    try:
-        from sessions_graph import SessionsGraph
-        from sessions_graph.connector import SessionsGraphConnector
-    except ImportError as exc:
-        msg = "sessions-graph is required for the sessions-graph Codex connector"
-        raise ImportError(msg) from exc
-
-    kwargs = _memgraph_kwargs(memgraph_env)
-    graph = SessionsGraph(**kwargs)
-    link.add_connector(SessionsGraphConnector(graph))
-
-
-def _add_actions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
-    try:
-        from actions_graph import ActionsGraph
-        from actions_graph.connector import ActionsGraphConnector
-    except ImportError as exc:
-        msg = "actions-graph is required for the actions-graph Codex connector"
-        raise ImportError(msg) from exc
-
-    kwargs = _memgraph_kwargs(memgraph_env)
-    graph = ActionsGraph(**kwargs)
-    link.add_connector(ActionsGraphConnector(graph))
-
-
-def _memgraph_kwargs(memgraph_env: dict[str, str] | None) -> dict[str, str]:
-    """Convert resolved memgraph env dict to kwargs for graph component constructors."""
-    if memgraph_env is None:
-        return {}
-    return {
-        "url": memgraph_env["MEMGRAPH_URL"],
-        "username": memgraph_env["MEMGRAPH_USER"],
-        "password": memgraph_env["MEMGRAPH_PASSWORD"],
-        "database": memgraph_env["MEMGRAPH_DATABASE"],
-    }
-
-
-def _connectors_from_env() -> list[str]:
-    value = os.environ.get("AGENT_CONTEXT_GRAPH_CODEX_CONNECTORS", "")
-    return [part.strip() for part in value.split(",") if part.strip()]
+    return run_hook(PLUGIN, argv)
 
 
 def _metadata_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -400,11 +331,6 @@ def _resolve_user_id(payload: dict[str, Any]) -> str | None:
     from agent_context_graph.adapters._identity import resolve_user_id
 
     return resolve_user_id(payload)
-
-
-def _debug_log(message: str) -> None:
-    if os.environ.get("AGENT_CONTEXT_GRAPH_CODEX_DEBUG") == "1":
-        print(message, file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/context-graph/agent-context-graph/src/agent_context_graph/cli.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/cli.py
@@ -164,10 +164,12 @@ def _config(argv: list[str]) -> int:
 
 
 def _bootstrap(argv: list[str]) -> int:
+    from agent_context_graph.hooks.runtime_plugin import load_runtime_plugins
+
     parser = argparse.ArgumentParser(description="Install and verify Agent Context Graph runtime dependencies.")
     parser.add_argument(
         "--runtime",
-        choices=["codex", "claude-code"],
+        choices=sorted(load_runtime_plugins()),
         required=True,
         help="Runtime hook adapter to bootstrap.",
     )
@@ -308,10 +310,12 @@ def _bootstrap(argv: list[str]) -> int:
 
 
 def _doctor(argv: list[str]) -> int:
+    from agent_context_graph.hooks.runtime_plugin import load_runtime_plugins
+
     parser = argparse.ArgumentParser(description="Check Agent Context Graph runtime hook setup.")
     parser.add_argument(
         "--runtime",
-        choices=["codex", "claude-code"],
+        choices=sorted(load_runtime_plugins()),
         default="claude-code",
         help="Runtime hook adapter to smoke test.",
     )
@@ -476,17 +480,12 @@ def _check_connector(connector_name: str) -> dict[str, object]:
 
 def _check_runtime(runtime: str, connectors: list[str]) -> dict[str, object]:
     try:
-        if runtime == "codex":
-            from agent_context_graph.adapters.codex import CodexHooksAdapter, create_link
+        from agent_context_graph.hooks.runner import create_link
+        from agent_context_graph.hooks.runtime_plugin import get_runtime_plugin
 
-            adapter_cls = CodexHooksAdapter
-        else:
-            from agent_context_graph.adapters.claude_code import ClaudeCodeHooksAdapter, create_link
-
-            adapter_cls = ClaudeCodeHooksAdapter
-
+        plugin = get_runtime_plugin(runtime)
         link = create_link(connectors)
-        adapter = adapter_cls(link)
+        adapter = plugin.adapter_class(link)
         adapter.handle_payload({"hook_event_name": "Stop", "session_id": "doctor"})
         return {"name": f"runtime:{runtime}", "ok": True, "detail": "strict hook smoke passed"}
     except Exception as exc:

--- a/context-graph/agent-context-graph/src/agent_context_graph/hooks/cli.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/hooks/cli.py
@@ -3,15 +3,9 @@
 from __future__ import annotations
 
 import argparse
-import json
-import os
-import shlex
-import shutil
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-from memgraph_toolbox.api.memgraph import MEMGRAPH_ENV_KEYS, memgraph_env
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -21,13 +15,12 @@ _HELP = """usage: agent-context-graph hook <command> [options]
 Bridge agent command hooks to agent-context-graph.
 
 Commands:
-  init codex   Generate private Codex hook config.
-  run codex    Run the OpenAI Codex command-hook adapter.
-  run claude-code
-               Run the Claude Code command-hook adapter.
+  init <runtime>   Generate a runtime's private hook config, if it supports one.
+  run <runtime>    Run a runtime's command-hook adapter.
 
-Runtimes:
-  claude-code  Claude Code command hooks.
+Runtimes are discovered via the `agent_context_graph.runtimes` entry point --
+run `agent-context-graph hook run --help` (or see `runtime_plugin.py`) to see
+what's registered in this environment.
 """
 
 
@@ -61,19 +54,16 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 def _run_runtime(runtime: str, runtime_args: list[str]) -> int:
-    if runtime == "codex":
-        from agent_context_graph.adapters.codex import main as codex_main
+    from agent_context_graph.hooks.runner import run_hook
+    from agent_context_graph.hooks.runtime_plugin import UnknownRuntimeError, get_runtime_plugin
 
-        return codex_main(runtime_args)
+    try:
+        plugin = get_runtime_plugin(runtime)
+    except UnknownRuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
 
-    if runtime in {"claude-code", "claude_code"}:
-        from agent_context_graph.adapters.claude_code import main as claude_code_main
-
-        return claude_code_main(runtime_args)
-
-    print(f"Unknown hook runtime: {runtime}", file=sys.stderr)
-    print(_HELP)
-    return 2
+    return run_hook(plugin, runtime_args)
 
 
 def _init(argv: list[str]) -> int:
@@ -81,168 +71,83 @@ def _init(argv: list[str]) -> int:
         print("usage: agent-context-graph hook init <runtime> [options]", file=sys.stderr)
         return 2
 
-    runtime = argv[0]
-    if runtime == "codex":
-        return _init_codex(argv[1:])
+    from agent_context_graph.hooks.runtime_plugin import UnknownRuntimeError, get_runtime_plugin
 
-    if runtime in {"claude-code", "claude_code"}:
-        print("Claude Code hook setup is not implemented yet.", file=sys.stderr)
+    runtime, init_argv = argv[0], argv[1:]
+    try:
+        plugin = get_runtime_plugin(runtime)
+    except UnknownRuntimeError as exc:
+        print(str(exc), file=sys.stderr)
         return 2
 
-    print(f"Unknown hook runtime for init: {runtime}", file=sys.stderr)
-    return 2
+    init = getattr(plugin, "init", None)
+    if init is None:
+        print(f"{plugin.name} hook setup is not implemented yet.", file=sys.stderr)
+        return 2
+
+    return _run_generic_init(plugin.name, init, init_argv)
 
 
-def _init_codex(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(description="Generate private OpenAI Codex hook config.")
+def _run_generic_init(runtime_name: str, init: Any, argv: list[str]) -> int:
+    """Parse the shared ``hook init`` flags and delegate to *init*.
+
+    The flag set (project dir, connectors, hook command override, Memgraph
+    overrides, schema setup, timeout, force) is generic across runtimes; each
+    plugin's own ``init`` interprets only the kwargs it needs.
+    """
+    parser = argparse.ArgumentParser(description=f"Generate a private {runtime_name} hook config.")
     parser.add_argument(
         "--connector",
         action="append",
         default=None,
-        help="Graph connector to enable. Defaults to skills-graph.",
+        help="Graph connector to enable. Defaults to skills-graph, actions-graph, sessions-graph.",
     )
     parser.add_argument(
         "--project-dir",
         default=".",
-        help="Project directory where .codex config should be generated.",
+        help="Project directory where the runtime's config should be generated.",
     )
     parser.add_argument(
         "--hook-command",
         default=None,
-        help="Full command to place in hooks.json. Defaults to this installed CLI.",
+        help="Full command to place in the runtime's hook config. Defaults to this installed CLI.",
     )
+    parser.add_argument("--memgraph-url", default=None, help="Memgraph Bolt URL for the hook command.")
+    parser.add_argument("--memgraph-user", default=None, help="Memgraph username for the hook command.")
     parser.add_argument(
-        "--memgraph-url",
-        default=None,
-        help="Memgraph Bolt URL for the hook command. Defaults to MEMGRAPH_URL or bolt://localhost:7687.",
+        "--memgraph-password", default=None, help="Memgraph password for --setup-schema. Never written to disk."
     )
-    parser.add_argument(
-        "--memgraph-user",
-        default=None,
-        help="Memgraph username for the hook command. Defaults to MEMGRAPH_USER or empty.",
-    )
-    parser.add_argument(
-        "--memgraph-password",
-        default=None,
-        help="Memgraph password for --setup-schema. Never written to hooks.json.",
-    )
-    parser.add_argument(
-        "--memgraph-database",
-        default=None,
-        help="Memgraph database for the hook command. Defaults to MEMGRAPH_DATABASE or memgraph.",
-    )
+    parser.add_argument("--memgraph-database", default=None, help="Memgraph database for the hook command.")
     parser.add_argument(
         "--setup-schema",
         action="store_true",
         help="Connect to Memgraph now and initialize enabled graph connector schemas.",
     )
-    parser.add_argument(
-        "--timeout",
-        type=int,
-        default=30,
-        help="Codex hook timeout in seconds.",
-    )
-    parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Overwrite existing .codex/config.toml or .codex/hooks.json.",
-    )
+    parser.add_argument("--timeout", type=int, default=30, help="Hook timeout in seconds.")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing generated config.")
     args = parser.parse_args(argv)
 
     connectors = args.connector or ["skills-graph", "actions-graph", "sessions-graph"]
     project_dir = Path(args.project_dir).expanduser().resolve()
-    codex_dir = project_dir / ".codex"
-    config_path = codex_dir / "config.toml"
-    hooks_path = codex_dir / "hooks.json"
 
-    existing = [path for path in (config_path, hooks_path) if path.exists()]
-    if existing and not args.force:
-        names = ", ".join(str(path) for path in existing)
-        print(f"Refusing to overwrite existing Codex config: {names}", file=sys.stderr)
+    try:
+        init(
+            project_dir,
+            connectors,
+            hook_command=args.hook_command,
+            memgraph_url=args.memgraph_url,
+            memgraph_user=args.memgraph_user,
+            memgraph_password=args.memgraph_password,
+            memgraph_database=args.memgraph_database,
+            setup_schema=args.setup_schema,
+            timeout=args.timeout,
+            force=args.force,
+        )
+    except FileExistsError as exc:
+        print(str(exc), file=sys.stderr)
         print("Re-run with --force to replace generated files.", file=sys.stderr)
         return 1
-
-    from agent_context_graph.adapters.codex import build_hooks_config
-
-    memgraph_values = _memgraph_env_from_args(args)
-    hook_command = args.hook_command or _default_hook_command("codex", connectors)
-    codex_dir.mkdir(parents=True, exist_ok=True)
-    config_path.write_text("[features]\ncodex_hooks = true\n", encoding="utf-8")
-    hooks_path.write_text(
-        json.dumps({"hooks": build_hooks_config(hook_command, timeout=args.timeout)}, indent=2) + "\n",
-        encoding="utf-8",
-    )
-    if args.setup_schema:
-        _setup_connector_schemas(connectors, memgraph_values)
-
-    print(f"Wrote {config_path}")
-    print(f"Wrote {hooks_path}")
-    print(f"Memgraph URL: {memgraph_values['MEMGRAPH_URL']}")
-    print(f"Memgraph database: {memgraph_values['MEMGRAPH_DATABASE']}")
-    print(f"Hook command: {_mask_secret(hook_command, memgraph_values['MEMGRAPH_PASSWORD'])}")
     return 0
-
-
-def _default_hook_command(runtime: str, connectors: list[str]) -> str:
-    executable = shutil.which("agent-context-graph")
-    base = [executable] if executable else [sys.executable, "-m", "agent_context_graph.cli"]
-    args = [*base, "hook", "run", runtime]
-    for connector in connectors:
-        args.extend(["--connector", connector])
-    return shlex.join(args)
-
-
-def _memgraph_env_from_args(args: argparse.Namespace) -> dict[str, str]:
-    return memgraph_env(
-        url=args.memgraph_url,
-        username=args.memgraph_user,
-        password=args.memgraph_password,
-        database=args.memgraph_database,
-    )
-
-
-def _setup_connector_schemas(connectors: list[str], memgraph_env: dict[str, str]) -> None:
-    previous = {key: os.environ.get(key) for key in MEMGRAPH_ENV_KEYS}
-    os.environ.update(memgraph_env)
-    try:
-        for connector in connectors:
-            normalized = connector.strip().replace("-", "_")
-            if normalized == "skills_graph":
-                _setup_skills_graph_schema()
-            elif normalized == "actions_graph":
-                _setup_actions_graph_schema()
-    finally:
-        for key, value in previous.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
-
-
-def _setup_skills_graph_schema() -> None:
-    try:
-        from skills_graph import SkillGraph
-    except ImportError as exc:
-        msg = "skills-graph is required to initialize the skills-graph schema"
-        raise ImportError(msg) from exc
-
-    SkillGraph().setup()
-
-
-def _setup_actions_graph_schema() -> None:
-    try:
-        from actions_graph import ActionsGraph
-    except ImportError as exc:
-        msg = "actions-graph is required to initialize the actions-graph schema"
-        raise ImportError(msg) from exc
-
-    ActionsGraph().setup()
-
-
-def _mask_secret(value: str, secret: str) -> str:
-    if not secret:
-        return value
-    return value.replace(shlex.quote(secret), "'****'").replace(secret, "****")
 
 
 if __name__ == "__main__":

--- a/context-graph/agent-context-graph/src/agent_context_graph/hooks/runner.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/hooks/runner.py
@@ -1,0 +1,189 @@
+"""Generic command-hook CLI runner, shared by every registered runtime plugin.
+
+Every command-hook adapter (``adapters/codex.py``, ``adapters/claude_code.py``)
+used to duplicate this exact stdin-loading / connector-construction / run
+sequence, differing only in which adapter class to instantiate and a handful
+of env var names. This collapses that into one implementation driven by a
+``RuntimeCLIPlugin`` (see ``runtime_plugin.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import TYPE_CHECKING, Any
+
+from agent_context_graph.link import AgentLink
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from agent_context_graph.hooks.runtime_plugin import RuntimeCLIPlugin
+
+
+def load_payload(stream: Any | None = None) -> dict[str, Any]:
+    """Read one JSON hook payload from a text stream (stdin by default)."""
+    if stream is None:
+        stream = sys.stdin
+    raw = stream.read()
+    if not raw.strip():
+        return {}
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        msg = "Hook payload must be a JSON object"
+        raise TypeError(msg)
+    return payload
+
+
+def create_link(connector_names: Iterable[str] = (), *, memgraph_env: dict[str, str] | None = None) -> AgentLink:
+    """Create an AgentLink with optional connectors named by CLI/config.
+
+    Runtime-agnostic: connectors (skills-graph, actions-graph, sessions-graph)
+    are graph components, not tied to any particular runtime adapter.
+    """
+    link = AgentLink()
+    for connector_name in connector_names:
+        normalized = connector_name.strip().replace("-", "_")
+        if not normalized:
+            continue
+        if normalized == "skills_graph":
+            _add_skills_graph_connector(link, memgraph_env)
+        elif normalized == "actions_graph":
+            _add_actions_graph_connector(link, memgraph_env)
+        elif normalized == "sessions_graph":
+            _add_sessions_graph_connector(link, memgraph_env)
+        else:
+            msg = f"Unsupported connector: {connector_name}"
+            raise ValueError(msg)
+    return link
+
+
+def _env_prefix(runtime_name: str) -> str:
+    return "AGENT_CONTEXT_GRAPH_" + runtime_name.strip().replace("-", "_").upper()
+
+
+def _connectors_from_env(runtime_name: str) -> list[str]:
+    value = os.environ.get(f"{_env_prefix(runtime_name)}_CONNECTORS", "")
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _debug_log(runtime_name: str, message: str) -> None:
+    if os.environ.get(f"{_env_prefix(runtime_name)}_DEBUG") == "1":
+        print(message, file=sys.stderr)
+
+
+def run_hook(plugin: RuntimeCLIPlugin, argv: Sequence[str] | None = None) -> int:
+    """Read one hook payload from stdin, run it through *plugin*, print a response.
+
+    This is what ``agent-context-graph hook run <runtime>`` invokes: parse
+    the shared CLI flags, resolve Memgraph config, translate the payload via
+    ``plugin.adapter_class``, and write back whatever ``plugin.response_for_payload``
+    says the runtime expects -- identical flow for every registered runtime.
+    """
+    parser = argparse.ArgumentParser(description=f"Bridge {plugin.name} hooks to agent-context-graph.")
+    parser.add_argument(
+        "--connector",
+        action="append",
+        default=None,
+        help="Graph connector to enable. Currently supported: skills-graph, actions-graph, sessions-graph.",
+    )
+    parser.add_argument(
+        "--session-id",
+        default=None,
+        help="Override the session id from the hook payload.",
+    )
+    parser.add_argument("--memgraph-url", default=None, help="Memgraph Bolt URL. Overrides config file value.")
+    parser.add_argument("--memgraph-user", default=None, help="Memgraph username. Overrides config file value.")
+    parser.add_argument("--memgraph-password", default=None, help="Memgraph password. Overrides config file value.")
+    parser.add_argument("--memgraph-database", default=None, help="Memgraph database. Overrides config file value.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return a non-zero status if the hook payload cannot be recorded.",
+    )
+    args = parser.parse_args(argv)
+
+    connector_names = args.connector
+    if connector_names is None:
+        connector_names = _connectors_from_env(plugin.name)
+
+    from agent_context_graph.adapters._identity import resolve_memgraph_env
+
+    memgraph_env = resolve_memgraph_env(
+        url=args.memgraph_url,
+        user=args.memgraph_user,
+        password=args.memgraph_password,
+        database=args.memgraph_database,
+    )
+
+    payload: dict[str, Any] = {}
+    try:
+        payload = load_payload()
+        link = create_link(connector_names, memgraph_env=memgraph_env)
+        adapter = plugin.adapter_class(link, session_id=args.session_id)
+        adapter.handle_payload(payload)
+        response = plugin.response_for_payload(payload)
+        if response is not None:
+            print(json.dumps(response))
+    except Exception as exc:
+        strict_env = os.environ.get(f"{_env_prefix(plugin.name)}_STRICT") == "1"
+        if args.strict or strict_env:
+            raise
+        response = plugin.response_for_payload(payload)
+        if response is not None:
+            print(json.dumps(response))
+        _debug_log(plugin.name, f"agent-context-graph {plugin.name} hook skipped: {exc}")
+    return 0
+
+
+def _add_skills_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
+    try:
+        from skills_graph import SkillGraph
+        from skills_graph.connector import SkillGraphConnector
+    except ImportError as exc:
+        msg = "skills-graph is required for the skills-graph connector"
+        raise ImportError(msg) from exc
+
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = SkillGraph(**kwargs)
+    link.add_connector(SkillGraphConnector(graph))
+
+
+def _add_sessions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
+    try:
+        from sessions_graph import SessionsGraph
+        from sessions_graph.connector import SessionsGraphConnector
+    except ImportError as exc:
+        msg = "sessions-graph is required for the sessions-graph connector"
+        raise ImportError(msg) from exc
+
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = SessionsGraph(**kwargs)
+    link.add_connector(SessionsGraphConnector(graph))
+
+
+def _add_actions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:
+    try:
+        from actions_graph import ActionsGraph
+        from actions_graph.connector import ActionsGraphConnector
+    except ImportError as exc:
+        msg = "actions-graph is required for the actions-graph connector"
+        raise ImportError(msg) from exc
+
+    kwargs = _memgraph_kwargs(memgraph_env)
+    graph = ActionsGraph(**kwargs)
+    link.add_connector(ActionsGraphConnector(graph))
+
+
+def _memgraph_kwargs(memgraph_env: dict[str, str] | None) -> dict[str, str]:
+    """Convert resolved memgraph env dict to kwargs for graph component constructors."""
+    if memgraph_env is None:
+        return {}
+    return {
+        "url": memgraph_env["MEMGRAPH_URL"],
+        "username": memgraph_env["MEMGRAPH_USER"],
+        "password": memgraph_env["MEMGRAPH_PASSWORD"],
+        "database": memgraph_env["MEMGRAPH_DATABASE"],
+    }

--- a/context-graph/agent-context-graph/src/agent_context_graph/hooks/runtime_plugin.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/hooks/runtime_plugin.py
@@ -1,0 +1,73 @@
+"""Registry for command-hook runtime plugins.
+
+A command-hook runtime (Codex, Claude Code, ...) registers itself by exposing
+an object with this shape under the ``agent_context_graph.runtimes`` entry
+point group, in its own package's ``pyproject.toml``:
+
+    [project.entry-points."agent_context_graph.runtimes"]
+    codex = "agent_context_graph.adapters.codex:PLUGIN"
+
+No changes to agent-context-graph itself are needed to add a new runtime.
+"""
+
+from __future__ import annotations
+
+from importlib import metadata
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ENTRY_POINT_GROUP = "agent_context_graph.runtimes"
+
+
+@runtime_checkable
+class RuntimeCLIPlugin(Protocol):
+    """What a runtime must supply to be usable by agent-context-graph's CLI.
+
+    ``init`` is optional -- a runtime that has no project-local hook-config
+    file to generate (or hasn't implemented one yet) may omit it; callers
+    should use ``getattr(plugin, "init", None)`` rather than assume it exists.
+    """
+
+    name: str
+    adapter_class: type[Any]
+
+    def response_for_payload(self, payload: dict[str, Any]) -> dict[str, Any] | None: ...
+
+    def build_hooks_config(self, command: str, *, timeout: int = 30) -> dict[str, Any]: ...
+
+    def init(self, project_dir: Path, connectors: list[str], **kwargs: Any) -> None: ...
+
+
+class UnknownRuntimeError(KeyError):
+    """Raised when no plugin is registered for a requested runtime name."""
+
+
+def _normalize(name: str) -> str:
+    return name.strip().replace("_", "-")
+
+
+def load_runtime_plugins() -> dict[str, RuntimeCLIPlugin]:
+    """Discover every registered runtime plugin, keyed by its normalized ``name``."""
+    plugins: dict[str, RuntimeCLIPlugin] = {}
+    for entry_point in metadata.entry_points(group=_ENTRY_POINT_GROUP):
+        plugin = entry_point.load()
+        plugins[_normalize(plugin.name)] = plugin
+    return plugins
+
+
+def get_runtime_plugin(name: str) -> RuntimeCLIPlugin:
+    """Look up a registered runtime plugin by name.
+
+    Raises ``UnknownRuntimeError`` (listing what *is* registered) if none
+    matches -- the CLI catches this to print a clear error instead of a
+    traceback.
+    """
+    plugins = load_runtime_plugins()
+    normalized = _normalize(name)
+    if normalized not in plugins:
+        available = ", ".join(sorted(plugins)) or "(none registered)"
+        msg = f"Unknown runtime: {name!r}. Available: {available}"
+        raise UnknownRuntimeError(msg)
+    return plugins[normalized]

--- a/context-graph/agent-context-graph/tests/test_hook_cli.py
+++ b/context-graph/agent-context-graph/tests/test_hook_cli.py
@@ -288,7 +288,7 @@ def test_top_level_cli_bootstrap_accepts_zero_port(monkeypatch, capsys):
 
 
 def test_top_level_cli_setup_aliases_codex_init(tmp_path, monkeypatch):
-    monkeypatch.setattr("agent_context_graph.hooks.cli.shutil.which", lambda _: "/bin/agent-context-graph")
+    monkeypatch.setattr("agent_context_graph.adapters.codex.shutil.which", lambda _: "/bin/agent-context-graph")
 
     assert top_level_main(["setup", "codex", "--project-dir", str(tmp_path)]) == 0
 
@@ -327,7 +327,7 @@ def test_init_codex_writes_private_config(tmp_path, capsys):
 
 
 def test_init_codex_does_not_bake_memgraph_connection_into_hook_command(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr("agent_context_graph.hooks.cli.shutil.which", lambda _: "/bin/agent-context-graph")
+    monkeypatch.setattr("agent_context_graph.adapters.codex.shutil.which", lambda _: "/bin/agent-context-graph")
 
     assert (
         main(
@@ -363,7 +363,7 @@ def test_init_codex_does_not_bake_memgraph_connection_into_hook_command(tmp_path
 
 
 def test_init_codex_uses_memgraph_env_only_for_setup_schema(tmp_path, monkeypatch):
-    monkeypatch.setattr("agent_context_graph.hooks.cli.shutil.which", lambda _: "/bin/agent-context-graph")
+    monkeypatch.setattr("agent_context_graph.adapters.codex.shutil.which", lambda _: "/bin/agent-context-graph")
     captured = {}
 
     class _SkillGraph:
@@ -412,7 +412,7 @@ def test_init_codex_uses_memgraph_env_only_for_setup_schema(tmp_path, monkeypatc
 
 
 def test_init_codex_sets_up_actions_graph_schema(tmp_path, monkeypatch):
-    monkeypatch.setattr("agent_context_graph.hooks.cli.shutil.which", lambda _: "/bin/agent-context-graph")
+    monkeypatch.setattr("agent_context_graph.adapters.codex.shutil.which", lambda _: "/bin/agent-context-graph")
     captured = {}
 
     class _ActionsGraph:
@@ -447,7 +447,7 @@ def test_init_codex_sets_up_actions_graph_schema(tmp_path, monkeypatch):
 
 
 def test_init_codex_uses_memgraph_toolbox_env_helper(tmp_path, monkeypatch):
-    monkeypatch.setattr("agent_context_graph.hooks.cli.shutil.which", lambda _: "/bin/agent-context-graph")
+    monkeypatch.setattr("agent_context_graph.adapters.codex.shutil.which", lambda _: "/bin/agent-context-graph")
     monkeypatch.setenv("MEMGRAPH_URL", "bolt://env-memgraph:7687")
     monkeypatch.setenv("MEMGRAPH_DATABASE", "env-skills")
 

--- a/context-graph/agent-context-graph/tests/test_runtime_plugin.py
+++ b/context-graph/agent-context-graph/tests/test_runtime_plugin.py
@@ -1,0 +1,50 @@
+"""Tests for the runtime plugin registry (entry_points-based discovery)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_context_graph.hooks.runtime_plugin import (
+    UnknownRuntimeError,
+    get_runtime_plugin,
+    load_runtime_plugins,
+)
+
+
+def test_load_runtime_plugins_discovers_builtin_codex_and_claude_code():
+    plugins = load_runtime_plugins()
+
+    assert set(plugins) == {"codex", "claude-code"}
+    assert plugins["codex"].name == "codex"
+    assert plugins["claude-code"].name == "claude-code"
+
+
+def test_get_runtime_plugin_normalizes_underscores_and_hyphens():
+    assert get_runtime_plugin("claude_code").name == "claude-code"
+    assert get_runtime_plugin("claude-code").name == "claude-code"
+    assert get_runtime_plugin("codex").name == "codex"
+
+
+def test_get_runtime_plugin_raises_on_unknown_runtime():
+    with pytest.raises(UnknownRuntimeError, match="Unknown runtime: 'made-up'"):
+        get_runtime_plugin("made-up")
+
+
+def test_codex_plugin_exposes_full_protocol():
+    plugin = get_runtime_plugin("codex")
+
+    from agent_context_graph.adapters.codex import CodexHooksAdapter
+
+    assert plugin.adapter_class is CodexHooksAdapter
+    assert plugin.response_for_payload({"hook_event_name": "Stop"}) == {"continue": True}
+    assert "SessionStart" in plugin.build_hooks_config("some-command")
+    assert callable(plugin.init)
+
+
+def test_claude_code_plugin_has_no_init():
+    plugin = get_runtime_plugin("claude-code")
+
+    from agent_context_graph.adapters.claude_code import ClaudeCodeHooksAdapter
+
+    assert plugin.adapter_class is ClaudeCodeHooksAdapter
+    assert getattr(plugin, "init", None) is None


### PR DESCRIPTION
## Summary

- `bootstrap`/`doctor`/`setup <runtime>` and `hook run`/`init <runtime>` hardcoded a closed `choices=["codex", "claude-code"]` enum with if/else dispatch in three places (`cli.py`'s `_check_runtime`, `hooks/cli.py`'s `_run_runtime` and `_init`) -- a third-party package implementing its own `RuntimeAdapter` for a new harness had no way to get `bootstrap`/`doctor`/`setup` support without a code change here.
- Adds a `RuntimeCLIPlugin` protocol (`adapter_class`, `response_for_payload`, `build_hooks_config`, optional `init`) registered via the `agent_context_graph.runtimes` entry point group, resolved through `importlib.metadata.entry_points()` -- no registry file, no code changes to this package needed to add a runtime.
- Also extracts `hooks/runner.py`: `codex.py` and `claude_code.py`'s `main()` duplicated near-identical stdin-loading/connector-construction/CLI-argument logic (flagged by a pre-existing `# TODO` in `codex.py`), differing only in the adapter class and a few env var names. One generic `run_hook(plugin, argv)` now serves both, and any future runtime.
- Codex and Claude Code become the first two registered plugins (in this package's own `pyproject.toml`) rather than special-cased code paths -- Claude Code's plugin has no `init`, matching its pre-existing "not implemented yet" behavior, now expressed by simply omitting the optional protocol member instead of a hardcoded early-return.
- Extends the "Adding a New Command-Hook Runtime Adapter" README section (from the previous PR) with the registration story.

Implements the design from [Grilling: CLI plugin-discovery for custom runtime adapters](https://github.com/memgraph/ai-toolkit/issues/269), a child ticket of the Wayfinder map [Continuous memory organization for context-graph](https://github.com/memgraph/ai-toolkit/issues/259).

## Test plan

- [x] All 88 existing + new unit tests pass, unchanged in behavior (only monkeypatch targets moved, matching where the code moved to)
- [x] `ruff check` / `ruff format --check`
- [x] Smoke tested for real (not just unit tests): `hook run codex` with a live Stop payload, `hook run <unknown>` prints a clear "Unknown runtime" error listing what's registered, `hook init claude-code` still prints its pre-existing "not implemented yet" message, `hook init codex` writes real `.codex/config.toml`+`.codex/hooks.json`
- [x] `doctor --runtime codex` and `doctor --runtime claude-code` both pass their full check suite (including the new registry-based `runtime:` smoke check) against a live Memgraph instance
- [x] Verified the connector-check failure seen when Memgraph isn't at the default port is pre-existing on `main` too (unrelated to this change) by reproducing it against unmodified `main` via `git stash`