### PR TITLE
context-graph: single-command installer for Claude Code

### DIFF
--- a/.github/workflows/test-context-graph-install.yaml
+++ b/.github/workflows/test-context-graph-install.yaml
@@ -1,0 +1,38 @@
+name: Test context-graph install.sh (manual)
+
+# Manual-trigger only, deliberately not on push/pull_request: this drives real
+# external state on the runner -- installs the Claude Code CLI, registers the
+# real memgraph/ai-toolkit marketplace, and installs the published
+# context-graph plugin from it -- rather than anything scoped to this
+# checkout. That's intentional: the point is verifying the actual onboarding
+# path a new user hits, not the PR's diff in isolation. Run this deliberately
+# when changing context-graph/scripts/install.sh or its README instructions.
+on:
+  workflow_dispatch: {}
+
+jobs:
+  install-sh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: python -m pip install uv
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      # No ANTHROPIC_API_KEY here on purpose: plugin marketplace/install is
+      # local config + a public git clone, and agent-context-graph's bootstrap
+      # /doctor hook smoke test doesn't call the model either -- confirmed by
+      # a full green run with no key set.
+      - name: Run install.sh end-to-end
+        env:
+          AGENT_CONTEXT_GRAPH_USER_ID: ci-test-user
+        run: ./context-graph/scripts/install.sh

--- a/.github/workflows/test-context-graph-install.yaml
+++ b/.github/workflows/test-context-graph-install.yaml
@@ -1,18 +1,23 @@
 name: Test context-graph install.sh (manual)
 
 # Manual-trigger only, deliberately not on push/pull_request: this drives real
-# external state on the runner -- installs the Claude Code CLI, registers the
-# real memgraph/ai-toolkit marketplace, and installs the published
-# context-graph plugin from it -- rather than anything scoped to this
-# checkout. That's intentional: the point is verifying the actual onboarding
-# path a new user hits, not the PR's diff in isolation. Run this deliberately
-# when changing context-graph/scripts/install.sh or its README instructions.
+# external state on the runner -- installs the Claude Code/Codex CLI,
+# registers the real memgraph/ai-toolkit marketplace, and installs the
+# published context-graph plugin from it -- rather than anything scoped to
+# this checkout. That's intentional: the point is verifying the actual
+# onboarding path a new user hits, not the PR's diff in isolation. Run this
+# deliberately when changing context-graph/scripts/install.sh or its README
+# instructions.
 on:
   workflow_dispatch: {}
 
 jobs:
   install-sh:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [claude-code, codex]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,13 +31,24 @@ jobs:
         run: python -m pip install uv
 
       - name: Install Claude Code CLI
+        if: matrix.runtime == 'claude-code'
         run: npm install -g @anthropic-ai/claude-code
 
-      # No ANTHROPIC_API_KEY here on purpose: plugin marketplace/install is
-      # local config + a public git clone, and agent-context-graph's bootstrap
-      # /doctor hook smoke test doesn't call the model either -- confirmed by
-      # a full green run with no key set.
+      - name: Install Codex CLI
+        if: matrix.runtime == 'codex'
+        run: npm install -g @openai/codex
+
+      # OPENAI_API_KEY is set for the codex leg since it's already an
+      # available secret and a real Codex install would have one configured
+      # too, but it isn't actually required: plugin marketplace/install is
+      # local config + a public git clone, and agent-context-graph's
+      # bootstrap/doctor hook smoke test calls the runtime adapter in-process
+      # rather than the real claude/codex binary, so it never calls a model
+      # either -- confirmed by a full green run on both runtimes with no key
+      # set at all.
       - name: Run install.sh end-to-end
         env:
+          CONTEXT_GRAPH_RUNTIME: ${{ matrix.runtime }}
           AGENT_CONTEXT_GRAPH_USER_ID: ci-test-user
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: ./context-graph/scripts/install.sh

