### PR TITLE
context-graph: test-graph-model — verify the graph model against a real Claude Code session (map #288)

### DIFF
--- a/.github/workflows/test-live-graph-model.yaml
+++ b/.github/workflows/test-live-graph-model.yaml
@@ -1,16 +1,17 @@
-name: Verify live subagent-nesting (manual)
+name: Test graph model against a live Claude Code session (manual)
 
 # Manual-trigger only, deliberately not on push/pull_request (map #288):
 # drives a real, billed Claude Code session, and subagent-spawning is
 # inherently non-deterministic (the model decides whether to delegate) -- a
 # bad fit for gating every PR. Run this deliberately when changing something
-# heavily around actions-graph's Agent node / SPAWNED inference rule (#277)
-# or agent-context-graph's Claude Code adapter.
+# heavily around actions-graph's Agent node / SPAWNED inference rule (#277),
+# skills-graph's Agent-scoped skill-usage attachment (#280), or
+# agent-context-graph's Claude Code adapter.
 on:
   workflow_dispatch: {}
 
 jobs:
-  verify-nesting:
+  test-graph-model:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -48,7 +49,7 @@ jobs:
       - name: Add workspace venv to PATH
         run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
-      - name: Run live subagent-nesting verification
+      - name: Run live graph-model verification
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: ./scripts/dev-memgraph.sh verify-nesting
+        run: ./scripts/dev-memgraph.sh test-graph-model

--- a/.github/workflows/test-live-graph-model.yaml
+++ b/.github/workflows/test-live-graph-model.yaml
@@ -1,11 +1,11 @@
 name: Test graph model against a live Claude Code session (manual)
 
-# Manual-trigger only, deliberately not on push/pull_request (map #288):
+# Manual-trigger only, deliberately not on push/pull_request:
 # drives a real, billed Claude Code session, and subagent-spawning is
 # inherently non-deterministic (the model decides whether to delegate) -- a
 # bad fit for gating every PR. Run this deliberately when changing something
-# heavily around actions-graph's Agent node / SPAWNED inference rule (#277),
-# skills-graph's Agent-scoped skill-usage attachment (#280), or
+# heavily around actions-graph's Agent node / SPAWNED inference rule,
+# skills-graph's Agent-scoped skill-usage attachment, or
 # agent-context-graph's Claude Code adapter.
 on:
   workflow_dispatch: {}

--- a/.github/workflows/verify-live-nesting.yaml
+++ b/.github/workflows/verify-live-nesting.yaml
@@ -1,0 +1,54 @@
+name: Verify live subagent-nesting (manual)
+
+# Manual-trigger only, deliberately not on push/pull_request (map #288):
+# drives a real, billed Claude Code session, and subagent-spawning is
+# inherently non-deterministic (the model decides whether to delegate) -- a
+# bad fit for gating every PR. Run this deliberately when changing something
+# heavily around actions-graph's Agent node / SPAWNED inference rule (#277)
+# or agent-context-graph's Claude Code adapter.
+on:
+  workflow_dispatch: {}
+
+jobs:
+  verify-nesting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: python -m pip install uv
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      # Populates the shared workspace .venv with agent-context-graph and the
+      # three connector packages' agent-context-graph extra -- the same
+      # combination `scripts/dev-memgraph.sh test` already relies on. Doing
+      # this explicitly (rather than a bare `uv sync`) is what makes
+      # `agent-context-graph hook run claude-code --connector ...` actually
+      # resolve real connectors instead of silently no-op'ing.
+      - name: Sync workspace environment
+        run: |
+          uv sync --package agent-context-graph
+          uv sync --package actions-graph --extra agent-context-graph
+          uv sync --package skills-graph --extra agent-context-graph
+          uv sync --package sessions-graph --extra agent-context-graph
+
+      # Puts this checkout's own workspace venv ahead of anything else on
+      # PATH -- a real, discovered-the-hard-way risk: a stale globally
+      # `uv tool install`ed agent-context-graph can otherwise shadow (or be
+      # shadowed by) this one, silently testing the wrong version of the code
+      # under review.
+      - name: Add workspace venv to PATH
+        run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Run live subagent-nesting verification
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: ./scripts/dev-memgraph.sh verify-nesting

--- a/context-graph/actions-graph/src/actions_graph/core.py
+++ b/context-graph/actions-graph/src/actions_graph/core.py
@@ -69,7 +69,7 @@ class ActionsGraph:
         # container key -> last action_id, where container key is ("session", session_id)
         # or ("agent", agent_id) -- FOLLOWED_BY is scoped per-container, not one flat chain.
         self._last_action_id: dict[tuple[str, str], str] = {}
-        # Verified against a real live Claude Code session (map #288): the tool
+        # Verified against a real live Claude Code session: the tool
         # that actually launches a subagent is named "Agent" in tool-call
         # payloads, not "Task" as originally assumed from docs alone. Keeping
         # both names since harness/version differences aren't fully known.
@@ -503,7 +503,7 @@ class ActionsGraph:
         return [self._row_to_agent(row) for row in rows]
 
     def _infer_spawning_action(self, session_id: str, agent_type: str) -> str | None:
-        """Infer which Action spawned a new Agent (the three-tier rule from #277).
+        """Infer which Action spawned a new Agent (the three-tier rule).
 
         Tier 1: filter open tool calls (no PostToolUse yet, not already linked
         to another Agent via SPAWNED) by agent-spawning tool name, anywhere in
@@ -859,12 +859,12 @@ class ActionsGraph:
     ) -> list[Action]:
         """Get all actions for a session, including those inside subagents.
 
-        Every Agent is directly session-reachable via HAS_AGENT (#278), so
-        this traverses both the session's own top-level actions and each
-        agent's actions -- at any nesting depth, since a nested agent still
-        gets its own direct HAS_AGENT from the session rather than chaining
-        through its spawning agent (#281: a flat single-hop match here would
-        silently drop all subagent activity).
+        Every Agent is directly session-reachable via HAS_AGENT, so this
+        traverses both the session's own top-level actions and each agent's
+        actions -- at any nesting depth, since a nested agent still gets its
+        own direct HAS_AGENT from the session rather than chaining through
+        its spawning agent (a flat single-hop match here would silently drop
+        all subagent activity).
 
         Args:
             session_id: Session ID

--- a/context-graph/actions-graph/src/actions_graph/core.py
+++ b/context-graph/actions-graph/src/actions_graph/core.py
@@ -69,7 +69,11 @@ class ActionsGraph:
         # container key -> last action_id, where container key is ("session", session_id)
         # or ("agent", agent_id) -- FOLLOWED_BY is scoped per-container, not one flat chain.
         self._last_action_id: dict[tuple[str, str], str] = {}
-        self.agent_spawning_tool_names: set[str] = {"Task"}
+        # Verified against a real live Claude Code session (map #288): the tool
+        # that actually launches a subagent is named "Agent" in tool-call
+        # payloads, not "Task" as originally assumed from docs alone. Keeping
+        # both names since harness/version differences aren't fully known.
+        self.agent_spawning_tool_names: set[str] = {"Agent", "Task"}
 
     # ------------------------------------------------------------------
     # Schema setup

--- a/context-graph/actions-graph/tests/test_e2e.py
+++ b/context-graph/actions-graph/tests/test_e2e.py
@@ -277,7 +277,7 @@ class TestAnalytics:
 
 
 class TestAgentOperations:
-    """Tests for the Agent node lifecycle, SPAWNED inference, and containment (#277/#278)."""
+    """Tests for the Agent node lifecycle, SPAWNED inference, and containment."""
 
     def test_start_and_end_agent(self, graph: ActionsGraph):
         session = Session(session_id="agent-lifecycle-session")
@@ -299,7 +299,7 @@ class TestAgentOperations:
         graph.create_session(session)
 
         # No open Task call exists -- SPAWNED can't be inferred, but HAS_AGENT
-        # must still exist so an ambiguous Agent stays reachable (#278).
+        # must still exist so an ambiguous Agent stays reachable.
         graph.start_agent(
             Agent(agent_id="agent-orphan", agent_type="Explore", session_id="unconditional-agent-session")
         )
@@ -328,7 +328,7 @@ class TestAgentOperations:
         assert rows[0]["c"] == 1
 
     def test_spawned_inference_matches_the_real_tool_name_agent_not_task(self, graph: ActionsGraph):
-        """Verified against a real live Claude Code session (map #288, 2026-08-17):
+        """Verified against a real live Claude Code session (2026-08-17):
         the tool that actually launches a subagent reports tool_name "Agent" in
         hook payloads -- "Task" is how Claude Code's CLI/UI refers to it, not
         what shows up in PreToolUse/PostToolUse. Locks in the fix to

--- a/context-graph/actions-graph/tests/test_e2e.py
+++ b/context-graph/actions-graph/tests/test_e2e.py
@@ -327,6 +327,31 @@ class TestAgentOperations:
         )
         assert rows[0]["c"] == 1
 
