### PR TITLE
langchain-memgraph: bump to 0.1.15, require memgraph-toolbox>=0.2.0

### DIFF
--- a/integrations/langchain-memgraph/pyproject.toml
+++ b/integrations/langchain-memgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-memgraph"
-version = "0.1.14"
+version = "0.1.15"
 description = "An integration package connecting Memgraph and LangChain"
 authors = [{ name = "Ante Javor", email = "ante.javor@memgraph.com" }]
 readme = "README.md"
@@ -19,7 +19,7 @@ dependencies = [
   "langchain-core>=1.2.28",
     "langchain-classic>=1.0.0",
     "neo4j>=5.28.1",
-    "memgraph-toolbox>=0.1.11",
+    "memgraph-toolbox>=0.2.0",
     "langchain>=1.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3054,7 +3054,7 @@ wheels = [
 
 [[package]]
 name = "langchain-memgraph"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "integrations/langchain-memgraph" }
 dependencies = [
     { name = "langchain" },


### PR DESCRIPTION
## Summary

Fixes a live production break: `pip install langchain-memgraph` today pulls the last-published `0.1.14` together with `memgraph-toolbox>=0.2.0` (unbounded floor), and immediately fails with `ImportError` — reported by a user whose CI unknowingly upgraded and broke.

**Root cause:**
- #211 restructured `memgraph-toolbox`'s tools (deleted `betweenness_centrality.py`, `config.py`, `constraint.py`, `index.py`, `node_neighborhood.py`, `node_vector_search.py`, `page_rank.py`, `storage.py`, `trigger.py`; replaced `schema.py`'s `ShowSchemaInfoTool` with `NodeSchemaTool`/`RelationshipSchemaTool`/`EnumSchemaTool`/`SearchSchemaTool`) and updated `langchain-memgraph`'s source in the *same commit* — but neither package's version was bumped.
- #244 later bumped and published `memgraph-toolbox` 0.2.0, but never touched `langchain-memgraph`.
- Downloaded the actual published `langchain-memgraph-0.1.14` wheel from PyPI and confirmed its `tools.py` still imports all 10 of the now-deleted modules/classes.

Checked siblings touched by the same restructuring commit: `mcp-memgraph` is fine (already published at 0.3.0 with `memgraph-toolbox>=0.2.0`). `unstructured2graph`/`lightrag-memgraph` have the same loose `>=0.1.11` floor but don't import any of the deleted symbols, so they aren't actually broken by this.

## Changes
- `langchain-memgraph` 0.1.14 → 0.1.15 (main's source already matches the current `memgraph-toolbox` API — this PR is a metadata-only fix).
- `memgraph-toolbox>=0.1.11` → `>=0.2.0`, so this exact pairing can't recur.

## Test plan
- [x] `uv run --package langchain-memgraph --extra test pytest` (unit tests) — 6 passed
- [x] Full import smoke test (`import langchain_memgraph`, `from langchain_memgraph.tools import *`, `from langchain_memgraph.toolkits import *`) against current `memgraph-toolbox` — succeeds
- [x] `ruff check` clean
- [ ] After merge: trigger `release-langchain-memgraph.yaml` (`workflow_dispatch`) to actually publish 0.1.15 to PyPI