--- a/context-graph/README.md
+++ b/context-graph/README.md
@@ -43,7 +43,17 @@ One command does everything below: starts a local Memgraph if none is reachable,
 curl -fsSL https://raw.githubusercontent.com/memgraph/ai-toolkit/main/context-graph/scripts/install.sh | bash
 ```
 
-Requires Docker (only if no Memgraph is already reachable) and the Claude Code CLI (`claude`) on `PATH`; it installs `uv` for you if missing. See the script's header for env overrides (`MEMGRAPH_HOST`/`PORT`, `AGENT_CONTEXT_GRAPH_USER_ID`, `SKIP_MEMGRAPH`, `SKIP_UV_INSTALL`).
+Requires Docker (only if no Memgraph is already reachable) and the Claude Code CLI (`claude`) on `PATH`; it installs `uv` for you if missing. Everything else is optional — all env vars, all with sane defaults:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `AGENT_CONTEXT_GRAPH_USER_ID` | `git config user.name`, else `$USER` | Identity recorded on every session (`identity.user_id`) |
+| `MEMGRAPH_HOST` | `localhost` | Host to bootstrap against and, if starting one, to publish the container on |
+| `MEMGRAPH_PORT` | `7687` | Bolt port, same two uses as above |
+| `SKIP_MEMGRAPH` | unset | Set to `1` to fail instead of auto-starting a local Memgraph when none is reachable |
+| `SKIP_UV_INSTALL` | unset | Set to `1` to fail instead of auto-installing `uv` when missing |
+
+Already reachable Memgraph, already-registered marketplace, already-installed plugin — each is detected and skipped, so rerunning is safe (e.g. to pick up a new context-graph version).
 
 Once it finishes, use Claude Code normally — every session writes to the graph automatically: `(:User)-[:HAD_SESSION]->(:Session)`, tool actions, skill usage, and any Memories the agent records.
 

--- a/context-graph/README.md
+++ b/context-graph/README.md
@@ -35,7 +35,20 @@ Everything is joined by a shared `(:Session {session_id})` node, so one graph an
 
 ## Getting started (Claude Code)
 
-The fastest path is the plugin — it wires all three connectors into Claude Code's hooks so capture is automatic.
+One command does everything below: starts a local Memgraph if none is reachable, registers the plugin marketplace, installs the plugin (this is the step that actually wires hooks into Claude Code — running `bootstrap` on its own does not), installs the `agent-context-graph` CLI with all three connectors, sets your identity, and verifies with `doctor`.
+
+```bash
+./context-graph/scripts/install.sh
+# or, without a checkout:
+curl -fsSL https://raw.githubusercontent.com/memgraph/ai-toolkit/main/context-graph/scripts/install.sh | bash
+```
+
+Requires Docker (only if no Memgraph is already reachable) and the Claude Code CLI (`claude`) on `PATH`; it installs `uv` for you if missing. See the script's header for env overrides (`MEMGRAPH_HOST`/`PORT`, `AGENT_CONTEXT_GRAPH_USER_ID`, `SKIP_MEMGRAPH`, `SKIP_UV_INSTALL`).
+
+Once it finishes, use Claude Code normally — every session writes to the graph automatically: `(:User)-[:HAD_SESSION]->(:Session)`, tool actions, skill usage, and any Memories the agent records.
+
+<details>
+<summary>What the script does, step by step (or if you'd rather run it by hand)</summary>
 
 ### 1. Start Memgraph
 
@@ -47,11 +60,18 @@ Requires **Memgraph ≥ 3.6** (sessions-graph uses text search, stable from that
 
 ### 2. Install the plugin
 
-Inside Claude Code:
+This is the step a plain `bootstrap` cannot do for you: it wires the hooks into Claude Code so sessions are actually captured. Inside Claude Code:
 
 ```text
 /plugin marketplace add memgraph/ai-toolkit
 /plugin install context-graph@context-graph-plugins