+    def test_spawned_inference_matches_the_real_tool_name_agent_not_task(self, graph: ActionsGraph):
+        """Verified against a real live Claude Code session (map #288, 2026-08-17):
+        the tool that actually launches a subagent reports tool_name "Agent" in
+        hook payloads -- "Task" is how Claude Code's CLI/UI refers to it, not
+        what shows up in PreToolUse/PostToolUse. Locks in the fix to
+        agent_spawning_tool_names so it can't silently regress back to "Task"-only."""
+        session = Session(session_id="spawn-real-tool-name-session")
+        graph.create_session(session)
+
+        spawning_call = graph.record_tool_call(
+            session_id="spawn-real-tool-name-session",
+            tool_name="Agent",
+            tool_input={"subagent_type": "Explore"},
+            tool_use_id="agent-tool-1",
+        )
+
+        graph.start_agent(Agent(agent_id="agent-3", agent_type="Explore", session_id="spawn-real-tool-name-session"))
+
+        rows = graph._db.query(
+            "MATCH (parent:Action {action_id: $action_id})-[:SPAWNED]->(a:Agent {agent_id: $agent_id}) "
+            "RETURN count(*) AS c",
+            params={"action_id": spawning_call.action_id, "agent_id": "agent-3"},
+        )
+        assert rows[0]["c"] == 1
+
     def test_spawned_inference_disambiguates_by_agent_type(self, graph: ActionsGraph):
         session = Session(session_id="spawn-disambiguate-session")
         graph.create_session(session)

--- a/scripts/dev-memgraph.sh
+++ b/scripts/dev-memgraph.sh
@@ -68,6 +68,15 @@ Commands:
   hooks-local        Point your REAL, live Claude Code plugin at the main container
                      (backs up your current ~/.config/context-graph/config.toml first).
   hooks-restore       Restore your real hook config from the hooks-local backup.
