### PR TITLE
agent-context-graph: make sessions-graph auto_reconcile a persistent config setting

### DIFF
--- a/context-graph/agent-context-graph/README.md
+++ b/context-graph/agent-context-graph/README.md
@@ -227,17 +227,39 @@ url = "bolt://localhost:7687"
 user = ""
 password = ""
 database = "memgraph"
+
+[llm]
+openai_api_key = ""
+anthropic_api_key = ""
+
+[reconcile]
+auto_reconcile = true
 ```
+
+`[llm]` and `[reconcile]` are only relevant if you enable sessions-graph's
+auto-trigger reconciliation (see
+[sessions-graph § reconciliation](../sessions-graph/README.md#session-reconciliation)).
+`[reconcile]` is omitted entirely from a freshly-bootstrapped file — absent
+means "never configured," distinct from an explicit `auto_reconcile = false`.
 
 Manage it with:
 
 ```bash
 agent-context-graph config show
 agent-context-graph config get memgraph.url
-agent-context-graph config set <key> <value>   # keys: identity.user_id, memgraph.{url,user,password,database}
+agent-context-graph config set <key> <value>
+# keys: identity.user_id, memgraph.{url,user,password,database},
+#       llm.{openai_api_key,anthropic_api_key}, reconcile.auto_reconcile
 ```
 
-Environment variables (`MEMGRAPH_URL`, `MEMGRAPH_USER`, `MEMGRAPH_PASSWORD`, `MEMGRAPH_DATABASE`, `AGENT_CONTEXT_GRAPH_USER_ID`) are consulted **only at bootstrap time** — if set, `bootstrap` persists them into the config file. Exporting them later has no effect on running hooks; use `config set` instead.
+Environment variables (`MEMGRAPH_URL`, `MEMGRAPH_USER`, `MEMGRAPH_PASSWORD`, `MEMGRAPH_DATABASE`, `AGENT_CONTEXT_GRAPH_USER_ID`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) are consulted **only at bootstrap time** — if set, `bootstrap` persists them into the config file. Exporting them later has no effect on running hooks; use `config set` instead.
+
+`reconcile.auto_reconcile` is the one exception: `bootstrap` never captures
+`SESSIONS_GRAPH_AUTO_RECONCILE` from the environment, and re-running
+`bootstrap` preserves whatever it's currently set to rather than resetting it.
+Unlike the keys above, nobody has that env var exported for an unrelated
+reason — it's only ever set via `agent-context-graph config set
+reconcile.auto_reconcile true`.
 
 ### OpenAI Codex Plugin
 

--- a/context-graph/agent-context-graph/docs/command-hooks.md
+++ b/context-graph/agent-context-graph/docs/command-hooks.md
@@ -69,18 +69,27 @@ memgraph.password
 memgraph.database
 llm.openai_api_key
 llm.anthropic_api_key
+reconcile.auto_reconcile
 ```
 