+```
+
+Or non-interactively, from any shell:
+
+```bash
+claude plugin marketplace add memgraph/ai-toolkit --sparse .claude-plugin
+claude plugin install context-graph@context-graph-plugins -y
 ```
 
 ### 3. Bootstrap and configure
@@ -92,7 +112,9 @@ You want every line `OK` — config (user_id set), Memgraph reachable, each conn
 
 From here, every session writes to the graph automatically: `(:User)-[:HAD_SESSION]->(:Session)`, tool actions, skill usage, and any Memories the agent records.
 
-> **Codex** follows the same flow with `--runtime codex` and `codex plugin marketplace add memgraph/ai-toolkit --sparse .agents/plugins`. See [agent-context-graph](./agent-context-graph/) for both runtimes and for the in-process SDK path (no plugin).
+</details>
+
+> **Codex** follows the same connector/bootstrap flow with `--runtime codex` and `codex plugin marketplace add memgraph/ai-toolkit --sparse .agents/plugins` — but Codex has no non-interactive plugin-*install* step today, so `install.sh` doesn't cover it end-to-end. See [agent-context-graph](./agent-context-graph/) for both runtimes and for the in-process SDK path (no plugin).
 
 ## Turning sessions into an entity graph (reconciliation)
 

--- a/context-graph/README.md
+++ b/context-graph/README.md
@@ -33,9 +33,9 @@ Everything is joined by a shared `(:Session {session_id})` node, so one graph an
 
 > `(:Session)` is a shared coordination point — every component `MERGE`s it idempotently, but only sessions-graph owns `(:User)` and the `HAD_SESSION` edge. Entity extraction is powered by [unstructured2graph](../unstructured2graph/), which lives outside this family.
 
-## Getting started (Claude Code)
+## Getting started (Claude Code or Codex)
 
-One command does everything below: starts a local Memgraph if none is reachable, registers the plugin marketplace, installs the plugin (this is the step that actually wires hooks into Claude Code — running `bootstrap` on its own does not), installs the `agent-context-graph` CLI with all three connectors, sets your identity, and verifies with `doctor`.
+One command does everything below: starts a local Memgraph if none is reachable, registers the plugin marketplace, installs the plugin (this is the step that actually wires hooks into the runtime — running `bootstrap` on its own does not), installs the `agent-context-graph` CLI with all three connectors, sets your identity, and verifies with `doctor`.
 
 ```bash
 ./context-graph/scripts/install.sh
@@ -43,19 +43,24 @@ One command does everything below: starts a local Memgraph if none is reachable,
 curl -fsSL https://raw.githubusercontent.com/memgraph/ai-toolkit/main/context-graph/scripts/install.sh | bash
 ```
 
-Requires Docker (only if no Memgraph is already reachable) and the Claude Code CLI (`claude`) on `PATH`; it installs `uv` for you if missing. Everything else is optional — all env vars, all with sane defaults:
+Requires Docker (only if no Memgraph is already reachable) and the runtime's CLI (`claude` or `codex`) on `PATH`; it installs `uv` for you if missing. Everything else is optional — all env vars, all with sane defaults:
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
+| `CONTEXT_GRAPH_RUNTIME` | `claude-code` | `claude-code` or `codex` |
 | `AGENT_CONTEXT_GRAPH_USER_ID` | `git config user.name`, else `$USER` | Identity recorded on every session (`identity.user_id`) |
 | `MEMGRAPH_HOST` | `localhost` | Host to bootstrap against and, if starting one, to publish the container on |
 | `MEMGRAPH_PORT` | `7687` | Bolt port, same two uses as above |
 | `SKIP_MEMGRAPH` | unset | Set to `1` to fail instead of auto-starting a local Memgraph when none is reachable |
 | `SKIP_UV_INSTALL` | unset | Set to `1` to fail instead of auto-installing `uv` when missing |
 
+```bash
+CONTEXT_GRAPH_RUNTIME=codex ./context-graph/scripts/install.sh
+```
+
 Already reachable Memgraph, already-registered marketplace, already-installed plugin — each is detected and skipped, so rerunning is safe (e.g. to pick up a new context-graph version).
 
-Once it finishes, use Claude Code normally — every session writes to the graph automatically: `(:User)-[:HAD_SESSION]->(:Session)`, tool actions, skill usage, and any Memories the agent records.
+Once it finishes, use the runtime normally — every session writes to the graph automatically: `(:User)-[:HAD_SESSION]->(:Session)`, tool actions, skill usage, and any Memories the agent records.
 
 <details>
 <summary>What the script does, step by step (or if you'd rather run it by hand)</summary>
@@ -70,18 +75,25 @@ Requires **Memgraph ≥ 3.6** (sessions-graph uses text search, stable from that
 
 ### 2. Install the plugin
 
-This is the step a plain `bootstrap` cannot do for you: it wires the hooks into Claude Code so sessions are actually captured. Inside Claude Code:
+This is the step a plain `bootstrap` cannot do for you: it wires the hooks into the runtime so sessions are actually captured. Inside Claude Code:
 
 ```text
 /plugin marketplace add memgraph/ai-toolkit
 /plugin install context-graph@context-graph-plugins
 ```
 
-Or non-interactively, from any shell:
+Or non-interactively, from any shell — Claude Code:
 
 ```bash
 claude plugin marketplace add memgraph/ai-toolkit --sparse .claude-plugin
 claude plugin install context-graph@context-graph-plugins -y
