### PR TITLE
context-graph: bump versions for release (subagent-nesting model + entry_points registry)

### DIFF
--- a/context-graph/actions-graph/pyproject.toml
+++ b/context-graph/actions-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "actions-graph"
-version = "0.1.2"
+version = "0.2.0"
 description = "Store and track LLM actions, tool calls, and sessions in Memgraph"
 readme = "README.md"
 license = { text = "MIT" }

--- a/context-graph/agent-context-graph/pyproject.toml
+++ b/context-graph/agent-context-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-context-graph"
-version = "0.1.9"
+version = "0.2.0"
 description = "Connect agent SDKs to context-graph components (actions-graph, skills-graph, etc.)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/context-graph/sessions-graph/pyproject.toml
+++ b/context-graph/sessions-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sessions-graph"
-version = "0.4.0"
+version = "0.5.0"
 description = "Cross-session memory store for agents, backed by Memgraph"
 readme = "README.md"
 license = { text = "MIT" }

--- a/context-graph/skills-graph/pyproject.toml
+++ b/context-graph/skills-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skills-graph"
-version = "0.1.3"
+version = "0.2.0"
 description = "Persist, retrieve and evolve AI skills in Memgraph"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "actions-graph"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "context-graph/actions-graph" }
 dependencies = [
     { name = "memgraph-toolbox" },
@@ -211,7 +211,7 @@ provides-extras = ["agent-context-graph", "claude-agent", "test"]
 
 [[package]]
 name = "agent-context-graph"
-version = "0.1.9"
+version = "0.2.0"
 source = { editable = "context-graph/agent-context-graph" }
 dependencies = [
     { name = "memgraph-toolbox" },
@@ -8341,7 +8341,7 @@ wheels = [
 
 [[package]]
 name = "sessions-graph"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "context-graph/sessions-graph" }
 dependencies = [
     { name = "memgraph-toolbox" },
@@ -8400,7 +8400,7 @@ wheels = [
 
 [[package]]
 name = "skills-graph"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "context-graph/skills-graph" }
 dependencies = [
     { name = "memgraph-toolbox" },


### PR DESCRIPTION
## Summary

PyPI has been stale for months relative to `main` — `actions-graph`, `skills-graph`, `sessions-graph`, and `agent-context-graph` haven't been released since before most of maps [#275](https://github.com/memgraph/ai-toolkit/issues/275)/[#288](https://github.com/memgraph/ai-toolkit/issues/288)'s work landed. Surfaced while checking whether [memgraph-platform#110](https://github.com/memgraph/memgraph-platform/pull/110) (the `ai-memory` demo, which `pip install`s these four unpinned) actually reflects the current Context Graph model — it doesn't, because the model itself was never published.

| Package | Old | New | What's new since last release |
|---|---|---|---|
| `actions-graph` | 0.1.2 | 0.2.0 | First-class `Agent` node model, `SPAWNED` inference rule, `HAS_AGENT` — all verified live against a real Claude Code session. Also the `agent_spawning_tool_names` default-name fix. |
| `skills-graph` | 0.1.3 | 0.2.0 | `USED_SKILL` attaches to the specific `Agent` (not just the flat `Session`) when skill usage happens inside a subagent. |
| `sessions-graph` | 0.4.0 | 0.5.0 | `reconcile_session()` now writes episodic `Session.summary`, plus config-propagation fixes to the reconcile subprocess. (0.4.0 itself was already unreleased — the ontology/label-promotion work from #248/#251.) |
| `agent-context-graph` | 0.1.9 | 0.2.0 | `entry_points`-based runtime plugin registry. (`main`'s `0.1.9` had already diverged from the last *published* `0.1.9` build without a version bump.) |

No code changes — version bumps only. Verified compatible with every internal consumer: all cross-package dependencies in this workspace use `>=` lower bounds with no upper bound, and `ai-memory.py`'s actual API calls were checked directly against current `main` and are unaffected (the Agent-node work is fully additive/either-container, not a breaking change).

## Next steps (after merge, not part of this PR)

Trigger the four `workflow_dispatch` release jobs (`release-actions-graph.yaml`, `release-skills-graph.yaml`, `release-sessions-graph.yaml`, `release-agent-context-graph.yaml`) against `main` to actually publish to PyPI.

## Test plan

- [x] `uv sync --all-packages --all-extras` resolves cleanly against the bumped versions
- [x] `ruff check` clean on all four packages
- [x] `uv.lock` diff is exactly the four version bumps, nothing else