-The `llm.*` keys are only needed if you enable the `sessions-graph` connector
-with `auto_reconcile` (`SESSIONS_GRAPH_AUTO_RECONCILE=1` at connector
-construction time): reconciliation shells out to a detached
-`sessions-graph reconcile` subprocess that does LLM-backed entity extraction
-via LightRAG, and needs an `OPENAI_API_KEY` (or `ANTHROPIC_API_KEY`) the same
-way it needs Memgraph credentials — resolved from this config file and
-injected into that subprocess's environment explicitly, not inherited from
-ambient shell env (see ADR 0003). `agent-context-graph bootstrap` captures
-`OPENAI_API_KEY`/`ANTHROPIC_API_KEY` from its own environment into the config
-file automatically, the same way it already does for `MEMGRAPH_*`.
+The `llm.*` keys and `reconcile.auto_reconcile` are only needed if you enable
+the `sessions-graph` connector's auto-trigger reconciliation
+(`agent-context-graph config set reconcile.auto_reconcile true`):
+reconciliation shells out to a detached `sessions-graph reconcile` subprocess
+that does LLM-backed entity extraction via LightRAG, and needs an
+`OPENAI_API_KEY` (or `ANTHROPIC_API_KEY`) the same way it needs Memgraph
+credentials — resolved from this config file and injected into that
+subprocess's environment explicitly, not inherited from ambient shell env
+(see ADR 0003). `agent-context-graph bootstrap` captures
+`OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/`SESSIONS_GRAPH_AUTO_RECONCILE` from its
+own environment into the config file automatically, the same way it already
+does for `MEMGRAPH_*`.
+
+`reconcile.auto_reconcile` itself is read directly by
+`agent_context_graph.hooks.runner._add_sessions_graph_connector` on every hook
+invocation (`resolve_auto_reconcile()`), not just at bootstrap/write time —
+unlike the `llm.*`/`memgraph.*` keys, which are only ever overlaid into a
+child subprocess's environment.
 
 To smoke test the generated command, copy the `"command"` value from `.codex/hooks.json` and run:
 

--- a/context-graph/agent-context-graph/pyproject.toml
+++ b/context-graph/agent-context-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-context-graph"
-version = "0.2.0"
+version = "0.2.1"
 description = "Connect agent SDKs to context-graph components (actions-graph, skills-graph, etc.)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
@@ -5,7 +5,7 @@ subprocesses that do not inherit shell profile environment variables.  This
 module provides a config-file-only resolution path so hook subprocesses (and
 subprocesses they in turn spawn, e.g. sessions-graph's detached
 reconciliation process) can reliably access identity, Memgraph connection,
-and LLM API key settings.
+LLM API key, and reconciliation opt-in settings.
 
 Resolution order (per ADR 0002):
   CLI flag > config file > hardcoded default
@@ -39,6 +39,10 @@ _LLM_DEFAULTS = {
     "anthropic_api_key": "",
 }
 
+_RECONCILE_DEFAULTS = {
+    "auto_reconcile": False,
+}
+
 _sentinel = object()
 _cached_config: object = _sentinel
 
@@ -54,6 +58,7 @@ class HookConfig:
     memgraph_database: str = _MEMGRAPH_DEFAULTS["database"]
     openai_api_key: str = _LLM_DEFAULTS["openai_api_key"]
     anthropic_api_key: str = _LLM_DEFAULTS["anthropic_api_key"]
+    auto_reconcile: bool = _RECONCILE_DEFAULTS["auto_reconcile"]
 
 
 def load_config() -> HookConfig:
@@ -120,6 +125,16 @@ def resolve_llm_env() -> dict[str, str]:
     }
 
 
+def resolve_auto_reconcile() -> bool:
+    """Resolve whether sessions-graph should auto-trigger reconciliation on SESSION_END.
+
+    Config file only — mirrors :func:`resolve_llm_env`. Off by default given
+    LightRAG entity extraction's LLM cost; opt in with
+    ``agent-context-graph config set reconcile.auto_reconcile true``.
+    """
+    return load_config().auto_reconcile
+
+
 def write_config(
     *,
     user_id: str | None = None,
@@ -129,6 +144,7 @@ def write_config(
     memgraph_database: str | None = None,
     openai_api_key: str | None = None,
     anthropic_api_key: str | None = None,
+    auto_reconcile: bool | None = None,
 ) -> Path:
     """Write or update the config file. Returns the path written to.
 
@@ -147,6 +163,7 @@ def write_config(
     final_database = memgraph_database if memgraph_database is not None else existing.memgraph_database
     final_openai_api_key = openai_api_key if openai_api_key is not None else existing.openai_api_key
     final_anthropic_api_key = anthropic_api_key if anthropic_api_key is not None else existing.anthropic_api_key
+    final_auto_reconcile = auto_reconcile if auto_reconcile is not None else existing.auto_reconcile
 
     content = _render_config(
         user_id=final_user_id or "",
@@ -156,6 +173,7 @@ def write_config(
         database=final_database,
         openai_api_key=final_openai_api_key,
         anthropic_api_key=final_anthropic_api_key,
+        auto_reconcile=final_auto_reconcile,
     )
 
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -176,6 +194,7 @@ def write_full_config(
     memgraph_database: str = _MEMGRAPH_DEFAULTS["database"],
     openai_api_key: str = _LLM_DEFAULTS["openai_api_key"],
     anthropic_api_key: str = _LLM_DEFAULTS["anthropic_api_key"],
+    auto_reconcile: bool = _RECONCILE_DEFAULTS["auto_reconcile"],
 ) -> Path:
     """Write a complete config file with all sections (used by bootstrap).
 
@@ -191,6 +210,7 @@ def write_full_config(
         database=memgraph_database,
         openai_api_key=openai_api_key,
         anthropic_api_key=anthropic_api_key,
+        auto_reconcile=auto_reconcile,
     )
 
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -227,6 +247,7 @@ def _read_config_file() -> HookConfig:
     identity = sections.get("identity", {})
     memgraph = sections.get("memgraph", {})
     llm = sections.get("llm", {})
+    reconcile = sections.get("reconcile", {})
 
     return HookConfig(
         user_id=identity.get("user_id") or None,
@@ -236,6 +257,7 @@ def _read_config_file() -> HookConfig:
         memgraph_database=memgraph.get("database") or _MEMGRAPH_DEFAULTS["database"],
         openai_api_key=llm.get("openai_api_key", _LLM_DEFAULTS["openai_api_key"]),
         anthropic_api_key=llm.get("anthropic_api_key", _LLM_DEFAULTS["anthropic_api_key"]),
+        auto_reconcile=parse_bool_flag(reconcile.get("auto_reconcile", "")),
     )
 
 
@@ -273,6 +295,7 @@ def _render_config(
     database: str,
     openai_api_key: str,
     anthropic_api_key: str,
+    auto_reconcile: bool,
 ) -> str:
     """Render the full config file content."""
     lines = [
@@ -293,8 +316,16 @@ def _render_config(
         f'openai_api_key = "{openai_api_key}"',
         f'anthropic_api_key = "{anthropic_api_key}"',
         "",
+        "[reconcile]",
+        f"auto_reconcile = {'true' if auto_reconcile else 'false'}",
+        "",
     ]
     return "\n".join(lines)
+
+
+def parse_bool_flag(value: str) -> bool:
+    """Parse a TOML/CLI boolean flag string. Truthy: "1"/"true"/"yes"/"on" (case-insensitive)."""
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _string_or_none(value: Any) -> str | None:

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
@@ -40,8 +40,14 @@ _LLM_DEFAULTS = {
 }
 
 _RECONCILE_DEFAULTS = {
-    "auto_reconcile": False,
+    "auto_reconcile": None,
 }
+
+#: Shared truthy/falsy vocabulary for TOML/CLI boolean flags — kept here so
+#: cli.py can validate `config set` input against the same set parse_bool_flag
+#: accepts, instead of redefining it inline.
+TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+FALSY_VALUES = frozenset({"0", "false", "no", "off"})
 
 _sentinel = object()
 _cached_config: object = _sentinel
@@ -58,7 +64,7 @@ class HookConfig:
     memgraph_database: str = _MEMGRAPH_DEFAULTS["database"]
     openai_api_key: str = _LLM_DEFAULTS["openai_api_key"]
     anthropic_api_key: str = _LLM_DEFAULTS["anthropic_api_key"]
-    auto_reconcile: bool = _RECONCILE_DEFAULTS["auto_reconcile"]
+    auto_reconcile: bool | None = _RECONCILE_DEFAULTS["auto_reconcile"]
 
 
 def load_config() -> HookConfig:
@@ -125,14 +131,31 @@ def resolve_llm_env() -> dict[str, str]:
     }
 
 
-def resolve_auto_reconcile() -> bool:
+def resolve_auto_reconcile() -> bool | None:
     """Resolve whether sessions-graph should auto-trigger reconciliation on SESSION_END.
 
-    Config file only — mirrors :func:`resolve_llm_env`. Off by default given
-    LightRAG entity extraction's LLM cost; opt in with
+    Config file only — mirrors :func:`resolve_llm_env`. Returns ``None`` when
+    never configured (the config-file key is absent), distinct from an
+    explicit ``False`` — callers (``agent_context_graph.hooks.runner``) pass
+    this straight through to ``SessionsGraphConnector(auto_reconcile=...)``,
+    whose own resolution order is explicit arg > ``SESSIONS_GRAPH_AUTO_RECONCILE``
+    env var > default off. Collapsing "never configured" to ``False`` here
+    would short-circuit that env var fallback for anyone still relying on it.
+    Off by default given LightRAG entity extraction's LLM cost; opt in with
     ``agent-context-graph config set reconcile.auto_reconcile true``.
     """
     return load_config().auto_reconcile
+
+
+def parse_bool_flag(value: str | bool) -> bool:
+    """Parse a TOML/CLI boolean flag string. Truthy: "1"/"true"/"yes"/"on" (case-insensitive).
+
+    Passing an actual ``bool`` through unchanged guards against a future
+    swap to a real TOML parser (which would hand back native booleans).
+    """
+    if isinstance(value, bool):
+        return value
+    return value.strip().lower() in TRUTHY_VALUES
 
 
 def write_config(
@@ -194,13 +217,22 @@ def write_full_config(
     memgraph_database: str = _MEMGRAPH_DEFAULTS["database"],
     openai_api_key: str = _LLM_DEFAULTS["openai_api_key"],
     anthropic_api_key: str = _LLM_DEFAULTS["anthropic_api_key"],
-    auto_reconcile: bool = _RECONCILE_DEFAULTS["auto_reconcile"],
+    auto_reconcile: bool | None = _RECONCILE_DEFAULTS["auto_reconcile"],
 ) -> Path:
     """Write a complete config file with all sections (used by bootstrap).
 
-    Always overwrites the entire file.
+    Overwrites every section except ``[reconcile]``: unlike identity/Memgraph/LLM
+    settings, ``auto_reconcile`` has no legitimate ambient-env source for
+    ``bootstrap`` to capture (nobody has ``SESSIONS_GRAPH_AUTO_RECONCILE``
+    exported for an unrelated reason the way they might already have
+    ``OPENAI_API_KEY``/`MEMGRAPH_PASSWORD` set) — it is only ever set via
+    ``config set reconcile.auto_reconcile``. Re-running bootstrap must not
+    silently revert it to off, so ``auto_reconcile`` is preserved from the
+    existing file unless explicitly given here.
     """
     global _cached_config
+
+    final_auto_reconcile = auto_reconcile if auto_reconcile is not None else _read_config_file().auto_reconcile
 
     content = _render_config(
         user_id=user_id,
@@ -210,7 +242,7 @@ def write_full_config(
         database=memgraph_database,
         openai_api_key=openai_api_key,
         anthropic_api_key=anthropic_api_key,
-        auto_reconcile=auto_reconcile,
+        auto_reconcile=final_auto_reconcile,
     )
 
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -248,6 +280,7 @@ def _read_config_file() -> HookConfig:
     memgraph = sections.get("memgraph", {})
     llm = sections.get("llm", {})
     reconcile = sections.get("reconcile", {})
+    auto_reconcile_raw = reconcile.get("auto_reconcile")
 
     return HookConfig(
         user_id=identity.get("user_id") or None,
@@ -257,7 +290,7 @@ def _read_config_file() -> HookConfig:
         memgraph_database=memgraph.get("database") or _MEMGRAPH_DEFAULTS["database"],
         openai_api_key=llm.get("openai_api_key", _LLM_DEFAULTS["openai_api_key"]),
         anthropic_api_key=llm.get("anthropic_api_key", _LLM_DEFAULTS["anthropic_api_key"]),
-        auto_reconcile=parse_bool_flag(reconcile.get("auto_reconcile", "")),
+        auto_reconcile=parse_bool_flag(auto_reconcile_raw) if auto_reconcile_raw is not None else None,
     )
 
 
@@ -280,7 +313,11 @@ def _parse_toml(path: Path) -> dict[str, dict[str, str]]:
         if current_section is not None and "=" in stripped:
             key, _, value = stripped.partition("=")
             key = key.strip()
-            value = value.strip().strip('"').strip("'")
+            value = value.strip()
+            if value[:1] not in {'"', "'"} and "#" in value:
+                # Bare (unquoted) value with a trailing comment, e.g. `auto_reconcile = true  # off for now`.
+                value = value.partition("#")[0].strip()
+            value = value.strip('"').strip("'")
             sections[current_section][key] = value
 
     return sections