+```
+
+Codex:
+
+```bash
+codex plugin marketplace add memgraph/ai-toolkit --sparse .agents/plugins
+codex plugin add context-graph@context-graph-plugins
 ```
 
 ### 3. Bootstrap and configure
@@ -91,6 +103,7 @@ The plugin's first run installs the `agent-context-graph` tool (with all three c
 ```bash
 agent-context-graph bootstrap --runtime claude-code \
   --connector skills-graph --connector actions-graph --connector sessions-graph
+# Codex: --runtime codex
 ```
 
 Set your identity — **required** for sessions-graph to attach sessions to a user:
@@ -114,17 +127,18 @@ agent-context-graph config set memgraph.database "memgraph"
 agent-context-graph config show
 agent-context-graph doctor --runtime claude-code \
   --connector skills-graph --connector actions-graph --connector sessions-graph
+# Codex: --runtime codex
 ```
 
 You want every line `OK` — config (user_id set), Memgraph reachable, each connector, and the strict hook smoke test.
 
-### 5. Use Claude Code normally
+### 5. Use the runtime normally
 
 From here, every session writes to the graph automatically: `(:User)-[:HAD_SESSION]->(:Session)`, tool actions, skill usage, and any Memories the agent records.
 
 </details>
 
-> **Codex** follows the same connector/bootstrap flow with `--runtime codex` and `codex plugin marketplace add memgraph/ai-toolkit --sparse .agents/plugins` — but Codex has no non-interactive plugin-*install* step today, so `install.sh` doesn't cover it end-to-end. See [agent-context-graph](./agent-context-graph/) for both runtimes and for the in-process SDK path (no plugin).
+See [agent-context-graph](./agent-context-graph/) for both runtimes' adapter details and for the in-process SDK path (no plugin).
 
 ## Turning sessions into an entity graph (reconciliation)
 

--- a/context-graph/agent-context-graph/README.md
+++ b/context-graph/agent-context-graph/README.md
@@ -257,13 +257,14 @@ Plugin source:
 context-graph/plugins/agent-context-graph-codex
 ```
 
-Register the public Git-backed marketplace:
+Register the public Git-backed marketplace and install the plugin:
 
 ```bash
 codex plugin marketplace add memgraph/ai-toolkit --sparse .agents/plugins
+codex plugin add context-graph@context-graph-plugins
 ```
 
-Then install or enable `context-graph` from the Codex plugin UI.
+Both are non-interactive; `codex plugin add` installs and enables the plugin in one step (`codex plugin list --json` confirms `"enabled": true`).
 
 Check the installed hook environment with:
 

--- a/context-graph/plugins/agent-context-graph-codex/README.md
+++ b/context-graph/plugins/agent-context-graph-codex/README.md
@@ -80,13 +80,14 @@ This repo exposes a public Git-backed marketplace at:
 .agents/plugins/marketplace.json
 ```
 
-Register the marketplace from GitHub:
+Register the marketplace from GitHub and install the plugin:
 
 ```bash
 codex plugin marketplace add memgraph/ai-toolkit --sparse .agents/plugins
+codex plugin add context-graph@context-graph-plugins
 ```
 
-Then install or enable `context-graph` from the Codex plugin UI.
+Both are non-interactive; `codex plugin add` installs and enables the plugin in one step.
 
 The Agent Context Graph skill is exposed as:
 