+  verify-nesting     Drive a real, non-interactive Claude Code session that spawns
+                     exactly one subagent, then assert the resulting graph shape
+                     (Session -HAS_AGENT-> Agent, the real spawning tool call
+                     -SPAWNED-> Agent, Agent -HAS_ACTION-> its own tool calls) is
+                     correct. Verifies #277's inference rule against a real
+                     session instead of synthetic e2e data. Needs ANTHROPIC_API_KEY
+                     (env, or .env at the repo root) and 'claude' + 'agent-context-graph'
+                     on PATH. Costs a real LLM call; Tier 1 only (one subagent,
+                     no concurrent-subagent disambiguation -- see issue #287).
   dogfood-env         Print export statements enabling auto_reconcile (true, automatic,
                      event-driven reconciliation on SESSION_END) for a claude session
                      launched afterward. Usage: eval \"\$(./scripts/dev-memgraph.sh dogfood-env)\" && claude
@@ -240,6 +249,21 @@ _resolve_openai_api_key() {
   [ -n "${OPENAI_API_KEY:-}" ]
 }
 
+# Resolves ANTHROPIC_API_KEY for cmd_verify_nesting: prefer whatever is
+# already in the environment, otherwise pull it from .env at the repo root.
+# Never prints the value anywhere.
+_resolve_anthropic_api_key() {
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    return 0
+  fi
+  local env_file="${REPO_ROOT}/.env"
+  if [ -f "${env_file}" ]; then
+    ANTHROPIC_API_KEY="$(grep -E '^ANTHROPIC_API_KEY=' "${env_file}" | head -1 | cut -d'=' -f2-)"
+    export ANTHROPIC_API_KEY
+  fi
+  [ -n "${ANTHROPIC_API_KEY:-}" ]
+}
+
 # Prints export statements for the vars SessionsGraphConnector's own
 # auto_reconcile fallback (SESSIONS_GRAPH_AUTO_RECONCILE) and the detached
 # reconcile subprocess it spawns actually need. Deliberately NOT something
@@ -395,6 +419,167 @@ cmd_hooks_restore() {
   agent-context-graph config show 2>/dev/null || true
 }
 
+# Verifies #277's SPAWNED subagent-nesting inference rule against a REAL
+# Claude Code session, not synthetic e2e data (map #288). Tier 1 only: one
+# subagent, no concurrent-subagent disambiguation (see issue #287).
+#
+# Generates its own self-contained hooks config (via claude_code.py's
+# build_hooks_config, with the same --connector flags the installed
+# marketplace plugin uses) rather than depending on that plugin already being
+# installed -- this needs to work unattended on a bare CI runner, not just a
+# dogfooding dev machine. Only the Memgraph *target* still goes through the
+# existing hooks-local/hooks-restore swap, shared with the installed plugin.
+cmd_verify_nesting() {
+  _container_up "${CONTAINER_NAME}" "${HOST_PORT}"
+
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "ERROR: claude is not on PATH." >&2
+    exit 1
+  fi
+  if ! command -v agent-context-graph >/dev/null 2>&1; then
+    echo "ERROR: agent-context-graph is not on PATH." >&2
+    echo "Install it first, e.g. via context-graph/plugins/agent-context-graph-claude/scripts/bootstrap.sh" >&2
+    exit 1
+  fi
+  if ! _resolve_anthropic_api_key; then
+    echo "ERROR: ANTHROPIC_API_KEY is not set and was not found in ${REPO_ROOT}/.env" >&2
+    echo "This drives a real Claude Code session and needs it." >&2
+    exit 1
+  fi
+
+  local settings_file
+  settings_file="$(mktemp -t verify-nesting-settings.XXXXXX.json)"
+  uv run --package agent-context-graph python3 - "${settings_file}" <<'PYEOF'
+import json
+import sys
+
+from agent_context_graph.adapters.claude_code import build_hooks_config
+
+# `uv run --package agent-context-graph agent-context-graph ...` rather than a
+# bare `agent-context-graph` -- a real, discovered-the-hard-way ambiguity: a
+# stale globally `uv tool install`ed copy can shadow (or be shadowed by) this
+# repo's own workspace venv on PATH, silently testing the wrong version of
+# this code. This form always resolves to the exact checkout being verified,
+# in CI or locally, regardless of what else is installed. --connector flags
+# match the installed marketplace plugin's own generated command
+# (context-graph-plugins/context-graph/*/hooks/hooks.json) -- without them,
+# `hook run` does nothing (a second real, silent gap this verification
+# tripped over).
+command = (
+    "uv run --package agent-context-graph agent-context-graph hook run claude-code "
+    "--connector skills-graph --connector actions-graph --connector sessions-graph"
+)
+with open(sys.argv[1], "w") as f:
+    json.dump({"hooks": build_hooks_config(command)}, f)
+PYEOF
+
+  # Only swap (and later restore) if hooks-local hasn't already been applied
+  # by the caller -- same convention cmd_hooks_local itself uses.
+  local we_swapped_hooks=0
+  if [ ! -f "${CONFIG_BACKUP}" ]; then
+    cmd_hooks_local
+    we_swapped_hooks=1
+  else
+    echo "Hook config already in local mode -- leaving as-is."
+  fi
+  if [ "${we_swapped_hooks}" -eq 1 ]; then
+    trap cmd_hooks_restore EXIT
+  fi
+
+  local session_id
+  session_id="$(uv run --package agent-context-graph python3 -c 'import uuid; print(uuid.uuid4())')"
+  echo "Driving a real Claude Code session (session_id=${session_id})..."
+
+  # Restricting the top-level session to ONLY the Task tool -- Claude Code's
+  # CLI/UI-facing name for subagent launch; it reports as tool_name "Agent" in
+  # the actual hook payloads, a real, non-obvious naming split this
+  # verification effort discovered -- forces genuine delegation: the model has
+  # no other way to accomplish anything, so it must spawn a subagent rather
+  # than maybe doing so.
+  local prompt="Use the Task tool to launch exactly one subagent (subagent_type: Explore) to search this repository for the string 'TODO' and report back a short summary of what it finds. Do not search yourself -- delegate the entire search to that one subagent."
+
+  local output_file
+  output_file="$(mktemp -t verify-nesting-output.XXXXXX.json)"
+  set +e
+  # Explicit cd: the hooks config's command embeds `uv run --package
+  # agent-context-graph ...`, which resolves relative to the hook
+  # subprocess's cwd -- which Claude Code sets to wherever `claude` itself
+  # was launched from. Must be $REPO_ROOT regardless of where this script
+  # was invoked from, or `uv run` won't find the workspace.
+  (cd "${REPO_ROOT}" && claude -p "${prompt}" \
+    --settings "${settings_file}" \
+    --setting-sources project \
+    --session-id "${session_id}" \
+    --output-format json \
+    --permission-mode bypassPermissions \
+    --allowedTools=Task) >"${output_file}" 2>&1
+  local claude_exit=$?
+  set -e
+
+  if [ "${claude_exit}" -ne 0 ]; then
+    echo "ERROR: claude exited with status ${claude_exit}:" >&2
+    cat "${output_file}" >&2
+    exit 1
+  fi
+
+  echo "Session complete. Checking graph shape for session_id=${session_id}..."
+  MEMGRAPH_URL="${LOCAL_MEMGRAPH_URL}" \
+    MEMGRAPH_USER="${LOCAL_MEMGRAPH_USER}" \
+    MEMGRAPH_PASSWORD="${LOCAL_MEMGRAPH_PASSWORD}" \
+    MEMGRAPH_DATABASE="${LOCAL_MEMGRAPH_DATABASE}" \
+    VERIFY_SESSION_ID="${session_id}" \
+    uv run --package actions-graph python3 - <<'PYEOF'
+import os
+import sys
+
+from actions_graph import ActionsGraph
+
+session_id = os.environ["VERIFY_SESSION_ID"]
+graph = ActionsGraph()
+
+checks = []
+
+session = graph.get_session(session_id)
+checks.append(("Session node exists", session is not None))
+
+agents = graph.get_session_agents(session_id) if session is not None else []
+checks.append(("HAS_AGENT: Session -> at least one Agent", len(agents) >= 1))
+
+spawned_ok = False
+has_action_ok = False
+if agents:
+    agent = agents[0]
+    rows = graph._db.query(
+        "MATCH (call:Action)-[:SPAWNED]->(:Agent {agent_id: $agent_id}) "
+        "RETURN call.tool_name AS tool_name",
+        params={"agent_id": agent.agent_id},
+    )
+    spawned_ok = len(rows) == 1 and rows[0]["tool_name"] in graph.agent_spawning_tool_names
+
+    action_rows = graph._db.query(
+        "MATCH (:Agent {agent_id: $agent_id})-[:HAS_ACTION]->(a:Action) RETURN count(a) AS c",
+        params={"agent_id": agent.agent_id},
+    )
+    has_action_ok = action_rows[0]["c"] >= 1
+
+checks.append(("SPAWNED: the real spawning tool call -> Agent", spawned_ok))
+checks.append(("HAS_ACTION: Agent -> its own tool calls", has_action_ok))
+
+print()
+all_ok = True
+for name, ok in checks:
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    all_ok = all_ok and ok
+
+print()
+if all_ok:
+    print("Tier 1 SPAWNED-inference verification PASSED against a real Claude Code session.")
+    sys.exit(0)
+print("Tier 1 SPAWNED-inference verification FAILED.")
+sys.exit(1)
+PYEOF
+}
+
 main() {
   local cmd="${1:-}"
   if [ "$#" -gt 0 ]; then
@@ -411,6 +596,7 @@ main() {
     dogfood-env) cmd_dogfood_env ;;
     hooks-local) cmd_hooks_local ;;
     hooks-restore) cmd_hooks_restore ;;