@@ -295,9 +332,15 @@ def _render_config(
     database: str,
     openai_api_key: str,
     anthropic_api_key: str,
-    auto_reconcile: bool,
+    auto_reconcile: bool | None,
 ) -> str:
-    """Render the full config file content."""
+    """Render the full config file content.
+
+    The ``[reconcile]`` section is omitted entirely when ``auto_reconcile`` is
+    ``None`` (never configured), so a fresh read of the file resolves it back
+    to ``None`` rather than a concrete ``false`` — see
+    :func:`resolve_auto_reconcile` for why that distinction matters.
+    """
     lines = [
         "# Context Graph hook configuration",
         "# Generated by: agent-context-graph config set / bootstrap",
@@ -315,17 +358,11 @@ def _render_config(
         "[llm]",
         f'openai_api_key = "{openai_api_key}"',
         f'anthropic_api_key = "{anthropic_api_key}"',
-        "",
-        "[reconcile]",
-        f"auto_reconcile = {'true' if auto_reconcile else 'false'}",
-        "",
     ]
+    if auto_reconcile is not None:
+        lines += ["", "[reconcile]", f"auto_reconcile = {'true' if auto_reconcile else 'false'}"]
+    lines.append("")
     return "\n".join(lines)
-
-
-def parse_bool_flag(value: str) -> bool:
-    """Parse a TOML/CLI boolean flag string. Truthy: "1"/"true"/"yes"/"on" (case-insensitive)."""
-    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _string_or_none(value: Any) -> str | None:

--- a/context-graph/agent-context-graph/src/agent_context_graph/cli.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/cli.py
@@ -69,6 +69,7 @@ def _config(argv: list[str]) -> int:
     from agent_context_graph.adapters._identity import (
         config_file_path,
         load_config,
+        parse_bool_flag,
         write_config,
     )
 
@@ -82,8 +83,10 @@ def _config(argv: list[str]) -> int:
         "memgraph.database": "memgraph_database",
         "llm.openai_api_key": "openai_api_key",
         "llm.anthropic_api_key": "anthropic_api_key",
+        "reconcile.auto_reconcile": "auto_reconcile",
     }
     _SECRET_KEYS = {"memgraph.password", "llm.openai_api_key", "llm.anthropic_api_key"}
+    _BOOL_KEYS = {"reconcile.auto_reconcile"}
 
     if not argv or argv[0] in {"-h", "--help"}:
         print("usage: agent-context-graph config set <key> <value>")
@@ -108,6 +111,7 @@ def _config(argv: list[str]) -> int:
         print(f"memgraph.database = {config.memgraph_database!r}")
         print(f"llm.openai_api_key = {'***' if config.openai_api_key else repr('')}")
         print(f"llm.anthropic_api_key = {'***' if config.anthropic_api_key else repr('')}")