--- a/context-graph/scripts/install.sh
+++ b/context-graph/scripts/install.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# One-command setup for Context Graph on Claude Code: start Memgraph if
+# nothing is reachable, register the plugin marketplace, install the plugin
+# (this is what actually wires hooks into Claude Code -- `bootstrap` alone
+# does not), install the agent-context-graph CLI with all three connectors,
+# set your identity, and verify with `doctor`.
+#
+# Usage:
+#   ./context-graph/scripts/install.sh
+#   curl -fsSL https://raw.githubusercontent.com/memgraph/ai-toolkit/main/context-graph/scripts/install.sh | bash
+#
+# Env overrides:
+#   AGENT_CONTEXT_GRAPH_USER_ID   identity to record (default: git user.name, else $USER)
+#   MEMGRAPH_HOST / MEMGRAPH_PORT default localhost:7687
+#   SKIP_MEMGRAPH=1               don't start a local Memgraph even if none is reachable
+#   SKIP_UV_INSTALL=1             don't auto-install uv if missing (just fail with instructions)
+#
+# Codex is NOT covered: unlike Claude Code, Codex has no non-interactive
+# plugin-install command today (its marketplace add is scriptable, but
+# enabling the plugin itself is a manual step in the Codex UI). Run this
+# script anyway to get Memgraph + the CLI + connectors installed, then finish
+# Codex's plugin step by hand -- see ../plugins/agent-context-graph-codex/README.md.
+
+set -euo pipefail
+
+RUNTIME="claude-code"
+CONNECTORS=(skills-graph actions-graph sessions-graph)
+MEMGRAPH_HOST="${MEMGRAPH_HOST:-localhost}"
+MEMGRAPH_PORT="${MEMGRAPH_PORT:-7687}"
+CONTAINER_NAME="context-graph-memgraph"
+MAGE_IMAGE="memgraph/memgraph-mage:latest"
+
+log() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+fail() { printf 'FAIL %s\n' "$*" >&2; exit 1; }
+
+bolt_reachable() {
+  (exec 3<>"/dev/tcp/${MEMGRAPH_HOST}/${MEMGRAPH_PORT}") 2>/dev/null
+}
+
+# A plain TCP accept happens well before Memgraph can actually complete a Bolt
+# handshake -- the MAGE image in particular preloads heavy ML query-module
+# dependencies after the socket is already listening. Once we start the
+# container ourselves, gate readiness on a real query via the mgconsole
+# bundled in the image, not just the socket.
+bolt_query_ready() {
+  docker exec "$CONTAINER_NAME" mgconsole --host 127.0.0.1 --port 7687 <<<"RETURN 1;" >/dev/null 2>&1
+}
+
+# ---- 1. Memgraph ------------------------------------------------------------
+log "Checking Memgraph at bolt://${MEMGRAPH_HOST}:${MEMGRAPH_PORT}"
+if bolt_reachable; then
+  echo "Already reachable -- using it as-is."
+elif [[ "${SKIP_MEMGRAPH:-0}" == "1" ]]; then
+  fail "memgraph: not reachable and SKIP_MEMGRAPH=1 -- start one and rerun."
+else
+  command -v docker >/dev/null 2>&1 || fail "docker is required to auto-start Memgraph: https://docs.docker.com/get-docker/ (or start your own and rerun with SKIP_MEMGRAPH=1)"
+  echo "Nothing reachable -- starting a local Memgraph ($MAGE_IMAGE)."
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker run -d --name "$CONTAINER_NAME" \
+    -p "${MEMGRAPH_PORT}:7687" -p 7444:7444 \
+    "$MAGE_IMAGE" --schema-info-enabled=True >/dev/null
+  ready=0
+  for _ in $(seq 1 90); do
+    if bolt_query_ready; then ready=1; break; fi
+    sleep 2
+  done
+  [[ "$ready" == "1" ]] || { docker logs "$CONTAINER_NAME" || true; fail "memgraph did not become ready in time"; }
+  echo "Memgraph is up on bolt://${MEMGRAPH_HOST}:${MEMGRAPH_PORT} (container: $CONTAINER_NAME)"
+fi
+
+# ---- 2. uv -------------------------------------------------------------------
+if ! command -v uv >/dev/null 2>&1; then
+  if [[ "${SKIP_UV_INSTALL:-0}" == "1" ]]; then
+    fail "uv not found and SKIP_UV_INSTALL=1: https://astral.sh/uv/install.sh"
+  fi
+  log "Installing uv (manages Python for the agent-context-graph tool)"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  command -v uv >/dev/null 2>&1 || fail "uv install did not put 'uv' on PATH -- open a new shell and rerun."
+fi
+echo "OK uv: $(command -v uv)"
+
+# ---- 3. Claude Code plugin (marketplace + install) ---------------------------
+# This is the step the plain `bootstrap` command cannot do for you: it's what
+# wires hooks into Claude Code so sessions actually get captured. Without it,
+# `doctor` below will look all-green but no real session will write anything.
+command -v claude >/dev/null 2>&1 || fail "claude (Claude Code CLI) not found on PATH -- install Claude Code first."
+
+log "Registering the ai-toolkit plugin marketplace"
+if claude plugin marketplace list --json 2>/dev/null | grep -q '"context-graph-plugins"'; then
+  echo "Already registered."
+else
+  claude plugin marketplace add memgraph/ai-toolkit --sparse .claude-plugin
+fi
+
+log "Installing the context-graph plugin"
+if claude plugin list --json 2>/dev/null | grep -q '"context-graph"'; then
+  echo "Already installed."
+else
+  claude plugin install context-graph@context-graph-plugins -y
+fi
+
+# ---- 4. agent-context-graph CLI + connectors ---------------------------------
+log "Installing agent-context-graph with skills-graph, actions-graph, sessions-graph"
+uv tool install "agent-context-graph>=0.1.9" \
+  --with "skills-graph[agent-context-graph]>=0.1.3" \
+  --with "actions-graph[agent-context-graph]>=0.1.1" \
+  --with "sessions-graph[agent-context-graph]>=0.1.2" \
+  --upgrade \
+  --refresh-package agent-context-graph \
+  --refresh-package skills-graph \
+  --refresh-package actions-graph
+
+# uv tool shims land in `uv tool dir --bin` (usually ~/.local/bin), which may
+# not be on PATH yet even when uv itself came from elsewhere (Homebrew, pipx).
+export PATH="$(uv tool dir --bin 2>/dev/null || echo "$HOME/.local/bin"):$PATH"
+command -v agent-context-graph >/dev/null 2>&1 || fail "agent-context-graph installed but not on PATH -- add $(uv tool dir --bin 2>/dev/null || echo "$HOME/.local/bin") to PATH and rerun."
+
+log "Bootstrapping ($RUNTIME)"
+connector_flags=()
+for c in "${CONNECTORS[@]}"; do connector_flags+=(--connector "$c"); done
+MEMGRAPH_HOST="$MEMGRAPH_HOST" MEMGRAPH_PORT="$MEMGRAPH_PORT" \
+  agent-context-graph bootstrap --runtime "$RUNTIME" "${connector_flags[@]}" --no-reinstall
+
+# ---- 5. Identity --------------------------------------------------------------
+USER_ID="${AGENT_CONTEXT_GRAPH_USER_ID:-$(git config --get user.name 2>/dev/null || true)}"
+USER_ID="${USER_ID:-$USER}"
+log "Setting identity.user_id = ${USER_ID}"
+agent-context-graph config set identity.user_id "$USER_ID"
+
+# ---- 6. Verify -----------------------------------------------------------------
+log "Verifying"
+agent-context-graph doctor --runtime "$RUNTIME" "${connector_flags[@]}"
+
+echo ""
+echo -e "\033[1;32m✓ Context Graph is live.\033[0m Use Claude Code normally -- every session now"
+echo "writes Actions/Skills/Memories to bolt://${MEMGRAPH_HOST}:${MEMGRAPH_PORT}."
+echo ""
+echo "Explore the graph: docker run -d -p 3000:3000 --add-host=host.docker.internal:host-gateway \\"
+echo "  -e QUICK_CONNECT_MG_HOST=host.docker.internal -e QUICK_CONNECT_MG_PORT=${MEMGRAPH_PORT} memgraph/lab:latest"
+echo "Docs: https://github.com/memgraph/ai-toolkit/tree/main/context-graph"