+    verify-nesting) cmd_verify_nesting ;;
     -h | --help | "") echo "$_HELP" ;;
     *)
       echo "Unknown command: $cmd" >&2

--- a/scripts/dev-memgraph.sh
+++ b/scripts/dev-memgraph.sh
@@ -76,12 +76,12 @@ Commands:
                      per-container FOLLOWED_BY chains (and that they never cross),
                      PARENT_OF (ToolCall->ToolResult) at both levels, USED_TOOL,
                      and USED_SKILL attaching to the Agent (not the Session).
-                     Verifies #277's inference rule and #280's skill-attachment
+                     Verifies the SPAWNED inference rule and the skill-attachment
                      rule against a real session instead of synthetic e2e data.
                      Needs ANTHROPIC_API_KEY (env, or .env at the repo root) and
                      'claude' + 'agent-context-graph' on PATH. Costs a real LLM
                      call; Tier 1 only (one subagent, no concurrent-subagent
-                     disambiguation -- see issue #287).
+                     disambiguation).
   dogfood-env         Print export statements enabling auto_reconcile (true, automatic,
                      event-driven reconciliation on SESSION_END) for a claude session
                      launched afterward. Usage: eval \"\$(./scripts/dev-memgraph.sh dogfood-env)\" && claude
@@ -425,10 +425,10 @@ cmd_hooks_restore() {
 }
 
 # Verifies a broad slice of the actions-graph/skills-graph model against a