+        print(f"reconcile.auto_reconcile = {config.auto_reconcile!r}")
         return 0
 
     if action == "set":
@@ -132,8 +136,17 @@ def _config(argv: list[str]) -> int:
         else:
             value = argv[2]
 
-        write_config(**{_CONFIG_KEYS[key]: value})
-        display_value = "***" if key in _SECRET_KEYS else repr(value)
+        write_value: str | bool = value
+        if key in _BOOL_KEYS:
+            normalized = value.strip().lower()
+            _TRUTHY, _FALSY = {"1", "true", "yes", "on"}, {"0", "false", "no", "off"}
+            if normalized not in _TRUTHY | _FALSY:
+                print(f"Invalid value for {key}: {value!r} (expected true/false)", file=sys.stderr)
+                return 2
+            write_value = parse_bool_flag(normalized)
+
+        write_config(**{_CONFIG_KEYS[key]: write_value})
+        display_value = "***" if key in _SECRET_KEYS else repr(write_value)
         print(f"Wrote {key} = {display_value} to {config_path}")
         return 0
 
@@ -266,7 +279,7 @@ def _bootstrap(argv: list[str]) -> int:
     print(f"OK agent-context-graph executable: {executable}")
 
     # Write hook configuration file (auto-write + inform).
-    from agent_context_graph.adapters._identity import write_full_config
+    from agent_context_graph.adapters._identity import parse_bool_flag, write_full_config
 
     user_id = os.environ.get("AGENT_CONTEXT_GRAPH_USER_ID", "")
     memgraph_user = os.environ.get("MEMGRAPH_USER", "")
@@ -274,6 +287,7 @@ def _bootstrap(argv: list[str]) -> int:
     memgraph_database = os.environ.get("MEMGRAPH_DATABASE", "memgraph")
     openai_api_key = os.environ.get("OPENAI_API_KEY", "")
     anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    auto_reconcile = parse_bool_flag(os.environ.get("SESSIONS_GRAPH_AUTO_RECONCILE", ""))
 
     config_path = write_full_config(
         user_id=user_id,
@@ -283,6 +297,7 @@ def _bootstrap(argv: list[str]) -> int:
         memgraph_database=memgraph_database,
         openai_api_key=openai_api_key,
         anthropic_api_key=anthropic_api_key,
+        auto_reconcile=auto_reconcile,
     )
     print(f"OK config: wrote {config_path}")
     if user_id:
@@ -302,6 +317,8 @@ def _bootstrap(argv: list[str]) -> int:
             "   no LLM API key found in environment — sessions-graph reconciliation needs one; "
             "set with: agent-context-graph config set llm.openai_api_key"
         )
+    if auto_reconcile:
+        print("   reconcile.auto_reconcile = True (captured from SESSIONS_GRAPH_AUTO_RECONCILE)")
 
     doctor_args = ["--runtime", args.runtime]
     for connector in connectors:

--- a/context-graph/agent-context-graph/src/agent_context_graph/cli.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/cli.py
@@ -67,6 +67,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _config(argv: list[str]) -> int:
     """Get or set persistent config values in ~/.config/context-graph/config.toml."""
     from agent_context_graph.adapters._identity import (
+        FALSY_VALUES,
+        TRUTHY_VALUES,
         config_file_path,
         load_config,
         parse_bool_flag,
@@ -111,7 +113,10 @@ def _config(argv: list[str]) -> int:
         print(f"memgraph.database = {config.memgraph_database!r}")
         print(f"llm.openai_api_key = {'***' if config.openai_api_key else repr('')}")
         print(f"llm.anthropic_api_key = {'***' if config.anthropic_api_key else repr('')}")
-        print(f"reconcile.auto_reconcile = {config.auto_reconcile!r}")
+        if config.auto_reconcile is None:
+            print("reconcile.auto_reconcile = unset (defaults to false)")
+        else:
+            print(f"reconcile.auto_reconcile = {'true' if config.auto_reconcile else 'false'}")
         return 0
 
     if action == "set":
@@ -139,14 +144,18 @@ def _config(argv: list[str]) -> int:
         write_value: str | bool = value
         if key in _BOOL_KEYS:
             normalized = value.strip().lower()
-            _TRUTHY, _FALSY = {"1", "true", "yes", "on"}, {"0", "false", "no", "off"}
-            if normalized not in _TRUTHY | _FALSY:
+            if normalized not in TRUTHY_VALUES | FALSY_VALUES:
                 print(f"Invalid value for {key}: {value!r} (expected true/false)", file=sys.stderr)
                 return 2
             write_value = parse_bool_flag(normalized)
 
         write_config(**{_CONFIG_KEYS[key]: write_value})
-        display_value = "***" if key in _SECRET_KEYS else repr(write_value)
+        if key in _SECRET_KEYS:
+            display_value = "***"
+        elif key in _BOOL_KEYS:
+            display_value = str(write_value).lower()
+        else:
+            display_value = repr(write_value)
         print(f"Wrote {key} = {display_value} to {config_path}")
         return 0
 
@@ -279,7 +288,7 @@ def _bootstrap(argv: list[str]) -> int:
     print(f"OK agent-context-graph executable: {executable}")
 
     # Write hook configuration file (auto-write + inform).
-    from agent_context_graph.adapters._identity import parse_bool_flag, write_full_config
+    from agent_context_graph.adapters._identity import write_full_config
 
     user_id = os.environ.get("AGENT_CONTEXT_GRAPH_USER_ID", "")
     memgraph_user = os.environ.get("MEMGRAPH_USER", "")
@@ -287,8 +296,14 @@ def _bootstrap(argv: list[str]) -> int:
     memgraph_database = os.environ.get("MEMGRAPH_DATABASE", "memgraph")
     openai_api_key = os.environ.get("OPENAI_API_KEY", "")
     anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-    auto_reconcile = parse_bool_flag(os.environ.get("SESSIONS_GRAPH_AUTO_RECONCILE", ""))
 
+    # auto_reconcile is deliberately NOT captured from SESSIONS_GRAPH_AUTO_RECONCILE
+    # here, unlike the keys above: those have a legitimate ambient-env source
+    # (people already have OPENAI_API_KEY/MEMGRAPH_PASSWORD exported for other
+    # tools), but nobody has this env var set for an unrelated reason -- it's
+    # only ever set via `config set reconcile.auto_reconcile`. write_full_config
+    # preserves the existing value when auto_reconcile isn't passed, so
+    # re-running bootstrap can't silently revert it to off.
     config_path = write_full_config(
         user_id=user_id,
         memgraph_url=memgraph_url,
@@ -297,7 +312,6 @@ def _bootstrap(argv: list[str]) -> int:
         memgraph_database=memgraph_database,
         openai_api_key=openai_api_key,
         anthropic_api_key=anthropic_api_key,
-        auto_reconcile=auto_reconcile,
     )
     print(f"OK config: wrote {config_path}")
     if user_id:
@@ -317,9 +331,6 @@ def _bootstrap(argv: list[str]) -> int:
             "   no LLM API key found in environment — sessions-graph reconciliation needs one; "
             "set with: agent-context-graph config set llm.openai_api_key"
         )