--- a/context-graph/scripts/install.sh
+++ b/context-graph/scripts/install.sh
@@ -1,29 +1,28 @@
 #!/usr/bin/env bash
-# One-command setup for Context Graph on Claude Code: start Memgraph if
-# nothing is reachable, register the plugin marketplace, install the plugin
-# (this is what actually wires hooks into Claude Code -- `bootstrap` alone
-# does not), install the agent-context-graph CLI with all three connectors,
-# set your identity, and verify with `doctor`.
+# One-command setup for Context Graph on Claude Code or Codex: start Memgraph
+# if nothing is reachable, register the plugin marketplace, install the
+# plugin (this is what actually wires hooks into the runtime -- `bootstrap`
+# alone does not), install the agent-context-graph CLI with all three
+# connectors, set your identity, and verify with `doctor`.
 #
 # Usage:
 #   ./context-graph/scripts/install.sh
 #   curl -fsSL https://raw.githubusercontent.com/memgraph/ai-toolkit/main/context-graph/scripts/install.sh | bash
 #
 # Env overrides:
+#   CONTEXT_GRAPH_RUNTIME         claude-code (default) or codex
 #   AGENT_CONTEXT_GRAPH_USER_ID   identity to record (default: git user.name, else $USER)
 #   MEMGRAPH_HOST / MEMGRAPH_PORT default localhost:7687
 #   SKIP_MEMGRAPH=1               don't start a local Memgraph even if none is reachable
 #   SKIP_UV_INSTALL=1             don't auto-install uv if missing (just fail with instructions)
