### PR TITLE
Add AGENTS.md, stop gitignoring it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,6 @@ cython_debug/
 # Local agent hook configuration
 /.codex/
 /.claude/settings.local.json
-/AGENTS.md
 /docs/agents/
 /context-graph/CONTEXT-MAP.md
 /context-graph/*/CONTEXT.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,8 @@
 # AGENTS.md
 
 Guidance for coding agents working in `memgraph/ai-toolkit`. This file is
-gitignored (see `.gitignore`) — it's a local, living doc, same treatment as
-`context-graph/CONTEXT-MAP.md`, each component's `CONTEXT.md`, and the
-`docs/adr/` files described below. Don't be surprised it never shows up in
-`git status`; update it in place as things change.
+tracked in git — update it in place as things change, in the same PR as the
+change that made it stale where practical.
 
 ## What this repo is
 
@@ -51,8 +49,9 @@ node; only `sessions-graph` owns `(:User)` and `HAD_SESSION`.
   ```
 - Run a workspace package's own suite via `uv run --package <name> --extra test pytest ...`
   (see `.github/workflows/tests.yaml` for the exact invocation per package,
-  including which extras each one needs — e.g. `skills-graph` and
-  `actions-graph` also need `--extra agent-context-graph`).
+  including which extras each one needs — e.g. `skills-graph`, `actions-graph`,
+  and `sessions-graph` all also need `--extra agent-context-graph`, and
+  `sessions-graph` additionally needs `--extra reconciliation`).
 
 ## Common commands
 
@@ -140,8 +139,8 @@ touching `agent-context-graph`'s hook/config code.
 
 ## Local-only design docs — read before non-trivial Context Graph work
 
-This repo keeps several living design documents **gitignored and local-only**
-(same treatment as this file): `context-graph/CONTEXT-MAP.md`, each
+This repo keeps several living design documents **gitignored and
+local-only** (unlike this file): `context-graph/CONTEXT-MAP.md`, each
 component's own `context-graph/*/CONTEXT.md`, `unstructured2graph/CONTEXT.md`,
 and per-package `docs/adr/*.md` files. They aren't in git, so a fresh clone
 or a fresh worktree won't have them — check whether your checkout already
@@ -178,9 +177,12 @@ the essentials, if you don't have them locally:
 - Model only what real harness hook/SDK payloads actually provide (verified
   against primary docs, or against a live session via
   `dev-memgraph.sh test-graph-model`), never an aspirational field nobody
-  populates — this is why `PARENT_OF` (nested actions) and
-  `Session.parent_session_id`/`FORKED_FROM` were deleted outright rather than
-  kept unpopulated.
+  populates — this is why `Session.parent_session_id`/`FORKED_FROM` were
+  deleted outright (no harness ever populates a parent/previous session id)
+  and why `(:Action)-[:PARENT_OF]->(:Action)` was narrowed to only
+  `ToolResult`/error → its `ToolCall`: its old "nested actions" meaning
+  (subagent nesting) wasn't real either, and moved to the dedicated
+  `(:Agent)`/`SPAWNED` mechanism instead.
 
 **Planning workflow** for substantial Context Graph design work: tracked as
 GitHub issues labeled `wayfinder:map` (title `Map: ...`), broken into

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,13 @@ gh issue list --label wayfinder:map --state open
   ```bash
   uv pip install -e memgraph-toolbox"[test]"   # quote extras on zsh/macOS
   ```
+- Working from a nested worktree under this checkout (e.g.
+  `.claude/worktrees/<name>/`)? Run `uv venv` there first. With no local
+  `.venv`, `uv pip install -e ...`/`uv run --package ...` walk up and
+  silently reuse — and mutate — the outer checkout's shared `.venv`,
+  repointing its editable installs at whichever worktree you happen to run
+  from. That's a real collision if another worktree or session relies on
+  that same shared environment.
 - Run a workspace package's own suite via `uv run --package <name> --extra test pytest ...`
   (see `.github/workflows/tests.yaml` for the exact invocation per package,
   including which extras each one needs — e.g. `skills-graph`, `actions-graph`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,23 @@ own real Claude Code session — see `./scripts/dev-memgraph.sh --help`.
   `pyproject.toml` — add your package's import name there if you add a new
   workspace member.
 
+## Type checking
+
+This repo standardizes on [`ty`](https://docs.astral.sh/ty/) (Astral's type
+checker — same vendor as `uv`/`ruff`), not `mypy` or `pyright`. **Not yet
+enforced in CI** — tracked in
+[#313](https://github.com/memgraph/ai-toolkit/issues/313); annotate as you
+touch code in the meantime rather than waiting for enforcement to land.
+`ty` needs a package's own installed dependencies to resolve imports (like
+`pytest`, unlike `ruff`), so check one package at a time:
+```bash
+uvx ty check <package>/src --python .venv
+```
+`integrations/lightrag-memgraph/pyproject.toml` still carries a dormant,
+never-wired-in `mypy` dev dependency and `[tool.mypy]` block predating this
+decision — don't treat it as a second standard; it's slated for removal in
+#313.
+
 ## Testing policy: prefer real Memgraph over mocks
 
 A cross-cutting rule for the Context Graph family and unstructured2graph,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # AGENTS.md
 
-Guidance for coding agents working in `memgraph/ai-toolkit`. This file is
-tracked in git — update it in place as things change, in the same PR as the
-change that made it stale where practical.
+Guidance for coding agents working in `memgraph/ai-toolkit`. Keep it in sync
+with the codebase — update it in the same PR as the change that makes part
+of it stale.
 
 ## What this repo is
 
@@ -38,6 +38,15 @@ Memgraph graph.
 
 Everything joins on a shared, idempotently-`MERGE`d `(:Session {session_id})`
 node; only `sessions-graph` owns `(:User)` and `HAD_SESSION`.
+
+Substantial design work in this family is tracked as GitHub issues labeled
+`wayfinder:map` (title `Map: ...`), broken into `wayfinder:grilling` /
+`wayfinder:research` / `wayfinder:prototype` / `wayfinder:task` child issues,
+using this repo's `/grilling`, `/domain-modeling`, and `/research` skills.
+Check open maps before starting non-trivial work here:
+```bash
+gh issue list --label wayfinder:map --state open
+```
 
 ## Environment & setup
 
@@ -136,63 +145,6 @@ environment variables at runtime — non-interactive hook subprocesses don't
 source shell profiles, so an env-var-only path would silently work in your
 interactive shell and silently fail in the hook. Keep that boundary when
 touching `agent-context-graph`'s hook/config code.
-
-## Local-only design docs — read before non-trivial Context Graph work
-
-This repo keeps several living design documents **gitignored and
-local-only** (unlike this file): `context-graph/CONTEXT-MAP.md`, each
-component's own `context-graph/*/CONTEXT.md`, `unstructured2graph/CONTEXT.md`,
-and per-package `docs/adr/*.md` files. They aren't in git, so a fresh clone
-or a fresh worktree won't have them — check whether your checkout already
-has them on disk (they accumulate over time as design work happens) before
-assuming they don't exist. If you resolve a real ambiguity while working in
-this family, update the relevant one in place.
-
-They hold the actual domain model and are more precise than this summary;
-the essentials, if you don't have them locally:
-
-- **Collection Tier vs. Memory Tier**: raw, ephemeral, hook-time data
-  (`actions-graph`'s `(:Action)`/`(:Agent)` nodes; the raw text other
-  components draw from) is Collection Tier — never call it memory. Memory
-  Tier is the distilled output: semantic (entities/`(:Chunk)`, via
-  `sessions-graph` reconciliation), episodic (`(:Episode)`, same
-  reconciliation pass), procedural (a planned `(:Procedure)`, mined —
-  not yet implemented), and explicit semantic assertions (`(:Memory)`,
-  written directly via `sessions-graph`'s API, not distilled).
-- **`Skill` is spec-locked**: a `(:Skill)` node means an Agent Skills
-  specification skill, full stop. A mined behavioral pattern is a
-  `(:Procedure)`, a deliberately separate node type/namespace — never a
-  "candidate Skill". Promotion from `Procedure` to `Skill` is explicit,
-  not-yet-built future work.
-- **`actions-graph`'s mission is observability, not memory** — even though
-  its data feeds memory elsewhere (`sessions-graph`, later a procedural
-  miner). Don't add memory-shaped behavior to `actions-graph` itself.
-- **`(:Session)` is a shared, ownerless coordination point** — any component
-  may `MERGE` it independently; only `sessions-graph` owns `(:User)` and
-  `HAD_SESSION`.
-- **`(:Agent)`** is a subagent's whole lifecycle as one node (not a pair of
-  flat Actions); `(:Action)-[:SPAWNED]->(:Agent)` links the spawning tool
-  call when a temporal-inference rule resolves it unambiguously — never
-  assume a field carries this directly, no real harness provides one.
-- Model only what real harness hook/SDK payloads actually provide (verified
-  against primary docs, or against a live session via
-  `dev-memgraph.sh test-graph-model`), never an aspirational field nobody
-  populates — this is why `Session.parent_session_id`/`FORKED_FROM` were
-  deleted outright (no harness ever populates a parent/previous session id)
-  and why `(:Action)-[:PARENT_OF]->(:Action)` was narrowed to only
-  `ToolResult`/error → its `ToolCall`: its old "nested actions" meaning
-  (subagent nesting) wasn't real either, and moved to the dedicated
-  `(:Agent)`/`SPAWNED` mechanism instead.
-
-**Planning workflow** for substantial Context Graph design work: tracked as
-GitHub issues labeled `wayfinder:map` (title `Map: ...`), broken into
-`wayfinder:grilling` / `wayfinder:research` / `wayfinder:prototype` /
-`wayfinder:task` child issues, using this repo's `/grilling`,
-`/domain-modeling`, and `/research` skills. Check open maps before starting
-non-trivial work in this area:
-```bash
-gh issue list --label wayfinder:map --state open
-```
 
 ## Releases
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,199 @@
+# AGENTS.md
+
+Guidance for coding agents working in `memgraph/ai-toolkit`. This file is
+gitignored (see `.gitignore`) — it's a local, living doc, same treatment as
+`context-graph/CONTEXT-MAP.md`, each component's `CONTEXT.md`, and the
+`docs/adr/` files described below. Don't be surprised it never shows up in
+`git status`; update it in place as things change.
+
+## What this repo is
+
+Memgraph AI Toolkit — a `uv` workspace of independently-versioned Python
+packages for building AI/agent applications on Memgraph: core DB utilities,
+framework integrations (LangChain, MCP, LightRAG), a document-to-graph
+pipeline, a SQL-to-graph migration agent, and **Context Graph**, a family of
+components that turn Claude Code / Codex agent sessions into a queryable
+Memgraph graph.
+
+## Repository layout
+
+| Path | What it is |
+|---|---|
+| `memgraph-toolbox/` | Core Memgraph client/tooling. Dependency of nearly everything else here. |
+| `integrations/langchain-memgraph/` | LangChain graph store, QA chain, toolkit. |
+| `integrations/mcp-memgraph/` | MCP server exposing Memgraph to LLMs. |
+| `integrations/lightrag-memgraph/` | LightRAG storage backends (KV/vector/doc-status/graph) on Memgraph. |
+| `unstructured2graph/` | Chunks unstructured input (files/URLs/text) and hands chunks to LightRAG for entity extraction. Outside the Context Graph family but shares its testing conventions. |
+| `agents/sql2graph/` | MySQL/Postgres → Memgraph migration agent. Has its own `uv.lock`/`.python-version`; run it with `cd agents/sql2graph && uv run main.py`. |
+| `context-graph/` | The Context Graph family — see below. |
+| `scripts/dev-memgraph.sh` | Local dev lifecycle: exploration Memgraph + isolated test Memgraph for the context-graph family and unstructured2graph. |
+| `skills/release/SKILL.md` | Release process for every PyPI/Docker-published package. |
+
+### The Context Graph family (`context-graph/`)
+
+| Package | Role |
+|---|---|
+| `agent-context-graph` | Event hub. Normalizes runtime hooks / SDK activity into a shared Event Protocol and routes it to graph connectors. |
+| `actions-graph` | Records tool calls/results/messages/subagent activity as `(:Action)`/`(:Agent)` nodes — observability, not memory. |
+| `skills-graph` | Tracks Agent-Skills-spec `(:Skill)` usage per session. |
+| `sessions-graph` | Owns `(:User)`/`(:Session)`, durable `(:Memory)` writes/recall, and session reconciliation into `(:Episode)` + extracted entities. |
+
+Everything joins on a shared, idempotently-`MERGE`d `(:Session {session_id})`
+node; only `sessions-graph` owns `(:User)` and `HAD_SESSION`.
+
+## Environment & setup
+
+- Python `>=3.10`, dependency/workspace manager is `uv`. Workspace members are
+  listed in the root `pyproject.toml` under `[tool.uv.workspace]`.
+- Install a package editable with its test extras, e.g.:
+  ```bash
+  uv pip install -e memgraph-toolbox"[test]"   # quote extras on zsh/macOS
+  ```
+- Run a workspace package's own suite via `uv run --package <name> --extra test pytest ...`
+  (see `.github/workflows/tests.yaml` for the exact invocation per package,
+  including which extras each one needs — e.g. `skills-graph` and
+  `actions-graph` also need `--extra agent-context-graph`).
+
+## Common commands
+
+**Lint / format** (matches `.github/workflows/lint.yaml`):
+```bash
+ruff check .
+ruff format --check .
+# to fix locally:
+ruff check --fix . && ruff format .
+```
+`.pre-commit-config.yaml` runs the same ruff hooks plus
+trailing-whitespace/end-of-file-fixer/check-yaml/check-toml/large-file/merge-conflict checks.
+
+**Tests, non-context-graph packages** — start a plain Memgraph container and
+run pytest in the package directory (see root `README.md` "Developing
+Locally" and `tests.yaml` for per-package extras/env vars, e.g.
+`langchain-memgraph` and `memgraph-toolbox`'s evaluation extras need
+`OPENAI_API_KEY`).
+
+**Tests, Context Graph family + unstructured2graph** — these test against a
+*real* Memgraph, not mocks (see Testing policy below). Don't hand-start a
+stray container for these; `scripts/dev-memgraph.sh` owns the disposable test
+instance so the automated suite can never collide with or wipe your
+exploration data:
+```bash
+./scripts/dev-memgraph.sh test                  # all packages
+./scripts/dev-memgraph.sh test sessions-graph    # one package
+./scripts/dev-memgraph.sh test-down              # reclaim the test container when done
+```
+The same script also drives a disposable *exploration* Memgraph
+(`up`/`hooks-local`/`inspect`/`reconcile`/`down`) for dogfooding against your
+own real Claude Code session — see `./scripts/dev-memgraph.sh --help`.
+
+## Code style
+
+- `ruff`, line length 120, target `py310`. Several naming-convention rules
+  (`N803`/`N806`/`N812`/`N815`) are deliberately ignored repo-wide because
+  graph/DB code follows external casing conventions (e.g. `G` for a graph
+  variable, Cypher/SQL identifier casing) — don't add per-line `noqa` for
+  those, the ignore is already global in root `pyproject.toml`.
+- `isort`'s `known-first-party` list is maintained by hand in
+  `pyproject.toml` — add your package's import name there if you add a new
+  workspace member.
+
+## Testing policy: prefer real Memgraph over mocks
+
+A cross-cutting rule for the Context Graph family and unstructured2graph,
+established after two real bugs (a missing `--connector` flag requirement,
+and `actions-graph` defaulting to the wrong agent-spawning tool name) shipped
+past a fully-green, fully-mocked test suite and were only caught by
+`scripts/dev-memgraph.sh test-graph-model` against a real Claude Code
+session.
+
+**Keep mocked**: hook/adapter → Event Protocol translation and Event
+Protocol → persistence-call translation (pure mapping, proven for real one
+layer down); pure model/dataclass validation with no I/O; exception branches
+a real Memgraph genuinely can't trigger; the LLM boundary in tests that
+aren't specifically about LLM behavior (real-LLM tests exist too, gated
+behind `requires_openai_key`-style skip markers — not deleted).
+
+**Convert to real e2e, or delete outright**: any test that asserts on the
+literal Cypher query string sent to a mocked client rather than executing
+it — a plausible-looking string can still be rejected by real Memgraph.
+Delete it if a real `test_e2e.py` already proves the same behavior; convert
+it (same scenario, executed against a real Memgraph, asserted on the
+resulting graph shape) if nothing else covers it. Prefer a real instance of
+another package's class over a hand-rolled fake standing in for it (e.g.
+don't fake `ActionsGraph` inside `sessions-graph`'s tests) — a fake can
+silently drift from the real shape as that package evolves.
+
+## Commit conventions
+
+Subject line is `<package>: <imperative, lowercase summary> (#PR)`, e.g.
+`sessions-graph: reconcile_session() now writes episodic Session.summary`.
+Cross-cutting family changes use `context-graph: ...`. Issue/ticket numbers
+belong in commit bodies or PR descriptions, not inline in *code comments* —
+that was tried and explicitly reverted.
+
+Credentials note: hook subprocesses (Claude Code/Codex) resolve Memgraph and
+LLM config **only** from `~/.config/context-graph/config.toml`, never from
+environment variables at runtime — non-interactive hook subprocesses don't
+source shell profiles, so an env-var-only path would silently work in your
+interactive shell and silently fail in the hook. Keep that boundary when
+touching `agent-context-graph`'s hook/config code.
+
+## Local-only design docs — read before non-trivial Context Graph work
+
+This repo keeps several living design documents **gitignored and local-only**
+(same treatment as this file): `context-graph/CONTEXT-MAP.md`, each
+component's own `context-graph/*/CONTEXT.md`, `unstructured2graph/CONTEXT.md`,
+and per-package `docs/adr/*.md` files. They aren't in git, so a fresh clone
+or a fresh worktree won't have them — check whether your checkout already
+has them on disk (they accumulate over time as design work happens) before
+assuming they don't exist. If you resolve a real ambiguity while working in
+this family, update the relevant one in place.
+
+They hold the actual domain model and are more precise than this summary;
+the essentials, if you don't have them locally:
+
+- **Collection Tier vs. Memory Tier**: raw, ephemeral, hook-time data
+  (`actions-graph`'s `(:Action)`/`(:Agent)` nodes; the raw text other
+  components draw from) is Collection Tier — never call it memory. Memory
+  Tier is the distilled output: semantic (entities/`(:Chunk)`, via
+  `sessions-graph` reconciliation), episodic (`(:Episode)`, same
+  reconciliation pass), procedural (a planned `(:Procedure)`, mined —
+  not yet implemented), and explicit semantic assertions (`(:Memory)`,
+  written directly via `sessions-graph`'s API, not distilled).
+- **`Skill` is spec-locked**: a `(:Skill)` node means an Agent Skills
+  specification skill, full stop. A mined behavioral pattern is a
+  `(:Procedure)`, a deliberately separate node type/namespace — never a
+  "candidate Skill". Promotion from `Procedure` to `Skill` is explicit,
+  not-yet-built future work.
+- **`actions-graph`'s mission is observability, not memory** — even though
+  its data feeds memory elsewhere (`sessions-graph`, later a procedural
+  miner). Don't add memory-shaped behavior to `actions-graph` itself.
+- **`(:Session)` is a shared, ownerless coordination point** — any component
+  may `MERGE` it independently; only `sessions-graph` owns `(:User)` and
+  `HAD_SESSION`.
+- **`(:Agent)`** is a subagent's whole lifecycle as one node (not a pair of
+  flat Actions); `(:Action)-[:SPAWNED]->(:Agent)` links the spawning tool
+  call when a temporal-inference rule resolves it unambiguously — never
+  assume a field carries this directly, no real harness provides one.
+- Model only what real harness hook/SDK payloads actually provide (verified
+  against primary docs, or against a live session via
+  `dev-memgraph.sh test-graph-model`), never an aspirational field nobody
+  populates — this is why `PARENT_OF` (nested actions) and
+  `Session.parent_session_id`/`FORKED_FROM` were deleted outright rather than
+  kept unpopulated.
+
+**Planning workflow** for substantial Context Graph design work: tracked as
+GitHub issues labeled `wayfinder:map` (title `Map: ...`), broken into
+`wayfinder:grilling` / `wayfinder:research` / `wayfinder:prototype` /
+`wayfinder:task` child issues, using this repo's `/grilling`,
+`/domain-modeling`, and `/research` skills. Check open maps before starting
+non-trivial work in this area:
+```bash
+gh issue list --label wayfinder:map --state open
+```
+
+## Releases
+
+All release workflows are manual (`workflow_dispatch` from the Actions tab);
+bump the subproject's `pyproject.toml` version before dispatching. Full
+package-to-workflow mapping and required secrets: `skills/release/SKILL.md`.


### PR DESCRIPTION
## Summary
- Adds a root `AGENTS.md` covering repo layout, `uv`/ruff setup and commands, the context-graph family's test-mocking-vs-e2e policy, commit conventions, and a digest of the Context Graph domain model (Collection Tier vs. Memory Tier, Skill vs. Procedure, etc.), with pointers to the local `CONTEXT-MAP.md`/`CONTEXT.md`/ADR docs for the full detail.
- Removes `/AGENTS.md` from `.gitignore` so this guidance is versioned and shared across checkouts instead of living only in whichever local copy a contributor happened to write.

## Test plan
- [ ] Skim `AGENTS.md` for accuracy against current package layout/commands
- [ ] Confirm `git status` no longer needs `--ignored` to see this file