### PR TITLE
agent-context-graph: document why claude.py stays hooks-only

### DIFF
--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/claude.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/claude.py
@@ -3,6 +3,17 @@
 Translates Claude Agent SDK hook callbacks into the common Event protocol
 and forwards them to the AgentLink hub.
 
+Note: this adapter only wires up the ``hooks={...}`` callback API. The SDK's
+separate message-stream API (``query()``/``ClaudeSDKClient.receive_response()``,
+yielding ``UserMessage``/``AssistantMessage``) carries a genuine
+``parent_tool_use_id`` field that would let a subagent's spawning tool call be
+linked directly rather than inferred -- verified empirically, not just in
+docs. Deliberately not consumed here: doing so would make this one adapter
+strictly better than the other three (Claude Code, Codex, OpenAI Agents SDK),
+which have no equivalent field and stay on the general temporal/agent_type
+inference rule uniformly. Revisit only if that asymmetry becomes worth
+taking on.
+
 Usage::
 
     from agent_context_graph import AgentLink


### PR DESCRIPTION
## Summary

Resolves ticket [#283](https://github.com/memgraph/ai-toolkit/issues/283) on map [#275](https://github.com/memgraph/ai-toolkit/issues/275) (Harness-grounded graph model across the Context Graph family): should the Claude Agent SDK adapter (`adapters/claude.py`) also consume the SDK's message-stream API (`query()`/`ClaudeSDKClient.receive_response()`) to get a real, non-inferred `parent_tool_use_id` for subagent-spawning links?

**Decision: hold off.** The message-stream API does carry a genuine `parent_tool_use_id` (verified empirically, not just in docs) — but wiring it up would make this one adapter strictly better than the other three (Claude Code, Codex, OpenAI Agents SDK), which have no equivalent field and stay on the general temporal/`agent_type` inference rule from #277. Keeping all four adapters uniform for now; the message-stream path stays available as explicit future work if that asymmetry is ever worth taking on.

No code behavior changes — this is a doc-only PR, adding the rationale directly to `claude.py`'s module docstring so the gap doesn't read as an unnoticed oversight later.

## Test plan

- [x] `ruff check` / `ruff format --check` clean (docstring-only change, no logic touched)