-#
-# Codex is NOT covered: unlike Claude Code, Codex has no non-interactive
-# plugin-install command today (its marketplace add is scriptable, but
-# enabling the plugin itself is a manual step in the Codex UI). Run this
-# script anyway to get Memgraph + the CLI + connectors installed, then finish
-# Codex's plugin step by hand -- see ../plugins/agent-context-graph-codex/README.md.
 
 set -euo pipefail
 
-RUNTIME="claude-code"
+RUNTIME="${CONTEXT_GRAPH_RUNTIME:-claude-code}"
+case "$RUNTIME" in
+  claude-code | codex) ;;
+  *) echo "FAIL unknown CONTEXT_GRAPH_RUNTIME: $RUNTIME (expected claude-code or codex)" >&2; exit 1 ;;
+esac
 CONNECTORS=(skills-graph actions-graph sessions-graph)
 MEMGRAPH_HOST="${MEMGRAPH_HOST:-localhost}"
 MEMGRAPH_PORT="${MEMGRAPH_PORT:-7687}"
@@ -80,25 +79,46 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 echo "OK uv: $(command -v uv)"
 
-# ---- 3. Claude Code plugin (marketplace + install) ---------------------------
+# ---- 3. Runtime plugin (marketplace + install) -------------------------------
 # This is the step the plain `bootstrap` command cannot do for you: it's what
-# wires hooks into Claude Code so sessions actually get captured. Without it,
+# wires hooks into the runtime so sessions actually get captured. Without it,
 # `doctor` below will look all-green but no real session will write anything.
-command -v claude >/dev/null 2>&1 || fail "claude (Claude Code CLI) not found on PATH -- install Claude Code first."
+case "$RUNTIME" in
+  claude-code)
+    command -v claude >/dev/null 2>&1 || fail "claude (Claude Code CLI) not found on PATH -- install Claude Code first."
 
-log "Registering the ai-toolkit plugin marketplace"
-if claude plugin marketplace list --json 2>/dev/null | grep -q '"context-graph-plugins"'; then
-  echo "Already registered."
-else
-  claude plugin marketplace add memgraph/ai-toolkit --sparse .claude-plugin
-fi
+    log "Registering the ai-toolkit plugin marketplace"
+    if claude plugin marketplace list --json 2>/dev/null | grep -q '"context-graph-plugins"'; then
+      echo "Already registered."
+    else
+      claude plugin marketplace add memgraph/ai-toolkit --sparse .claude-plugin
+    fi
 
-log "Installing the context-graph plugin"
-if claude plugin list --json 2>/dev/null | grep -q '"context-graph"'; then
-  echo "Already installed."
-else
-  claude plugin install context-graph@context-graph-plugins -y
-fi
+    log "Installing the context-graph plugin"
+    if claude plugin list --json 2>/dev/null | grep -q '"context-graph"'; then
+      echo "Already installed."
+    else
+      claude plugin install context-graph@context-graph-plugins -y
+    fi
+    ;;
+  codex)
+    command -v codex >/dev/null 2>&1 || fail "codex (Codex CLI) not found on PATH -- install Codex first."
+
+    log "Registering the ai-toolkit plugin marketplace"
+    if codex plugin marketplace list --json 2>/dev/null | grep -q '"context-graph-plugins"'; then
+      echo "Already registered."
+    else
+      codex plugin marketplace add memgraph/ai-toolkit --sparse .agents/plugins
+    fi
+
+    log "Installing the context-graph plugin"
+    if codex plugin list --json 2>/dev/null | grep -q '"context-graph"'; then
+      echo "Already installed."
+    else
+      codex plugin add context-graph@context-graph-plugins
+    fi
+    ;;
+esac
 
 # ---- 4. agent-context-graph CLI + connectors ---------------------------------
 log "Installing agent-context-graph with skills-graph, actions-graph, sessions-graph"