-# REAL Claude Code session, not synthetic e2e data (map #288): #277's SPAWNED
-# subagent-nesting inference rule, #278's per-container HAS_ACTION/FOLLOWED_BY
-# containment, and #280's Agent-scoped skill-usage attachment. Tier 1 only:
-# one subagent, no concurrent-subagent disambiguation (see issue #287).
+# REAL Claude Code session, not synthetic e2e data: the SPAWNED subagent-
+# nesting inference rule, per-container HAS_ACTION/FOLLOWED_BY containment,
+# and Agent-scoped skill-usage attachment. Tier 1 only: one subagent, no
+# concurrent-subagent disambiguation.
 #
 # Generates its own self-contained hooks config (via claude_code.py's
 # build_hooks_config, with the same --connector flags the installed
@@ -504,7 +504,7 @@ PYEOF
   # no other way to accomplish anything, so it must spawn a subagent rather
   # than maybe doing so. The skill-file read is folded into the SAME subagent
   # call (rather than a second session) so this still costs exactly one LLM
-  # call while also exercising skills-graph's Agent-scoped USED_SKILL (#280).
+  # call while also exercising skills-graph's Agent-scoped USED_SKILL.
   local prompt="Use the Task tool to launch exactly one subagent (subagent_type: Explore) to do two things: (1) read the file skills/release/SKILL.md and note what it's for, and (2) search this repository for the string 'TODO'. Report back a short summary combining both. Do not do either yourself -- delegate the entire thing to that one subagent."
 
   local output_file
@@ -592,7 +592,7 @@ if len(agent_actions) >= 2:
         params={"ids": agent_ids},
     )
     followed_by_ok = rows[0]["c"] == len(agent_ids) - 1
-checks.append(("FOLLOWED_BY: Agent's own actions form one ordered chain (#278)", followed_by_ok))
+checks.append(("FOLLOWED_BY: Agent's own actions form one ordered chain", followed_by_ok))
 
 # FOLLOWED_BY: the top-level session's own chain never crosses into the Agent's.
 top_level_actions = db.query(
@@ -611,7 +611,7 @@ if agent and top_level_actions and agent_actions:
         params={"top_ids": top_ids, "agent_ids": agent_ids},
     )
     chain_separation_ok = rows[0]["c"] == 0
-checks.append(("FOLLOWED_BY: top-level chain never crosses into the Agent's chain (#278)", chain_separation_ok))
+checks.append(("FOLLOWED_BY: top-level chain never crosses into the Agent's chain", chain_separation_ok))
 
 # PARENT_OF: the spawning tool call itself resolves to its own ToolResult.
 parent_of_top_ok = False
@@ -645,7 +645,7 @@ if agent:
     used_tool_ok = rows[0]["c"] >= 1
 checks.append(("USED_TOOL: Agent's tool calls link to Tool nodes", used_tool_ok))
 
-# USED_SKILL (skills-graph, #280): attaches to the Agent, not the Session --
+# USED_SKILL (skills-graph): attaches to the Agent, not the Session --
 # reading skills/release/SKILL.md happened inside the subagent, so the
 # either-container design should route it there, not to the top-level Session.
 used_skill_agent_ok = False
@@ -661,7 +661,7 @@ if agent:
         params={"sid": session_id},
     )
     used_skill_session_absent_ok = session_rows[0]["c"] == 0
-checks.append(("USED_SKILL: attaches to the Agent, not the Session (#280)", used_skill_agent_ok))
+checks.append(("USED_SKILL: attaches to the Agent, not the Session", used_skill_agent_ok))
 checks.append(("USED_SKILL: correctly NOT also attached to the Session", used_skill_session_absent_ok))
 
 print()

--- a/scripts/dev-memgraph.sh
+++ b/scripts/dev-memgraph.sh
@@ -68,15 +68,20 @@ Commands:
   hooks-local        Point your REAL, live Claude Code plugin at the main container
                      (backs up your current ~/.config/context-graph/config.toml first).
   hooks-restore       Restore your real hook config from the hooks-local backup.