-    if auto_reconcile:
-        print("   reconcile.auto_reconcile = True (captured from SESSIONS_GRAPH_AUTO_RECONCILE)")
-
     doctor_args = ["--runtime", args.runtime]
     for connector in connectors:
         doctor_args.extend(["--connector", connector])
@@ -390,7 +401,13 @@ def _check_config() -> dict[str, object]:
     parts.append(
         "llm_key=SET" if llm_key_set else "llm_key=NOT SET (needed only for sessions-graph auto-reconciliation)"
     )
-    return {"name": "config", "ok": bool(config.user_id), "detail": f"{path} — {'; '.join(parts)}"}
+    auto_reconcile_on = bool(config.auto_reconcile)
+    parts.append(f"auto_reconcile={'ON' if auto_reconcile_on else 'OFF'}")
+    broken_auto_reconcile = auto_reconcile_on and not llm_key_set
+    if broken_auto_reconcile:
+        parts.append("WARNING: auto_reconcile is ON but no LLM key is set — reconciliation will fail")
+    ok = bool(config.user_id) and not broken_auto_reconcile
+    return {"name": "config", "ok": ok, "detail": f"{path} — {'; '.join(parts)}"}
 
 
 def _check_memgraph() -> dict[str, object]:

--- a/context-graph/agent-context-graph/src/agent_context_graph/hooks/runner.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/hooks/runner.py
@@ -159,9 +159,11 @@ def _add_sessions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] 
         msg = "sessions-graph is required for the sessions-graph connector"
         raise ImportError(msg) from exc
 
+    from agent_context_graph.adapters._identity import resolve_auto_reconcile
+
     kwargs = _memgraph_kwargs(memgraph_env)
     graph = SessionsGraph(**kwargs)
-    link.add_connector(SessionsGraphConnector(graph))
+    link.add_connector(SessionsGraphConnector(graph, auto_reconcile=resolve_auto_reconcile()))
 
 
 def _add_actions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] | None = None) -> None:

--- a/context-graph/agent-context-graph/tests/test_config_cli.py
+++ b/context-graph/agent-context-graph/tests/test_config_cli.py
@@ -24,7 +24,7 @@ def config_dir(monkeypatch, tmp_path):
 
 def test_config_set_reconcile_auto_reconcile_true(config_dir, capsys):
     assert top_level_main(["config", "set", "reconcile.auto_reconcile", "true"]) == 0
-    assert "Wrote reconcile.auto_reconcile = True" in capsys.readouterr().out
+    assert "Wrote reconcile.auto_reconcile = true" in capsys.readouterr().out
     assert _identity.load_config().auto_reconcile is True
 
 
@@ -33,7 +33,7 @@ def test_config_set_reconcile_auto_reconcile_false(config_dir, capsys):
     _identity._reset_cache()
 
     assert top_level_main(["config", "set", "reconcile.auto_reconcile", "false"]) == 0
-    assert "Wrote reconcile.auto_reconcile = False" in capsys.readouterr().out
+    assert "Wrote reconcile.auto_reconcile = false" in capsys.readouterr().out
     assert _identity.load_config().auto_reconcile is False
 
 
@@ -50,6 +50,19 @@ def test_config_get_reconcile_auto_reconcile(config_dir, capsys):
     assert capsys.readouterr().out.strip() == "True"
 
 
-def test_config_show_includes_reconcile_auto_reconcile(config_dir, capsys):
+def test_config_get_reconcile_auto_reconcile_reports_unset(config_dir, capsys):
+    assert top_level_main(["config", "get", "reconcile.auto_reconcile"]) == 1
+    assert "not set" in capsys.readouterr().err
+
+
+def test_config_show_reports_unset_reconcile_auto_reconcile(config_dir, capsys):
     assert top_level_main(["config", "show"]) == 0
-    assert "reconcile.auto_reconcile = False" in capsys.readouterr().out
+    assert "reconcile.auto_reconcile = unset (defaults to false)" in capsys.readouterr().out
+
+
+def test_config_show_includes_explicit_reconcile_auto_reconcile(config_dir, capsys):
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+
+    assert top_level_main(["config", "show"]) == 0
+    assert "reconcile.auto_reconcile = true" in capsys.readouterr().out