@@ -132,8 +152,9 @@ agent-context-graph config set identity.user_id "$USER_ID"
 log "Verifying"
 agent-context-graph doctor --runtime "$RUNTIME" "${connector_flags[@]}"
 
+RUNTIME_LABEL="Claude Code"; [[ "$RUNTIME" == "codex" ]] && RUNTIME_LABEL="Codex"
 echo ""
-echo -e "\033[1;32m✓ Context Graph is live.\033[0m Use Claude Code normally -- every session now"
+echo -e "\033[1;32m✓ Context Graph is live.\033[0m Use $RUNTIME_LABEL normally -- every session now"
 echo "writes Actions/Skills/Memories to bolt://${MEMGRAPH_HOST}:${MEMGRAPH_PORT}."
 echo ""
 echo "Explore the graph: docker run -d -p 3000:3000 --add-host=host.docker.internal:host-gateway \\"


### PR DESCRIPTION
## Summary

memgraph-platform PR #110's "wire it into a real harness" snippet (`uv tool install` + `agent-context-graph bootstrap` + `config set identity.user_id`) looks complete — `doctor` comes back all green — but it's missing the one step that actually wires hooks into Claude Code: `claude plugin marketplace add` + `claude plugin install`. Without it, the CLI is installed and Memgraph is reachable, but Claude Code never learns the plugin exists, so no real session writes anything.

- `context-graph/scripts/install.sh` (new) — one idempotent script: starts a local Memgraph if none is reachable, registers the `memgraph/ai-toolkit` marketplace, installs the `context-graph` plugin (skipping steps already done), installs `agent-context-graph` with all three connectors, sets identity (`git config user.name` fallback), and verifies with `doctor`.
- `context-graph/README.md` — leads with the one-liner; the old 5-step manual flow is preserved in a collapsed `<details>` for people who want to see/run it by hand, plus a note that Codex has no non-interactive plugin-install step today so it isn't covered end-to-end.
- `.github/workflows/test-context-graph-install.yaml` (new) — manual-dispatch job that installs the Claude Code CLI and runs `install.sh` for real against the published marketplace/plugin (no `ANTHROPIC_API_KEY` needed — plugin management and the bootstrap hook smoke test are both local/no-LLM).

## Bug found while testing

The initial version of `install.sh` gated "Memgraph is ready" on a plain TCP-accept check. That's not sufficient for the MAGE image: the socket opens well before Memgraph can actually complete a Bolt handshake (it's loading heavier ML query-module deps first), so the immediately-following `bootstrap`/`doctor` step failed with a real `Could not connect to Memgraph database` error. Fixed by gating readiness on an actual `mgconsole` query via `docker exec`, matching the pattern `skills-graph`'s and `actions-graph`'s own CI jobs already use for this same image.

## Test plan

- [x] Ran `install.sh` end-to-end locally in a sandboxed `$HOME`/`$CLAUDE_CONFIG_DIR` (so it wouldn't touch my real Claude Code config): cold start (no Memgraph, no marketplace, no plugin) — hit the TCP-vs-Bolt-ready race above, fixed it, reran clean: every `doctor` line `OK` (uv, memgraph, agent-context-graph, all three connectors, `runtime:claude-code` strict hook smoke).
- [x] Reran a second time to confirm the idempotent "already registered" / "already installed" branches for the marketplace and plugin steps.
- [x] `bash -n` clean.
- [ ] Not yet run in CI — the new `test-context-graph-install.yaml` workflow is `workflow_dispatch`-only (mirrors `test-live-graph-model.yaml`'s convention: real external state, not something to run on every push); trigger it manually to verify on a fresh runner.