-  verify-nesting     Drive a real, non-interactive Claude Code session that spawns
-                     exactly one subagent, then assert the resulting graph shape
-                     (Session -HAS_AGENT-> Agent, the real spawning tool call
-                     -SPAWNED-> Agent, Agent -HAS_ACTION-> its own tool calls) is
-                     correct. Verifies #277's inference rule against a real
-                     session instead of synthetic e2e data. Needs ANTHROPIC_API_KEY
-                     (env, or .env at the repo root) and 'claude' + 'agent-context-graph'
-                     on PATH. Costs a real LLM call; Tier 1 only (one subagent,
-                     no concurrent-subagent disambiguation -- see issue #287).
+  test-graph-model    Drive a real, non-interactive Claude Code session that spawns
+                     exactly one subagent and reads one real skill file, then assert
+                     a broad slice of the actions-graph/skills-graph model against
+                     the result: Session-HAS_AGENT->Agent, the real spawning tool
+                     call-SPAWNED->Agent, Agent-HAS_ACTION->its own tool calls,
+                     per-container FOLLOWED_BY chains (and that they never cross),
+                     PARENT_OF (ToolCall->ToolResult) at both levels, USED_TOOL,
+                     and USED_SKILL attaching to the Agent (not the Session).
+                     Verifies #277's inference rule and #280's skill-attachment
+                     rule against a real session instead of synthetic e2e data.
+                     Needs ANTHROPIC_API_KEY (env, or .env at the repo root) and
+                     'claude' + 'agent-context-graph' on PATH. Costs a real LLM
+                     call; Tier 1 only (one subagent, no concurrent-subagent
+                     disambiguation -- see issue #287).
   dogfood-env         Print export statements enabling auto_reconcile (true, automatic,
                      event-driven reconciliation on SESSION_END) for a claude session
                      launched afterward. Usage: eval \"\$(./scripts/dev-memgraph.sh dogfood-env)\" && claude
@@ -249,7 +254,7 @@ _resolve_openai_api_key() {
   [ -n "${OPENAI_API_KEY:-}" ]
 }
 
-# Resolves ANTHROPIC_API_KEY for cmd_verify_nesting: prefer whatever is
+# Resolves ANTHROPIC_API_KEY for cmd_test_graph_model: prefer whatever is
 # already in the environment, otherwise pull it from .env at the repo root.
 # Never prints the value anywhere.
 _resolve_anthropic_api_key() {
@@ -419,9 +424,11 @@ cmd_hooks_restore() {
   agent-context-graph config show 2>/dev/null || true
 }
 
-# Verifies #277's SPAWNED subagent-nesting inference rule against a REAL
-# Claude Code session, not synthetic e2e data (map #288). Tier 1 only: one
-# subagent, no concurrent-subagent disambiguation (see issue #287).
+# Verifies a broad slice of the actions-graph/skills-graph model against a
+# REAL Claude Code session, not synthetic e2e data (map #288): #277's SPAWNED
+# subagent-nesting inference rule, #278's per-container HAS_ACTION/FOLLOWED_BY
+# containment, and #280's Agent-scoped skill-usage attachment. Tier 1 only:
+# one subagent, no concurrent-subagent disambiguation (see issue #287).
 #
 # Generates its own self-contained hooks config (via claude_code.py's
 # build_hooks_config, with the same --connector flags the installed
@@ -429,7 +436,7 @@ cmd_hooks_restore() {
 # installed -- this needs to work unattended on a bare CI runner, not just a
 # dogfooding dev machine. Only the Memgraph *target* still goes through the
 # existing hooks-local/hooks-restore swap, shared with the installed plugin.
-cmd_verify_nesting() {
+cmd_test_graph_model() {
   _container_up "${CONTAINER_NAME}" "${HOST_PORT}"
 
   if ! command -v claude >/dev/null 2>&1; then
@@ -448,7 +455,7 @@ cmd_verify_nesting() {
   fi
 
   local settings_file
-  settings_file="$(mktemp -t verify-nesting-settings.XXXXXX.json)"
+  settings_file="$(mktemp -t test-graph-model-settings.XXXXXX.json)"
   uv run --package agent-context-graph python3 - "${settings_file}" <<'PYEOF'
 import json
 import sys
@@ -495,11 +502,13 @@ PYEOF
   # the actual hook payloads, a real, non-obvious naming split this
   # verification effort discovered -- forces genuine delegation: the model has
   # no other way to accomplish anything, so it must spawn a subagent rather
-  # than maybe doing so.
-  local prompt="Use the Task tool to launch exactly one subagent (subagent_type: Explore) to search this repository for the string 'TODO' and report back a short summary of what it finds. Do not search yourself -- delegate the entire search to that one subagent."
+  # than maybe doing so. The skill-file read is folded into the SAME subagent
+  # call (rather than a second session) so this still costs exactly one LLM
+  # call while also exercising skills-graph's Agent-scoped USED_SKILL (#280).
+  local prompt="Use the Task tool to launch exactly one subagent (subagent_type: Explore) to do two things: (1) read the file skills/release/SKILL.md and note what it's for, and (2) search this repository for the string 'TODO'. Report back a short summary combining both. Do not do either yourself -- delegate the entire thing to that one subagent."
 
   local output_file
-  output_file="$(mktemp -t verify-nesting-output.XXXXXX.json)"
+  output_file="$(mktemp -t test-graph-model-output.XXXXXX.json)"
   set +e
   # Explicit cd: the hooks config's command embeds `uv run --package
   # agent-context-graph ...`, which resolves relative to the hook
@@ -536,6 +545,7 @@ from actions_graph import ActionsGraph
 
 session_id = os.environ["VERIFY_SESSION_ID"]
 graph = ActionsGraph()
+db = graph._db
 
 checks = []
 
@@ -545,25 +555,114 @@ checks.append(("Session node exists", session is not None))
 agents = graph.get_session_agents(session_id) if session is not None else []
 checks.append(("HAS_AGENT: Session -> at least one Agent", len(agents) >= 1))
 
+agent = agents[0] if agents else None
+
+spawning_action_id = None
 spawned_ok = False
-has_action_ok = False
-if agents:
-    agent = agents[0]
-    rows = graph._db.query(
+if agent:
+    rows = db.query(
         "MATCH (call:Action)-[:SPAWNED]->(:Agent {agent_id: $agent_id}) "
-        "RETURN call.tool_name AS tool_name",
+        "RETURN call.tool_name AS tool_name, call.action_id AS action_id",
         params={"agent_id": agent.agent_id},
     )
     spawned_ok = len(rows) == 1 and rows[0]["tool_name"] in graph.agent_spawning_tool_names
+    if rows:
+        spawning_action_id = rows[0]["action_id"]
+checks.append(("SPAWNED: the real spawning tool call -> Agent", spawned_ok))
 
-    action_rows = graph._db.query(
-        "MATCH (:Agent {agent_id: $agent_id})-[:HAS_ACTION]->(a:Action) RETURN count(a) AS c",
+agent_actions = []
+if agent:
+    agent_actions = db.query(
+        "MATCH (:Agent {agent_id: $agent_id})-[:HAS_ACTION]->(a:Action) "
+        "RETURN a.action_id AS action_id, a.action_type AS action_type, a.timestamp AS ts "
+        "ORDER BY ts",
         params={"agent_id": agent.agent_id},
     )
-    has_action_ok = action_rows[0]["c"] >= 1
+checks.append(("HAS_ACTION: Agent -> its own tool calls", len(agent_actions) >= 1))
 
-checks.append(("SPAWNED: the real spawning tool call -> Agent", spawned_ok))
-checks.append(("HAS_ACTION: Agent -> its own tool calls", has_action_ok))
+# FOLLOWED_BY: the agent's own actions form one connected chain (n-1 edges
+# purely within that set -- order doesn't need re-deriving, connectivity does).
+followed_by_ok = True
+if len(agent_actions) >= 2:
+    agent_ids = [a["action_id"] for a in agent_actions]
+    rows = db.query(
+        "MATCH (a:Action)-[:FOLLOWED_BY]->(b:Action) "
+        "WHERE a.action_id IN $ids AND b.action_id IN $ids "
+        "RETURN count(*) AS c",
+        params={"ids": agent_ids},
+    )
+    followed_by_ok = rows[0]["c"] == len(agent_ids) - 1
+checks.append(("FOLLOWED_BY: Agent's own actions form one ordered chain (#278)", followed_by_ok))
+
+# FOLLOWED_BY: the top-level session's own chain never crosses into the Agent's.
+top_level_actions = db.query(
+    "MATCH (:Session {session_id: $sid})-[:HAS_ACTION]->(a:Action) RETURN a.action_id AS action_id",
+    params={"sid": session_id},
+)
+chain_separation_ok = True
+if agent and top_level_actions and agent_actions:
+    top_ids = [a["action_id"] for a in top_level_actions]
+    agent_ids = [a["action_id"] for a in agent_actions]
+    rows = db.query(
+        "MATCH (a:Action)-[:FOLLOWED_BY]->(b:Action) "
+        "WHERE (a.action_id IN $top_ids AND b.action_id IN $agent_ids) "
+        "   OR (a.action_id IN $agent_ids AND b.action_id IN $top_ids) "
+        "RETURN count(*) AS c",
+        params={"top_ids": top_ids, "agent_ids": agent_ids},
+    )
+    chain_separation_ok = rows[0]["c"] == 0
+checks.append(("FOLLOWED_BY: top-level chain never crosses into the Agent's chain (#278)", chain_separation_ok))
+
+# PARENT_OF: the spawning tool call itself resolves to its own ToolResult.
+parent_of_top_ok = False
+if spawning_action_id:
+    rows = db.query(
+        "MATCH (:Action {action_id: $aid})-[:PARENT_OF]->(:Action:ToolResult) RETURN count(*) AS c",
+        params={"aid": spawning_action_id},
+    )
+    parent_of_top_ok = rows[0]["c"] == 1
+checks.append(("PARENT_OF: the spawning tool call -> its ToolResult", parent_of_top_ok))
+
+# PARENT_OF: at least one of the Agent's own tool calls resolves the same way.
+parent_of_nested_ok = False
+nested_calls = [a["action_id"] for a in agent_actions if a["action_type"] == "tool_call"]
+if nested_calls:
+    rows = db.query(
+        "MATCH (:Action {action_id: $aid})-[:PARENT_OF]->(:Action:ToolResult) RETURN count(*) AS c",
+        params={"aid": nested_calls[0]},
+    )
+    parent_of_nested_ok = rows[0]["c"] == 1
+checks.append(("PARENT_OF: a nested tool call inside the Agent -> its ToolResult", parent_of_nested_ok))
+
+# USED_TOOL: the Agent's own tool calls link to real Tool nodes.
+used_tool_ok = False
+if agent:
+    rows = db.query(
+        "MATCH (:Agent {agent_id: $agent_id})-[:HAS_ACTION]->(:Action)-[:USED_TOOL]->(t:Tool) "
+        "RETURN count(DISTINCT t) AS c",
+        params={"agent_id": agent.agent_id},
+    )
+    used_tool_ok = rows[0]["c"] >= 1
+checks.append(("USED_TOOL: Agent's tool calls link to Tool nodes", used_tool_ok))
+
+# USED_SKILL (skills-graph, #280): attaches to the Agent, not the Session --
+# reading skills/release/SKILL.md happened inside the subagent, so the
+# either-container design should route it there, not to the top-level Session.
+used_skill_agent_ok = False
+used_skill_session_absent_ok = True
+if agent:
+    rows = db.query(
+        "MATCH (:Agent {agent_id: $agent_id})-[:USED_SKILL]->(sk:Skill) RETURN sk.name AS name",
+        params={"agent_id": agent.agent_id},
+    )
+    used_skill_agent_ok = len(rows) >= 1
+    session_rows = db.query(
+        "MATCH (:Session {session_id: $sid})-[:USED_SKILL]->(:Skill) RETURN count(*) AS c",
+        params={"sid": session_id},
+    )
+    used_skill_session_absent_ok = session_rows[0]["c"] == 0
+checks.append(("USED_SKILL: attaches to the Agent, not the Session (#280)", used_skill_agent_ok))
+checks.append(("USED_SKILL: correctly NOT also attached to the Session", used_skill_session_absent_ok))
 
 print()
 all_ok = True
@@ -573,9 +672,9 @@ for name, ok in checks:
 
 print()
 if all_ok:
-    print("Tier 1 SPAWNED-inference verification PASSED against a real Claude Code session.")
+    print("Graph-model verification PASSED against a real Claude Code session.")
     sys.exit(0)
-print("Tier 1 SPAWNED-inference verification FAILED.")
+print("Graph-model verification FAILED.")
 sys.exit(1)
 PYEOF
 }
@@ -596,7 +695,7 @@ main() {
     dogfood-env) cmd_dogfood_env ;;
     hooks-local) cmd_hooks_local ;;
     hooks-restore) cmd_hooks_restore ;;
-    verify-nesting) cmd_verify_nesting ;;
+    test-graph-model) cmd_test_graph_model ;;
     -h | --help | "") echo "$_HELP" ;;
     *)
       echo "Unknown command: $cmd" >&2


### PR DESCRIPTION
## Summary

Implements the destination of wayfinder map [#288](https://github.com/memgraph/ai-toolkit/issues/288): a repeatable way to verify, against a **real Claude Code session** (not synthetic e2e data), that a broad slice of the actions-graph/skills-graph model actually holds up.

- **`scripts/dev-memgraph.sh test-graph-model`** — drives a scripted, non-interactive `claude -p` session restricted to the Task tool (forcing genuine subagent delegation), where the one spawned subagent both reads a real `SKILL.md` file and searches the repo — one LLM session, eleven assertions:
  - `Session -[:HAS_AGENT]-> Agent`, `Action -[:SPAWNED]-> Agent` (the real spawning tool call), `Agent -[:HAS_ACTION]-> Action` (#277/#278)
  - `FOLLOWED_BY`: the subagent's own chain is correctly ordered, and never crosses into the top-level session's own separate chain (#278)
  - `PARENT_OF`: `ToolCall`→`ToolResult` correlation at both the top level and inside the subagent
  - `USED_TOOL`: the subagent's tool calls link to real `Tool` nodes
  - `USED_SKILL`: attaches to the `Agent`, not the `Session`, when the skill read happens inside a subagent (#280) — verified live for the first time
- **`.github/workflows/test-live-graph-model.yaml`** — manual `workflow_dispatch` job wrapping the same check. Deliberately not on every push/PR: it drives a real, billed LLM session, and subagent-spawning is inherently non-deterministic — worth having on tap for deliberate use when changing something heavily in this area, not a PR gate.

## Two real bugs found, not just tooling built

Running this against an actual live session (rather than reasoning from docs) surfaced two genuine, previously-unknown gaps:

1. `agent-context-graph hook run claude-code` silently does nothing without explicit `--connector skills-graph --connector actions-graph --connector sessions-graph` flags — undocumented outside the installed marketplace plugin's own generated command.
2. `actions-graph`'s `agent_spawning_tool_names` defaulted to `{"Task"}`, but real `PreToolUse`/`PostToolUse` hook payloads report the spawning tool as `tool_name: "Agent"` — `"Task"` is only how Claude Code's CLI/UI refers to it. This meant Tier 1 of #277's inference rule had **never actually matched anything against a real session**. Fixed to `{"Agent", "Task"}`, with a regression test locking in the real name. Correction posted directly to #277, since it invalidates that ticket's doc-derived assumption.

Also worked around a PATH ambiguity discovered along the way: a stale, globally `uv tool install`ed `agent-context-graph` can shadow this repo's own workspace source. The hook command now always resolves via `uv run --package agent-context-graph`, deterministically, regardless of what else is installed.

## Test plan

- [x] `scripts/dev-memgraph.sh test-graph-model` run against a real Claude Code session — all 11 checks passing (plus 3 earlier clean runs of the narrower pre-expansion check)
- [x] Full suite (55 tests) green via `scripts/dev-memgraph.sh test`
- [x] `ruff check` / `ruff format --check` clean
- [ ] CI workflow itself (`test-live-graph-model.yaml`) needs its first live `workflow_dispatch` trigger post-merge to fully validate the fresh-runner path (install steps, PATH wiring) — validated locally against every piece it depends on, but a GitHub-hosted runner run is the real proof