--- a/context-graph/agent-context-graph/tests/test_config_cli.py
+++ b/context-graph/agent-context-graph/tests/test_config_cli.py
@@ -1,0 +1,55 @@
+"""Tests for the `agent-context-graph config set/get/show` CLI subcommand."""
+
+import pytest
+
+from agent_context_graph.adapters import _identity
+from agent_context_graph.cli import main as top_level_main
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    _identity._reset_cache()
+    yield
+    _identity._reset_cache()
+
+
+@pytest.fixture()
+def config_dir(monkeypatch, tmp_path):
+    config_dir = tmp_path / "context-graph"
+    config_file = config_dir / "config.toml"
+    monkeypatch.setattr(_identity, "_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(_identity, "_CONFIG_FILE", config_file)
+    return config_dir
+
+
+def test_config_set_reconcile_auto_reconcile_true(config_dir, capsys):
+    assert top_level_main(["config", "set", "reconcile.auto_reconcile", "true"]) == 0
+    assert "Wrote reconcile.auto_reconcile = True" in capsys.readouterr().out
+    assert _identity.load_config().auto_reconcile is True
+
+
+def test_config_set_reconcile_auto_reconcile_false(config_dir, capsys):
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+
+    assert top_level_main(["config", "set", "reconcile.auto_reconcile", "false"]) == 0
+    assert "Wrote reconcile.auto_reconcile = False" in capsys.readouterr().out
+    assert _identity.load_config().auto_reconcile is False
+
+
+def test_config_set_reconcile_auto_reconcile_rejects_invalid_value(config_dir, capsys):
+    assert top_level_main(["config", "set", "reconcile.auto_reconcile", "banana"]) == 2
+    assert "Invalid value for reconcile.auto_reconcile" in capsys.readouterr().err
+
+
+def test_config_get_reconcile_auto_reconcile(config_dir, capsys):
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+
+    assert top_level_main(["config", "get", "reconcile.auto_reconcile"]) == 0
+    assert capsys.readouterr().out.strip() == "True"
+
+
+def test_config_show_includes_reconcile_auto_reconcile(config_dir, capsys):
+    assert top_level_main(["config", "show"]) == 0
+    assert "reconcile.auto_reconcile = False" in capsys.readouterr().out

--- a/context-graph/agent-context-graph/tests/test_identity.py
+++ b/context-graph/agent-context-graph/tests/test_identity.py
@@ -106,14 +106,22 @@ def test_write_config_preserves_llm_keys(config_dir):
 # --- resolve_auto_reconcile ---
 
 
-def test_auto_reconcile_defaults_to_false(config_dir):
-    assert _identity.resolve_auto_reconcile() is False
+def test_auto_reconcile_is_none_when_never_configured(config_dir):
+    """None (not False) when never configured, so callers can fall back to the
+    SESSIONS_GRAPH_AUTO_RECONCILE env var instead of forcing it off (finding 1)."""
+    assert _identity.resolve_auto_reconcile() is None
 
 
 def test_auto_reconcile_from_config_file(config_dir):
     _identity.write_full_config(auto_reconcile=True)
     _identity._reset_cache()
     assert _identity.resolve_auto_reconcile() is True
+
+
+def test_auto_reconcile_explicit_false_is_not_collapsed_to_none(config_dir):
+    _identity.write_full_config(auto_reconcile=False)
+    _identity._reset_cache()
+    assert _identity.resolve_auto_reconcile() is False
 
 
 def test_write_config_preserves_auto_reconcile(config_dir):
@@ -134,6 +142,26 @@ def test_write_config_can_toggle_auto_reconcile_off(config_dir):
     assert _identity.load_config().auto_reconcile is False
 
 
+def test_write_full_config_preserves_auto_reconcile_when_not_given(config_dir):
+    """Simulates re-running `bootstrap`: it must not silently revert
+    reconcile.auto_reconcile to off just because it doesn't pass it (finding 2)."""
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+    _identity.write_full_config(user_id="rebootstrapped")
+    _identity._reset_cache()
+    config = _identity.load_config()
+    assert config.auto_reconcile is True
+    assert config.user_id == "rebootstrapped"
+
+
+def test_write_full_config_can_explicitly_set_auto_reconcile(config_dir):
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+    _identity.write_full_config(auto_reconcile=False)
+    _identity._reset_cache()
+    assert _identity.load_config().auto_reconcile is False
+
+
 # --- parse_bool_flag ---
 
 
@@ -145,6 +173,28 @@ def test_parse_bool_flag_truthy_values():
 def test_parse_bool_flag_falsy_values():
     for value in ("0", "false", "no", "off", "", "garbage"):
         assert _identity.parse_bool_flag(value) is False
+
+
+def test_parse_bool_flag_passes_real_bool_through(config_dir):
+    assert _identity.parse_bool_flag(True) is True
+    assert _identity.parse_bool_flag(False) is False
+
+
+# --- _parse_toml inline comments ---
+
+
+def test_parse_toml_strips_inline_comment_on_bare_value(config_dir, tmp_path):
+    f = tmp_path / "test.toml"
+    f.write_text("[reconcile]\nauto_reconcile = true  # off for now\n")
+    sections = _identity._parse_toml(f)
+    assert sections["reconcile"]["auto_reconcile"] == "true"
+
+
+def test_parse_toml_leaves_quoted_value_with_hash_alone(config_dir, tmp_path):
+    f = tmp_path / "test.toml"
+    f.write_text('[identity]\nuser_id = "user#123"\n')
+    sections = _identity._parse_toml(f)
+    assert sections["identity"]["user_id"] == "user#123"
 
 
 # --- write_config ---
@@ -174,7 +224,7 @@ def test_write_full_config_writes_all_defaults(config_dir):
     assert config.user_id is None  # empty string -> None
     assert config.memgraph_url == "bolt://localhost:7687"
     assert config.memgraph_database == "memgraph"
-    assert config.auto_reconcile is False
+    assert config.auto_reconcile is None
 
 
 # --- load_config ---

--- a/context-graph/agent-context-graph/tests/test_identity.py
+++ b/context-graph/agent-context-graph/tests/test_identity.py
@@ -103,6 +103,50 @@ def test_write_config_preserves_llm_keys(config_dir):
     assert config.user_id == "someone"
 
 
+# --- resolve_auto_reconcile ---
+
+
+def test_auto_reconcile_defaults_to_false(config_dir):
+    assert _identity.resolve_auto_reconcile() is False
+
+
+def test_auto_reconcile_from_config_file(config_dir):
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+    assert _identity.resolve_auto_reconcile() is True
+
+
+def test_write_config_preserves_auto_reconcile(config_dir):
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+    _identity.write_config(user_id="someone")
+    _identity._reset_cache()
+    config = _identity.load_config()
+    assert config.auto_reconcile is True
+    assert config.user_id == "someone"
+
+
+def test_write_config_can_toggle_auto_reconcile_off(config_dir):
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+    _identity.write_config(auto_reconcile=False)
+    _identity._reset_cache()
+    assert _identity.load_config().auto_reconcile is False
+
+
+# --- parse_bool_flag ---
+
+
+def test_parse_bool_flag_truthy_values():
+    for value in ("1", "true", "True", "yes", "YES", "on"):
+        assert _identity.parse_bool_flag(value) is True
+
+
+def test_parse_bool_flag_falsy_values():
+    for value in ("0", "false", "no", "off", "", "garbage"):
+        assert _identity.parse_bool_flag(value) is False
+
+
 # --- write_config ---
 
 
@@ -130,6 +174,7 @@ def test_write_full_config_writes_all_defaults(config_dir):
     assert config.user_id is None  # empty string -> None
     assert config.memgraph_url == "bolt://localhost:7687"
     assert config.memgraph_database == "memgraph"
+    assert config.auto_reconcile is False
 
 
 # --- load_config ---

--- a/context-graph/agent-context-graph/tests/test_runner_sessions_graph_connector.py
+++ b/context-graph/agent-context-graph/tests/test_runner_sessions_graph_connector.py
@@ -1,0 +1,64 @@
+"""Tests that the sessions-graph connector wiring resolves auto_reconcile from
+persistent config (agent_context_graph.adapters._identity), not just the
+SESSIONS_GRAPH_AUTO_RECONCILE env var read internally by SessionsGraphConnector.
+"""
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from agent_context_graph.adapters import _identity
+from agent_context_graph.hooks.runner import create_link
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    _identity._reset_cache()
+    yield
+    _identity._reset_cache()
+
+
+@pytest.fixture()
+def config_dir(monkeypatch, tmp_path):
+    config_dir = tmp_path / "context-graph"
+    config_file = config_dir / "config.toml"
+    monkeypatch.setattr(_identity, "_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(_identity, "_CONFIG_FILE", config_file)
+    return config_dir
+
+
+@pytest.fixture()
+def fake_sessions_graph(monkeypatch):
+    """Stub the sessions_graph package so runner.py's import succeeds without it installed."""
+    constructed = {}
+
+    class _SessionsGraph:
+        def __init__(self, **kwargs):
+            pass
+
+    class _SessionsGraphConnector:
+        def __init__(self, graph, *, auto_reconcile=None):
+            constructed["auto_reconcile"] = auto_reconcile
+
+    fake_core = ModuleType("sessions_graph")
+    fake_core.SessionsGraph = _SessionsGraph
+    fake_connector = ModuleType("sessions_graph.connector")
+    fake_connector.SessionsGraphConnector = _SessionsGraphConnector
+
+    monkeypatch.setitem(sys.modules, "sessions_graph", fake_core)
+    monkeypatch.setitem(sys.modules, "sessions_graph.connector", fake_connector)
+    return constructed
+
+
+def test_sessions_graph_connector_defaults_auto_reconcile_off(config_dir, fake_sessions_graph):
+    create_link(["sessions_graph"])
+    assert fake_sessions_graph["auto_reconcile"] is False
+
+
+def test_sessions_graph_connector_reads_auto_reconcile_from_config(config_dir, fake_sessions_graph):
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+
+    create_link(["sessions_graph"])
+    assert fake_sessions_graph["auto_reconcile"] is True

--- a/context-graph/agent-context-graph/tests/test_runner_sessions_graph_connector.py
+++ b/context-graph/agent-context-graph/tests/test_runner_sessions_graph_connector.py
@@ -51,14 +51,29 @@ def fake_sessions_graph(monkeypatch):
     return constructed
 
 
-def test_sessions_graph_connector_defaults_auto_reconcile_off(config_dir, fake_sessions_graph):
+def test_sessions_graph_connector_passes_none_when_unconfigured(config_dir, fake_sessions_graph):
+    """Unconfigured must resolve to None, not False -- otherwise it silently
+    suppresses the connector's own SESSIONS_GRAPH_AUTO_RECONCILE env fallback
+    for anyone who has that var exported (finding 1)."""
     create_link(["sessions_graph"])
-    assert fake_sessions_graph["auto_reconcile"] is False
+    assert fake_sessions_graph["auto_reconcile"] is None
 
 
-def test_sessions_graph_connector_reads_auto_reconcile_from_config(config_dir, fake_sessions_graph):
+def test_sessions_graph_connector_reads_auto_reconcile_true_from_config(config_dir, fake_sessions_graph):
     _identity.write_full_config(auto_reconcile=True)
     _identity._reset_cache()
 
     create_link(["sessions_graph"])
     assert fake_sessions_graph["auto_reconcile"] is True
+
+
+def test_sessions_graph_connector_reads_explicit_false_from_config(config_dir, fake_sessions_graph):
+    """An explicit `config set reconcile.auto_reconcile false` must be passed
+    through as False (suppressing auto-reconcile), not collapsed to None."""
+    _identity.write_full_config(auto_reconcile=True)
+    _identity._reset_cache()
+    _identity.write_config(auto_reconcile=False)
+    _identity._reset_cache()
+
+    create_link(["sessions_graph"])
+    assert fake_sessions_graph["auto_reconcile"] is False

--- a/context-graph/sessions-graph/README.md
+++ b/context-graph/sessions-graph/README.md
@@ -175,12 +175,26 @@ Codex) enforce a timeout on hook commands. Instead:
 
 - Or, if you want it triggered automatically without a manual/cron step, opt
   in to a **best-effort detached background process** spawned right after a
-  session ends: pass `SessionsGraphConnector(graph, auto_reconcile=True)`, or set
+  session ends. For hook-based runtimes (Claude Code, Codex), set this
+  persistently:
+
+  ```bash
+  agent-context-graph config set reconcile.auto_reconcile true
+  ```
+
+  This writes `[reconcile] auto_reconcile = true` to
+  `~/.config/context-graph/config.toml`, which
+  `agent_context_graph.hooks.runner._add_sessions_graph_connector` reads on
+  every hook invocation via `resolve_auto_reconcile()` — no shell/session
+  restart quirks, since hook subprocesses don't reliably inherit shell
+  profile environment variables. Direct SDK integrations that construct
+  `SessionsGraphConnector` themselves can instead pass
+  `SessionsGraphConnector(graph, auto_reconcile=True)`, or set
   `SESSIONS_GRAPH_AUTO_RECONCILE=1` in the environment the connector is
-  constructed in (this is what hook-based runtimes read, since they don't
-  expose a constructor kwarg for it). This is fire-and-forget — if the
-  process dies before finishing (machine sleep, crash), the session stays
-  `pending` and `sessions-graph reconcile --pending` is the reliable backfill.
+  constructed in (a fallback, only consulted when `auto_reconcile` isn't
+  passed explicitly). This is fire-and-forget — if the process dies before
+  finishing (machine sleep, crash), the session stays `pending` and
+  `sessions-graph reconcile --pending` is the reliable backfill.
 
 Programmatically:
 

--- a/context-graph/sessions-graph/src/sessions_graph/connector.py
+++ b/context-graph/sessions-graph/src/sessions_graph/connector.py
@@ -50,13 +50,14 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_EVENTS = {EventType.SESSION_START, EventType.SESSION_END}
 
 #: Read at connector construction time when auto_reconcile isn't passed explicitly.
-#: Hook-based runtimes (Claude Code, Codex) no longer rely on this: since
-#: agent_context_graph 0.2.0, agent_context_graph.hooks.runner._add_sessions_graph_connector
+#: As of agent_context_graph 0.2.1, agent_context_graph.hooks.runner._add_sessions_graph_connector
 #: resolves the persistent ``reconcile.auto_reconcile`` config-file setting
 #: (agent_context_graph.adapters._identity.resolve_auto_reconcile(), set via
 #: ``agent-context-graph config set reconcile.auto_reconcile true``) and passes
-#: it explicitly, which takes priority. This env var remains a fallback for
-#: SDK integrations that construct SessionsGraphConnector directly.
+#: that straight through -- an explicit True/False from the config file takes
+#: priority, but resolve_auto_reconcile() returns None when never configured,
+#: in which case this env var is still consulted below. SDK integrations that
+#: construct SessionsGraphConnector directly rely solely on this env var.
 _AUTO_RECONCILE_ENV_VAR = "SESSIONS_GRAPH_AUTO_RECONCILE"
 
 

--- a/context-graph/sessions-graph/src/sessions_graph/connector.py
+++ b/context-graph/sessions-graph/src/sessions_graph/connector.py
@@ -50,11 +50,13 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_EVENTS = {EventType.SESSION_START, EventType.SESSION_END}
 
 #: Read at connector construction time when auto_reconcile isn't passed explicitly.
-#: Note: hook-based runtimes (Claude Code, Codex) construct this connector
-#: without exposing a constructor kwarg for it (see
-#: agent_context_graph.adapters.claude_code/codex._add_sessions_graph_connector),
-#: so this env var is currently the only way to opt in there; SDK integrations
-#: that construct SessionsGraphConnector directly can pass auto_reconcile=True instead.
+#: Hook-based runtimes (Claude Code, Codex) no longer rely on this: since
+#: agent_context_graph 0.2.0, agent_context_graph.hooks.runner._add_sessions_graph_connector
+#: resolves the persistent ``reconcile.auto_reconcile`` config-file setting
+#: (agent_context_graph.adapters._identity.resolve_auto_reconcile(), set via
+#: ``agent-context-graph config set reconcile.auto_reconcile true``) and passes
+#: it explicitly, which takes priority. This env var remains a fallback for
+#: SDK integrations that construct SessionsGraphConnector directly.
 _AUTO_RECONCILE_ENV_VAR = "SESSIONS_GRAPH_AUTO_RECONCILE"
 
 
@@ -81,9 +83,11 @@ class SessionsGraphConnector(GraphConnector):
     Args:
         graph: An initialised :class:`SessionsGraph` instance.
         auto_reconcile: Whether to spawn a detached reconciliation process on
-            SESSION_END. Defaults to the ``SESSIONS_GRAPH_AUTO_RECONCILE`` env
-            var (truthy: "1"/"true"/"yes"/"on") when not given explicitly.
-            Off by default given LightRAG entity extraction's LLM cost.
+            SESSION_END. Hook-based runtimes pass this explicitly, resolved
+            from the persistent ``reconcile.auto_reconcile`` config-file
+            setting. Defaults to the ``SESSIONS_GRAPH_AUTO_RECONCILE`` env var
+            (truthy: "1"/"true"/"yes"/"on") when not given explicitly. Off by
+            default given LightRAG entity extraction's LLM cost.
     """
 
     def __init__(self, graph: SessionsGraph, *, auto_reconcile: bool | None = None) -> None:

--- a/context-graph/sessions-graph/tests/test_sessions_graph.py
+++ b/context-graph/sessions-graph/tests/test_sessions_graph.py
@@ -180,14 +180,23 @@ class TestSessionsGraphConnector:
         assert connector.active_user_id is None
         assert connector.active_session_id is None
 
-    def test_auto_reconcile_defaults_off_and_does_not_spawn_process(self):
+    def test_auto_reconcile_defaults_off_and_does_not_spawn_process(self, monkeypatch):
+        # Must not consult ambient env for this -- a real shell with
+        # SESSIONS_GRAPH_AUTO_RECONCILE=1 exported would otherwise make this
+        # test flip Popen on and fail, dumping the *real* env= dict (secrets
+        # included) into the assertion failure message. Same bug class this
+        # test exists to catch, just at the test level instead of the code.
+        monkeypatch.delenv("SESSIONS_GRAPH_AUTO_RECONCILE", raising=False)
         connector, _graph, _db, SessionStartEvent, SessionEndEvent = self._make()
 
         with patch("sessions_graph.connector.subprocess.Popen") as mock_popen:
             connector.on_event(SessionStartEvent(session_id="s-1", user_id="alice"))
             connector.on_event(SessionEndEvent(session_id="s-1"))
 
-        mock_popen.assert_not_called()
+        # call_count, not assert_not_called(): the latter's failure message
+        # renders the full call args -- including env=dict(os.environ), real
+        # secrets and all -- which is exactly how this got flagged in review.
+        assert mock_popen.call_count == 0
 
     def test_auto_reconcile_true_spawns_detached_process(self, context_graph_config):
         from sessions_graph.connector import SessionsGraphConnector

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ provides-extras = ["agent-context-graph", "claude-agent", "test"]
 
 [[package]]
 name = "agent-context-graph"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "context-graph/agent-context-graph" }
 dependencies = [
     { name = "memgraph-toolbox" },


### PR DESCRIPTION
## Summary
- `SESSIONS_GRAPH_AUTO_RECONCILE` was only read as a raw env var at `SessionsGraphConnector` construction time — but hook subprocesses (Claude Code, Codex) aren't guaranteed to inherit shell profile environment variables, which is exactly why `identity.user_id`, `memgraph.*`, and `llm.*` already live in `~/.config/context-graph/config.toml` instead.
- Adds `reconcile.auto_reconcile` as the same kind of persistent, config-file-only setting: `agent-context-graph config set reconcile.auto_reconcile true`, captured by `bootstrap` the same way `llm.*` keys are, and resolved explicitly by `hooks/runner.py` when constructing the sessions-graph connector.
- The `SESSIONS_GRAPH_AUTO_RECONCILE` env var remains a fallback for SDK integrations that construct `SessionsGraphConnector` directly (unchanged behavior there).
- Docs updated in `sessions-graph/README.md` and `agent-context-graph/docs/command-hooks.md`.

## Test plan
- [x] `uv run --package agent-context-graph pytest` — 102 passed
- [x] `uv run --package sessions-graph pytest` — 55 passed
- [x] `ruff check` clean
- [x] Verified live: reinstalled `agent-context-graph` from local source, ran `config set/get/show reconcile.auto_reconcile` end-to-end against the real `~/.config/context-graph/config.toml`