### PR TITLE
Enforce ty type checking across the workspace

### DIFF
--- a/agents/sql2graph/core/hygm/hygm.py
+++ b/agents/sql2graph/core/hygm/hygm.py
@@ -38,7 +38,7 @@ try:
         summarize_relationship as meta_summarize_relationship,
     )
 except ImportError:
-    from core.utils.meta_graph import (  # type: ignore
+    from core.utils.meta_graph import (
         node_key as meta_node_key,
         summarize_node as meta_summarize_node,
         relationship_key as meta_relationship_key,

--- a/agents/sql2graph/core/hygm/models/graph_models.py
+++ b/agents/sql2graph/core/hygm/models/graph_models.py
@@ -6,7 +6,7 @@ These models represent the graph structure and provide schema format conversion.
 
 import datetime
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 # Import from within the same package
@@ -20,8 +20,10 @@ try:
         RelationshipSource,
     )
 except ImportError:
-    # Fallback for when imported from different contexts
-    from sources import (
+    # Fallback for when imported from different contexts (matches the
+    # core.hygm.models.X fallback style used by every other dual-context
+    # import in this package; a bare `sources` is never on sys.path).
+    from core.hygm.models.sources import (
         ConstraintSource,
         EnumSource,
         IndexSource,
@@ -31,6 +33,18 @@ except ImportError:
     )
 
 
+def _default_string_types() -> list[dict[str, Any]]:
+    return [{"type": "String", "count": 1, "examples": [""]}]
+
+
+def _default_gid_example() -> list[dict[str, Any]]:
+    return [{"gid": 0}]
+
+
+def _default_single_empty_example() -> list[dict[str, Any]]:
+    return [{}]
+
+
 @dataclass
 class GraphProperty:
     """Represents a property with full schema format details."""
@@ -38,12 +52,8 @@ class GraphProperty:
     key: str
     count: int = 1
     filling_factor: float = 100.0
-    types: list[dict[str, Any]] = None
+    types: list[dict[str, Any]] = field(default_factory=_default_string_types)
     source: PropertySource | None = None
-
-    def __post_init__(self):
-        if self.types is None:
-            self.types = [{"type": "String", "count": 1, "examples": [""]}]
 
 
 @dataclass
@@ -52,15 +62,9 @@ class GraphNode:
 
     labels: list[str]  # Node labels
     count: int = 1
-    properties: list[GraphProperty] = None
-    examples: list[dict[str, Any]] = None
+    properties: list[GraphProperty] = field(default_factory=list)
+    examples: list[dict[str, Any]] = field(default_factory=_default_gid_example)
     source: NodeSource | None = None
-
-    def __post_init__(self):
-        if self.properties is None:
-            self.properties = []
-        if self.examples is None:
-            self.examples = [{"gid": 0}]
 
     @property
     def primary_label(self) -> str:
@@ -76,16 +80,10 @@ class GraphRelationship:
     start_node_labels: list[str]
     end_node_labels: list[str]
     count: int = 1
-    properties: list[GraphProperty] = None
-    examples: list[dict[str, Any]] = None
+    properties: list[GraphProperty] = field(default_factory=list)
+    examples: list[dict[str, Any]] = field(default_factory=_default_single_empty_example)
     source: RelationshipSource | None = None
     directionality: str = "directed"
-
-    def __post_init__(self):
-        if self.properties is None:
-            self.properties = []
-        if self.examples is None:
-            self.examples = [{}]
 
 
 @dataclass
@@ -94,17 +92,11 @@ class GraphIndex:
 
     labels: list[str] | None = None  # For node indexes
     edge_type: str | None = None  # For edge indexes
-    properties: list[str] = None
+    properties: list[str] = field(default_factory=list)
     count: int = 0
-    examples: list[dict[str, Any]] = None
+    examples: list[dict[str, Any]] = field(default_factory=_default_single_empty_example)
     type: str = "label+property"  # Index type
     source: IndexSource | None = None
-
-    def __post_init__(self):
-        if self.properties is None:
-            self.properties = []
-        if self.examples is None:
-            self.examples = [{}]
 
 
 @dataclass
@@ -114,13 +106,9 @@ class GraphConstraint:
     type: str  # "unique", "existence", "data_type"
     labels: list[str] | None = None  # For node constraints
     edge_type: str | None = None  # For edge constraints
-    properties: list[str] = None
+    properties: list[str] = field(default_factory=list)
     data_type: str | None = None
     source: ConstraintSource | None = None
-
-    def __post_init__(self):
-        if self.properties is None:
-            self.properties = []
 
 
 @dataclass
@@ -138,23 +126,11 @@ class GraphModel:
 
     nodes: list[GraphNode]
     edges: list[GraphRelationship]
-    node_indexes: list[GraphIndex] = None
-    edge_indexes: list[GraphIndex] = None
-    node_constraints: list[GraphConstraint] = None
-    edge_constraints: list[GraphConstraint] = None
-    enums: list[GraphEnum] = None
-
-    def __post_init__(self):
-        if self.node_indexes is None:
-            self.node_indexes = []
-        if self.edge_indexes is None:
-            self.edge_indexes = []
-        if self.node_constraints is None:
-            self.node_constraints = []
-        if self.edge_constraints is None:
-            self.edge_constraints = []
-        if self.enums is None:
-            self.enums = []
+    node_indexes: list[GraphIndex] = field(default_factory=list)
+    edge_indexes: list[GraphIndex] = field(default_factory=list)
+    node_constraints: list[GraphConstraint] = field(default_factory=list)
+    edge_constraints: list[GraphConstraint] = field(default_factory=list)
+    enums: list[GraphEnum] = field(default_factory=list)
 
     @classmethod
     def from_schema_format(cls, schema_dict: dict[str, Any]) -> "GraphModel":

--- a/agents/sql2graph/core/hygm/strategies/llm.py
+++ b/agents/sql2graph/core/hygm/strategies/llm.py
@@ -6,12 +6,13 @@ Supports multiple providers: OpenAI, Anthropic, Gemini via LangChain.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from langchain_core.language_models import BaseChatModel
 
 if TYPE_CHECKING:
     from core.hygm.models.graph_models import GraphModel
+    from core.hygm.models.llm_models import LLMGraphModel
 
 try:
     from .base import BaseModelingStrategy
@@ -117,12 +118,17 @@ class LLMStrategy(BaseModelingStrategy):
 
             # Generate the structured output using LangChain's with_structured_output
             structured_llm = self.llm_client.with_structured_output(LLMGraphModel)
-            llm_model = structured_llm.invoke(
+            raw_llm_model = structured_llm.invoke(
                 [
                     {"role": "system", "content": system_message},
                     {"role": "user", "content": prompt},
                 ]
             )
+            # with_structured_output()'s return type is dict[str, Any] | BaseModel
+            # to cover both the dict-schema and pydantic-schema call shapes; we
+            # always pass a pydantic BaseModel class (LLMGraphModel) above, so at
+            # runtime this is always an LLMGraphModel instance.
+            llm_model = cast("LLMGraphModel", raw_llm_model)
 
             logger.info(
                 "LLM generated %d nodes and %d relationships",

--- a/agents/sql2graph/core/hygm/validation/base.py
+++ b/agents/sql2graph/core/hygm/validation/base.py
@@ -61,6 +61,10 @@ class ValidationMetrics:
     constraints_covered: int = 0
     constraints_total: int = 0
     coverage_percentage: float = 0.0
+    data_nodes_expected: int = 0
+    data_nodes_actual: int = 0
+    data_relationships_expected: int = 0
+    data_relationships_actual: int = 0
 
     def calculate_coverage(self):
         """Calculate overall coverage percentage."""

--- a/agents/sql2graph/core/hygm/validation/memgraph_data_validator.py
+++ b/agents/sql2graph/core/hygm/validation/memgraph_data_validator.py
@@ -53,7 +53,7 @@ class MemgraphDataValidator(BaseValidator):
         return self.validate_post_migration(expected_model)
 
     def validate_post_migration(
-        self, expected_model: GraphModel, expected_data_counts: dict[str, int] = None
+        self, expected_model: GraphModel, expected_data_counts: dict[str, int] | None = None
     ) -> ValidationResult:
         """
         Validate the migrated schema and data against expected model.
@@ -863,7 +863,7 @@ class MemgraphDataValidator(BaseValidator):
         self,
         expected: dict[str, Any],
         actual: dict[str, Any],
-        expected_data_counts: dict[str, int] = None,
+        expected_data_counts: dict[str, int] | None = None,
     ):
         """Update validation metrics using the base ValidationMetrics."""
         # Update basic counts
@@ -922,7 +922,7 @@ class MemgraphDataValidator(BaseValidator):
 def validate_memgraph_data(
     expected_model: GraphModel,
     memgraph_connection,
-    expected_data_counts: dict[str, int] = None,
+    expected_data_counts: dict[str, int] | None = None,
     detailed_report: bool = True,
 ) -> ValidationResult:
     """

--- a/agents/sql2graph/core/hygm/validation/memgraph_data_validator.py
+++ b/agents/sql2graph/core/hygm/validation/memgraph_data_validator.py
@@ -202,8 +202,13 @@ class MemgraphDataValidator(BaseValidator):
         Returns:
             Structured schema information
         """
-        nodes = {}
-        relationships = {}
+        # Declared up front as dict[str, Any] so the checker treats each entry
+        # as a plain mapping (supporting .update()) rather than inferring a
+        # narrow literal shape from the first assignment below, whose "labels"
+        # value (list | Unknown) and "properties" value (dict) would otherwise
+        # get unioned together as the dict's value type.
+        nodes: dict[Any, dict[str, Any]] = {}
+        relationships: dict[Any, dict[str, Any]] = {}
         indexes = []
         constraints = []
 

--- a/agents/sql2graph/core/migration_agent.py
+++ b/agents/sql2graph/core/migration_agent.py
@@ -467,7 +467,11 @@ class SQLToMemgraphAgent:
 
     def _build_workflow(self) -> StateGraph:
         """Build the LangGraph workflow with clear separation of concerns."""
-        workflow = StateGraph(MigrationState)
+        # ty limitation: a plain TypedDict doesn't structurally satisfy
+        # langgraph's StateLike protocol bound (verified with a minimal
+        # TypedDict + StateGraph repro outside this codebase) even though it's
+        # exactly the documented, supported way to declare LangGraph state.
+        workflow = StateGraph(MigrationState)  # ty: ignore[invalid-argument-type]
 
         # Add nodes - refactored for better modularity
         workflow.add_node(
@@ -1166,10 +1170,13 @@ MERGE (from)-[:{rel_name}]->(to);"""
                 if table_name in table_counts:
                     expected_nodes += table_counts[table_name]
 
-            # Create expected data counts for the validator
-            expected_data_counts = {
+            # Create expected data counts for the validator. `_update_metrics`
+            # only ever reads the "nodes"/"relationships" keys (both int), so
+            # this is declared/built as dict[str, int] -- `selected_tables`
+            # was never read by the validator and has been dropped rather than
+            # widening the type to accommodate a value nothing consumes.
+            expected_data_counts: dict[str, int] = {
                 "nodes": expected_nodes,
-                "selected_tables": selected_tables,
             }
 
             # Run validation using existing connection and data counts

--- a/agents/sql2graph/database/adapters/memgraph.py
+++ b/agents/sql2graph/database/adapters/memgraph.py
@@ -7,7 +7,14 @@ to support post-migration validation.
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    # Imported directly (rather than referenced as `neo4j.Driver`) so its
+    # type is precise even though the `neo4j` name itself is inferred as
+    # `<module 'neo4j'> | None` below to model the optional-import fallback.
+    from neo4j import Driver
+    from typing_extensions import LiteralString
 
 try:
     import neo4j
@@ -15,7 +22,12 @@ except ImportError:
     neo4j = None
 
 try:
-    import mgclient
+    # mgclient (the native Memgraph client) is a genuinely optional driver:
+    # unlike neo4j/psycopg2/mysql-connector below, it is never declared as a
+    # dependency of this package at all, so ty has no stub to resolve it
+    # against -- there is no fix short of adding a real dependency, which is
+    # out of scope for a types-only pass.
+    import mgclient  # ty: ignore[unresolved-import]
 except ImportError:
     mgclient = None
 
@@ -49,9 +61,12 @@ class MemgraphAdapter:
             config: Connection configuration
         """
         self.config = config
-        self.connection = None
-        self.driver = None
-        self._connection_type = None
+        # mgclient's connection type is unresolvable (see the import above),
+        # so this is genuinely Any; neo4j is a real dependency (declared in
+        # pyproject.toml) so its Driver type is precise.
+        self.connection: Any = None
+        self.driver: Driver | None = None
+        self._connection_type: str | None = None
 
     def connect(self) -> bool:
         """
@@ -78,15 +93,20 @@ class MemgraphAdapter:
     def _try_mgclient_connection(self) -> bool:
         """Try to connect using mgclient."""
         try:
-            self.connection = mgclient.connect(
+            # Only reached when connect() has already checked `mgclient` is
+            # truthy, an invariant this private method's own signature can't
+            # express since the check lives in the caller.
+            mg = cast("Any", mgclient)
+            connection = mg.connect(
                 host=self.config.host,
                 port=self.config.port,
                 username=self.config.username,
                 password=self.config.password,
-                sslmode=mgclient.SSLMode.REQUIRE if self.config.use_ssl else mgclient.SSLMode.DISABLE,
+                sslmode=mg.SSLMode.REQUIRE if self.config.use_ssl else mg.SSLMode.DISABLE,
             )
+            self.connection = connection
             # Test the connection
-            cursor = self.connection.cursor()
+            cursor = connection.cursor()
             cursor.execute("RETURN 1")
             cursor.fetchall()
             return True
@@ -97,13 +117,17 @@ class MemgraphAdapter:
     def _try_neo4j_connection(self) -> bool:
         """Try to connect using neo4j driver."""
         try:
+            # Only reached when connect() has already checked `neo4j` is
+            # truthy; see the comment on _try_mgclient_connection above.
+            nx = cast("Any", neo4j)
             uri = f"{'bolt+s' if self.config.use_ssl else 'bolt'}://{self.config.host}:{self.config.port}"
-            self.driver = neo4j.GraphDatabase.driver(
+            driver = nx.GraphDatabase.driver(
                 uri,
                 auth=(self.config.username, self.config.password) if self.config.username else None,
             )
+            self.driver = driver
             # Test the connection
-            with self.driver.session() as session:
+            with driver.session() as session:
                 session.run("RETURN 1")
             return True
         except Exception as e:
@@ -138,8 +162,16 @@ class MemgraphAdapter:
 
     def _execute_neo4j_query(self, query: str) -> list[tuple]:
         """Execute query using neo4j driver."""
-        with self.driver.session() as session:
-            result = session.run(query)
+        # execute_query() (the only caller) already checked _connection_type
+        # == "neo4j" before dispatching here, which is only ever set right
+        # after a successful self.driver assignment in _try_neo4j_connection.
+        driver = cast("Driver", self.driver)
+        with driver.session() as session:
+            # Cypher text is built dynamically at runtime, so it can never be
+            # a `LiteralString` in the sense neo4j's typed API wants; that
+            # constraint exists to steer callers away from string-building
+            # untrusted input, which isn't how queries are built here.
+            result = session.run(cast("LiteralString", query))
             return [tuple(record.values()) for record in result]
 
     def get_schema_info(self) -> list[tuple]:

--- a/agents/sql2graph/database/adapters/mysql.py
+++ b/agents/sql2graph/database/adapters/mysql.py
@@ -5,7 +5,7 @@ This module provides MySQL-specific implementation of the DatabaseAnalyzer inter
 """
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import mysql.connector
 
@@ -16,6 +16,15 @@ from ..analyzer import (
 )
 
 logger = logging.getLogger(__name__)
+
+# mysql-connector-python types cursor.fetchall()/.fetchone() broadly as
+# Union[RowType, Dict[str, RowItemType]] (RowItemType itself a large union of
+# every column value type MySQL can produce), because a single cursor()
+# method's return type has to cover both its tuple- and dict-returning
+# cursor subclasses. Every cursor in this file is created with no arguments
+# (never `dictionary=True`) except in get_table_data(), so at runtime these
+# always return plain tuples of column values.
+_Row = tuple[Any, ...]
 
 
 class MySQLAnalyzer(DatabaseAnalyzer):
@@ -68,7 +77,7 @@ class MySQLAnalyzer(DatabaseAnalyzer):
 
         cursor = self.connection.cursor()
         cursor.execute("SHOW TABLES")
-        tables = [table[0] for table in cursor.fetchall()]
+        tables = [table[0] for table in cast("list[_Row]", cursor.fetchall())]
         cursor.close()
         return tables
 
@@ -81,7 +90,7 @@ class MySQLAnalyzer(DatabaseAnalyzer):
         cursor.execute(f"DESCRIBE {table_name}")
 
         columns = []
-        for row in cursor.fetchall():
+        for row in cast("list[_Row]", cursor.fetchall()):
             field_name = row[0]
             data_type = row[1]
             is_nullable = row[2] == "YES"
@@ -181,7 +190,7 @@ class MySQLAnalyzer(DatabaseAnalyzer):
         cursor.execute(query, (self.connection_config["database"], table_name))
 
         foreign_keys = []
-        for row in cursor.fetchall():
+        for row in cast("list[_Row]", cursor.fetchall()):
             foreign_keys.append(
                 ForeignKeyInfo(
                     column_name=row[0],
@@ -204,7 +213,10 @@ class MySQLAnalyzer(DatabaseAnalyzer):
             query += f" LIMIT {limit}"
 
         cursor.execute(query)
-        data = cursor.fetchall()
+        # dictionary=True above selects a dict-returning cursor subclass at
+        # runtime; the stub's cursor() factory isn't overloaded on that
+        # literal bool, so it can't narrow fetchall()'s return type for us.
+        data = cast("list[dict[str, Any]]", cursor.fetchall())
         cursor.close()
         return data
 
@@ -215,7 +227,8 @@ class MySQLAnalyzer(DatabaseAnalyzer):
 
         cursor = self.connection.cursor()
         cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
-        count = cursor.fetchone()[0]
+        # SELECT COUNT(*) always yields exactly one row.
+        count = cast("_Row", cursor.fetchone())[0]
         cursor.close()
         return count
 
@@ -232,7 +245,7 @@ class MySQLAnalyzer(DatabaseAnalyzer):
         AND TABLE_NAME = %s
         """
         cursor.execute(query, (self.connection_config["database"], table_name))
-        result = cursor.fetchone()
+        result = cast("_Row | None", cursor.fetchone())
         cursor.close()
 
         if result:
@@ -252,7 +265,7 @@ class MySQLAnalyzer(DatabaseAnalyzer):
         AND TABLE_TYPE = 'BASE TABLE'
         """
         cursor.execute(query, (self.connection_config["database"],))
-        tables = [table[0] for table in cursor.fetchall()]
+        tables = [table[0] for table in cast("list[_Row]", cursor.fetchall())]
         cursor.close()
         return tables
 
@@ -283,8 +296,12 @@ class MySQLAnalyzer(DatabaseAnalyzer):
         """
         cursor.execute(query, (self.connection_config["database"], table_name))
 
-        indexes = {}
-        for row in cursor.fetchall():
+        # Declared as dict[str, Any] up front so the checker treats each
+        # entry as a plain mapping (supporting .append() on "columns") rather
+        # than widening the value type from the heterogeneous dict literal
+        # assigned below (str/bool/list all mixed into one inferred union).
+        indexes: dict[Any, dict[str, Any]] = {}
+        for row in cast("list[_Row]", cursor.fetchall()):
             index_name = row[0]
             column_name = row[1]
             is_unique = row[2] == 0

--- a/agents/sql2graph/database/adapters/postgresql.py
+++ b/agents/sql2graph/database/adapters/postgresql.py
@@ -8,8 +8,16 @@ try:
     import psycopg2.extras  # type: ignore[import-not-found]
     from psycopg2 import sql  # type: ignore[import-not-found]
 except ImportError as import_error:  # pragma: no cover - optional dependency
-    psycopg2 = None  # type: ignore[assignment]
-    sql = None  # type: ignore[assignment]
+    # psycopg2-binary is actually a hard dependency of this package (see
+    # pyproject.toml), so this branch is a defensive fallback that's never
+    # exercised by a correct install; every call site below already guards
+    # with `if psycopg2 is None: raise ImportError(...)` before use. ty
+    # infers psycopg2's declared type as the concrete module from the try
+    # branch above, so re-binding it to None here is flagged even though
+    # it's the same None-fallback shape used throughout this file's sibling
+    # adapters.
+    psycopg2 = None  # ty: ignore[invalid-assignment]
+    sql = None
     _PSYCOPG2_IMPORT_ERROR = import_error
 else:
     _PSYCOPG2_IMPORT_ERROR = None

--- a/agents/sql2graph/examples/basic_migration.py
+++ b/agents/sql2graph/examples/basic_migration.py
@@ -32,8 +32,10 @@ def run_basic_migration():
         # Setup and validate environment
         source_db_config, memgraph_config = setup_and_validate_environment()
 
-        # Create migration agent in automatic mode (non-interactive)
-        agent = SQLToMemgraphAgent(interactive_graph_modeling=False)
+        # Create migration agent in automatic mode (non-interactive). This is
+        # already the default (ModelingMode.AUTOMATIC); `interactive_graph_
+        # modeling` was a stale kwarg that no longer exists on __init__.
+        agent = SQLToMemgraphAgent()
 
         # Run migration
         print("Starting automatic migration...")

--- a/agents/sql2graph/main.py
+++ b/agents/sql2graph/main.py
@@ -59,9 +59,6 @@ LOG_LEVEL_CHOICES = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
 
 PROVIDER_CHOICES = ["openai", "anthropic", "gemini"]
 
-# Sentinel returned by edit_mapping_interactive to signal a reset
-_RESET = object()
-
 
 def _lower_env(name: str) -> Optional[str]:
     value = os.getenv(name)
@@ -723,11 +720,13 @@ def edit_mapping_interactive(
     mapping: Dict[str, Any],
     llm: Any,
     mapping_path: str,
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """
     Interactive loop: let the user edit a mapping via natural language.
 
-    Uses HyGM's operation parsing and application under the hood.
+    Uses HyGM's operation parsing and application under the hood. Returns
+    None (rather than a real mapping dict) to signal that the caller should
+    discard the mapping and regenerate it from the source database.
     """
     from core.hygm import HyGM, GraphModelingStrategy, ModelingMode
 
@@ -789,7 +788,7 @@ def edit_mapping_interactive(
                         print_mapping_summary(mapping)
                     _print_editor_banner()
                 elif cmd == "reset":
-                    return _RESET
+                    return None
                 else:
                     print(f"Unknown command: {user_input}")
                 continue
@@ -890,7 +889,7 @@ def generate_mapping(
 
     while True:
         result = edit_mapping_interactive(mapping, agent.llm, mapping_path)
-        if result is not _RESET:
+        if result is not None:
             break
         print("\n🔄 Resetting mapping — regenerating from source database...\n")
         mapping = _generate_fresh_mapping(agent, source_db_config)

--- a/context-graph/actions-graph/src/actions_graph/__init__.py
+++ b/context-graph/actions-graph/src/actions_graph/__init__.py
@@ -54,7 +54,7 @@ from .models import (
 )
 
 try:
-    __version__ = metadata.version(__package__)
+    __version__ = metadata.version(__package__ or __name__)
 except metadata.PackageNotFoundError:
     # Case where package metadata is not available.
     __version__ = ""

--- a/context-graph/actions-graph/src/actions_graph/connector.py
+++ b/context-graph/actions-graph/src/actions_graph/connector.py
@@ -8,7 +8,7 @@ Agent Context Graph only routes normalized runtime events.
 from __future__ import annotations
 
 import hashlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from agent_context_graph.events import (
     AgentEndEvent,
@@ -153,7 +153,11 @@ class ActionsGraphConnector(GraphConnector):
         self._ensure_session(event)
         self._graph.end_agent(
             event.agent_name,
-            last_assistant_message=self._content(event.output),
+            # AgentEndEvent.output is Any at the Event Protocol boundary, but every
+            # real adapter (openai.py, claude.py, claude_code.py) only ever sets it
+            # to a str or leaves it None -- never the list-of-content-blocks shape
+            # _content() also handles for ToolResult.content.
+            last_assistant_message=cast("str | None", self._content(event.output)),
             metadata=self._metadata(event),
         )
 

--- a/context-graph/actions-graph/src/actions_graph/core.py
+++ b/context-graph/actions-graph/src/actions_graph/core.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, TypedDict
 
 from memgraph_toolbox.api.memgraph import Memgraph
 
@@ -45,6 +45,23 @@ from .models import (
     ToolCall,
     ToolResult,
 )
+
+
+class _BaseActionKwargs(TypedDict):
+    """Shape of the fields ``_row_to_action`` shares across every ``Action`` subclass.
+
+    A closed key set (deliberately never ``action_type``) so splatting it into
+    ``ToolCall(**base_kwargs, ...)`` etc. can't be misread as supplying that
+    subclass-specific parameter, unlike a plain ``dict[str, <inferred union>]``.
+    """
+
+    action_id: str
+    session_id: str
+    timestamp: str
+    status: ActionStatus
+    duration_ms: int | None
+    parent_action_id: str | None
+    metadata: dict[str, Any]
 
 
 class ActionsGraph:
@@ -600,7 +617,7 @@ class ActionsGraph:
         props = self._action_to_props(action)
 
         # Promoted fields: first-class node properties for graph traversal
-        _tool_name: str | None = props.get("tool_name") or (action.tool_name if hasattr(action, "tool_name") else None)
+        _tool_name: str | None = props.get("tool_name") or getattr(action, "tool_name", None)
         _is_error: bool = bool(props.get("is_error", False))
         _is_mcp: bool = bool(props.get("is_mcp", False))
 
@@ -1175,7 +1192,7 @@ class ActionsGraph:
         props = json.loads(row["properties"]) if row.get("properties") else {}
         metadata = json.loads(row["metadata"]) if row.get("metadata") else {}
 
-        base_kwargs = {
+        base_kwargs: _BaseActionKwargs = {
             "action_id": row["action_id"],
             "session_id": row.get("session_id") or "",
             "timestamp": row["timestamp"],

--- a/context-graph/actions-graph/src/actions_graph/hooks.py
+++ b/context-graph/actions-graph/src/actions_graph/hooks.py
@@ -19,7 +19,7 @@ Usage:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from .models import (
     ActionStatus,
@@ -443,17 +443,20 @@ def create_tracking_hooks(
     # Create tracker
     tracker = ActionTracker(graph, session_id, **tracker_kwargs)
 
-    # Build hooks dictionary
+    # Build hooks dictionary. Our hook callbacks return a permissive dict[str, Any]
+    # rather than the SDK's precise AsyncHookJSONOutput/SyncHookJSONOutput shapes,
+    # matching the try/except HookMatcher shim above: this module treats the SDK
+    # as optional/duck-typed rather than taking a hard type dependency on it.
     return {
-        "PreToolUse": [HookMatcher(hooks=[tracker.pre_tool_use])],
-        "PostToolUse": [HookMatcher(hooks=[tracker.post_tool_use])],
-        "PostToolUseFailure": [HookMatcher(hooks=[tracker.post_tool_use_failure])],
-        "UserPromptSubmit": [HookMatcher(hooks=[tracker.user_prompt_submit])],
-        "SubagentStart": [HookMatcher(hooks=[tracker.subagent_start])],
-        "SubagentStop": [HookMatcher(hooks=[tracker.subagent_stop])],
-        "PermissionRequest": [HookMatcher(hooks=[tracker.permission_request])],
-        "Notification": [HookMatcher(hooks=[tracker.notification])],
-        "Stop": [HookMatcher(hooks=[tracker.stop])],
+        "PreToolUse": [HookMatcher(hooks=[cast("Any", tracker.pre_tool_use)])],
+        "PostToolUse": [HookMatcher(hooks=[cast("Any", tracker.post_tool_use)])],
+        "PostToolUseFailure": [HookMatcher(hooks=[cast("Any", tracker.post_tool_use_failure)])],
+        "UserPromptSubmit": [HookMatcher(hooks=[cast("Any", tracker.user_prompt_submit)])],
+        "SubagentStart": [HookMatcher(hooks=[cast("Any", tracker.subagent_start)])],
+        "SubagentStop": [HookMatcher(hooks=[cast("Any", tracker.subagent_stop)])],
+        "PermissionRequest": [HookMatcher(hooks=[cast("Any", tracker.permission_request)])],
+        "Notification": [HookMatcher(hooks=[cast("Any", tracker.notification)])],
+        "Stop": [HookMatcher(hooks=[cast("Any", tracker.stop)])],
     }
 
 

--- a/context-graph/actions-graph/tests/test_connector.py
+++ b/context-graph/actions-graph/tests/test_connector.py
@@ -1,5 +1,7 @@
 """Tests for ActionsGraphConnector."""
 
+from typing import TYPE_CHECKING, cast
+
 from actions_graph.connector import ActionsGraphConnector
 from actions_graph.models import ActionStatus, Agent, ErrorEvent, Message, Session, ToolCall, ToolResult
 from agent_context_graph.events import (
@@ -12,6 +14,9 @@ from agent_context_graph.events import (
     ToolEndEvent,
     ToolStartEvent,
 )
+
+if TYPE_CHECKING:
+    from actions_graph import ActionsGraph
 
 
 class FakeActionsGraph:
@@ -57,7 +62,7 @@ class FakeActionsGraph:
 
 def test_records_session_start():
     graph = FakeActionsGraph()
-    connector = ActionsGraphConnector(graph)
+    connector = ActionsGraphConnector(cast("ActionsGraph", graph))
 
     connector.on_event(
         SessionStartEvent(
@@ -77,7 +82,7 @@ def test_records_session_start():
 
 def test_records_tool_start_as_tool_call_action():
     graph = FakeActionsGraph()
-    connector = ActionsGraphConnector(graph)
+    connector = ActionsGraphConnector(cast("ActionsGraph", graph))
 
     connector.on_event(
         ToolStartEvent(
@@ -103,7 +108,7 @@ def test_records_tool_start_as_tool_call_action():
 
 def test_records_tool_end_as_tool_result_with_stable_parent_id():
     graph = FakeActionsGraph()
-    connector = ActionsGraphConnector(graph)
+    connector = ActionsGraphConnector(cast("ActionsGraph", graph))
 
     connector.on_event(
         ToolStartEvent(
@@ -133,7 +138,7 @@ def test_records_tool_end_as_tool_result_with_stable_parent_id():
 
 def test_records_tool_error_as_failed_tool_result():
     graph = FakeActionsGraph()
-    connector = ActionsGraphConnector(graph)
+    connector = ActionsGraphConnector(cast("ActionsGraph", graph))
 
     connector.on_event(
         ToolEndEvent(
@@ -155,7 +160,7 @@ def test_records_tool_error_as_failed_tool_result():
 
 def test_records_message_and_error_events():
     graph = FakeActionsGraph()
-    connector = ActionsGraphConnector(graph)
+    connector = ActionsGraphConnector(cast("ActionsGraph", graph))
 
     connector.on_event(
         MessageEvent(
@@ -186,7 +191,7 @@ def test_records_message_and_error_events():
 
 def test_records_agent_start_as_agent_node_not_action():
     graph = FakeActionsGraph()
-    connector = ActionsGraphConnector(graph)
+    connector = ActionsGraphConnector(cast("ActionsGraph", graph))
 
     connector.on_event(
         AgentStartEvent(
@@ -209,7 +214,7 @@ def test_records_agent_start_as_agent_node_not_action():
 
 def test_records_agent_end_updates_same_agent_node():
     graph = FakeActionsGraph()
-    connector = ActionsGraphConnector(graph)
+    connector = ActionsGraphConnector(cast("ActionsGraph", graph))
 
     connector.on_event(
         AgentStartEvent(
@@ -236,7 +241,7 @@ def test_records_agent_end_updates_same_agent_node():
 
 def test_records_session_end():
     graph = FakeActionsGraph()
-    connector = ActionsGraphConnector(graph)
+    connector = ActionsGraphConnector(cast("ActionsGraph", graph))
 
     connector.on_event(
         SessionEndEvent(

--- a/context-graph/actions-graph/tests/test_e2e.py
+++ b/context-graph/actions-graph/tests/test_e2e.py
@@ -291,6 +291,7 @@ class TestAgentOperations:
 
         graph.end_agent("agent-1", last_assistant_message="Found it")
         ended = graph.get_agent("agent-1")
+        assert ended is not None
         assert ended.status == ActionStatus.COMPLETED
         assert ended.last_assistant_message == "Found it"
 

--- a/context-graph/actions-graph/tests/test_hooks.py
+++ b/context-graph/actions-graph/tests/test_hooks.py
@@ -1,6 +1,7 @@
 """Tests for standalone Claude SDK action hooks."""
 
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -16,6 +17,9 @@ from actions_graph.models import (
     ToolCall,
     ToolResult,
 )
+
+if TYPE_CHECKING:
+    from actions_graph import ActionsGraph
 
 
 class FakeActionsGraph:
@@ -56,7 +60,7 @@ class FakeActionsGraph:
 @pytest.mark.asyncio
 async def test_tool_hooks_record_call_result_and_failure():
     graph = FakeActionsGraph()
-    tracker = ActionTracker(graph, "session-1")
+    tracker = ActionTracker(cast("ActionsGraph", graph), "session-1")
 
     await tracker.pre_tool_use(
         {"tool_name": "Read", "tool_input": {"file_path": "a.py"}, "tool_use_id": "tool-1"},
@@ -86,7 +90,7 @@ async def test_tool_hooks_record_call_result_and_failure():
 @pytest.mark.asyncio
 async def test_message_subagent_permission_notification_and_stop_hooks():
     graph = FakeActionsGraph()
-    tracker = ActionTracker(graph, "session-1")
+    tracker = ActionTracker(cast("ActionsGraph", graph), "session-1")
 
     await tracker.user_prompt_submit({"prompt": "hello", "cwd": "/repo"}, None, {})
     await tracker.subagent_start({"agent_id": "agent-1", "agent_type": "reviewer"}, None, {})
@@ -114,7 +118,7 @@ async def test_message_subagent_permission_notification_and_stop_hooks():
 @pytest.mark.asyncio
 async def test_tool_call_inside_subagent_links_to_agent_container():
     graph = FakeActionsGraph()
-    tracker = ActionTracker(graph, "session-1")
+    tracker = ActionTracker(cast("ActionsGraph", graph), "session-1")
 
     await tracker.subagent_start({"agent_id": "agent-1", "agent_type": "reviewer"}, None, {})
     await tracker.pre_tool_use(
@@ -136,7 +140,7 @@ async def test_tool_call_inside_subagent_links_to_agent_container():
 def test_create_tracking_hooks_creates_session_and_hook_map():
     graph = FakeActionsGraph()
 
-    hooks = create_tracking_hooks(graph, "session-1", session_kwargs={})
+    hooks = create_tracking_hooks(cast("ActionsGraph", graph), "session-1", session_kwargs={})
 
     assert graph.sessions[0].session_id == "session-1"
     assert set(hooks) == {
@@ -154,7 +158,7 @@ def test_create_tracking_hooks_creates_session_and_hook_map():
 
 def test_message_handler_records_assistant_result_and_rate_limit():
     graph = FakeActionsGraph()
-    handler = create_message_handler(graph, "session-1")
+    handler = create_message_handler(cast("ActionsGraph", graph), "session-1")
 
     handler(
         SimpleNamespace(

--- a/context-graph/agent-context-graph/src/agent_context_graph/__init__.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/__init__.py
@@ -42,7 +42,7 @@ from .link import AgentLink
 from .protocols import GraphConnector, RuntimeAdapter
 
 try:
-    __version__ = metadata.version(__package__)
+    __version__ = metadata.version(__package__ or __name__)
 except metadata.PackageNotFoundError:
     # Case where package metadata is not available.
     __version__ = ""

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/_identity.py
@@ -49,8 +49,7 @@ _RECONCILE_DEFAULTS = {
 TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 FALSY_VALUES = frozenset({"0", "false", "no", "off"})
 
-_sentinel = object()
-_cached_config: object = _sentinel
+_cached_config: HookConfig | None = None
 
 
 @dataclass(frozen=True)
@@ -74,8 +73,8 @@ def load_config() -> HookConfig:
     Caches the result for the lifetime of the process.
     """
     global _cached_config
-    if _cached_config is not _sentinel:
-        return _cached_config  # type: ignore[return-value]
+    if _cached_config is not None:
+        return _cached_config
 
     config = _read_config_file()
     _cached_config = config
@@ -204,7 +203,7 @@ def write_config(
     _CONFIG_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
 
     # Invalidate cache.
-    _cached_config = _sentinel
+    _cached_config = None
     return _CONFIG_FILE
 
 
@@ -249,7 +248,7 @@ def write_full_config(
     _CONFIG_FILE.write_text(content, encoding="utf-8")
     _CONFIG_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
 
-    _cached_config = _sentinel
+    _cached_config = None
     return _CONFIG_FILE
 
 
@@ -375,4 +374,4 @@ def _string_or_none(value: Any) -> str | None:
 def _reset_cache() -> None:
     """Reset the module cache (for testing)."""
     global _cached_config
-    _cached_config = _sentinel
+    _cached_config = None

--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/claude.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/claude.py
@@ -29,7 +29,7 @@ Usage::
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from agent_context_graph.events import (
     AgentEndEvent,
@@ -105,15 +105,19 @@ class ClaudeAdapter(RuntimeAdapter):
                     self.hooks = hooks or []
                     self.timeout = timeout
 
+        # Our hook callbacks return a permissive dict[str, Any] rather than the
+        # SDK's precise AsyncHookJSONOutput/SyncHookJSONOutput shapes, matching
+        # the try/except HookMatcher shim above: this module treats the SDK as
+        # optional/duck-typed rather than taking a hard type dependency on it.
         return {
-            "PreToolUse": [HookMatcher(hooks=[self._pre_tool_use])],
-            "PostToolUse": [HookMatcher(hooks=[self._post_tool_use])],
-            "PostToolUseFailure": [HookMatcher(hooks=[self._post_tool_use_failure])],
-            "UserPromptSubmit": [HookMatcher(hooks=[self._user_prompt_submit])],
-            "SubagentStart": [HookMatcher(hooks=[self._subagent_start])],
-            "SubagentStop": [HookMatcher(hooks=[self._subagent_stop])],
-            "Notification": [HookMatcher(hooks=[self._notification])],
-            "Stop": [HookMatcher(hooks=[self._stop])],
+            "PreToolUse": [HookMatcher(hooks=[cast("Any", self._pre_tool_use)])],
+            "PostToolUse": [HookMatcher(hooks=[cast("Any", self._post_tool_use)])],
+            "PostToolUseFailure": [HookMatcher(hooks=[cast("Any", self._post_tool_use_failure)])],
+            "UserPromptSubmit": [HookMatcher(hooks=[cast("Any", self._user_prompt_submit)])],
+            "SubagentStart": [HookMatcher(hooks=[cast("Any", self._subagent_start)])],
+            "SubagentStop": [HookMatcher(hooks=[cast("Any", self._subagent_stop)])],
+            "Notification": [HookMatcher(hooks=[cast("Any", self._notification)])],
+            "Stop": [HookMatcher(hooks=[cast("Any", self._stop)])],
         }
 
     # ------------------------------------------------------------------

--- a/context-graph/agent-context-graph/src/agent_context_graph/cli.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/cli.py
@@ -10,7 +10,7 @@ import socket
 import subprocess
 import sys
 from importlib import metadata
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -149,7 +149,10 @@ def _config(argv: list[str]) -> int:
                 return 2
             write_value = parse_bool_flag(normalized)
 
-        write_config(**{_CONFIG_KEYS[key]: write_value})
+        # The key/value pairing is only known at runtime (bool iff key is in
+        # _BOOL_KEYS, str otherwise); write_config's own parameters are precisely
+        # typed per key, so the checker can't verify this dynamic dispatch itself.
+        write_config(**cast("dict[str, Any]", {_CONFIG_KEYS[key]: write_value}))
         if key in _SECRET_KEYS:
             display_value = "***"
         elif key in _BOOL_KEYS:
@@ -372,7 +375,7 @@ def _doctor(argv: list[str]) -> int:
     checks.append(_check_runtime(args.runtime, connectors))
 
     ok = all(check["ok"] for check in checks)
-    payload = {"ok": ok, "checks": checks}
+    payload: _DoctorPayload = {"ok": ok, "checks": checks}
     if args.json:
         print(json.dumps(payload, indent=2))
     else:
@@ -380,7 +383,18 @@ def _doctor(argv: list[str]) -> int:
     return 0 if ok else 1
 
 
-def _check_config() -> dict[str, object]:
+class _CheckResult(TypedDict):
+    name: str
+    ok: bool
+    detail: str
+
+
+class _DoctorPayload(TypedDict):
+    ok: bool
+    checks: list[_CheckResult]
+
+
+def _check_config() -> _CheckResult:
     from agent_context_graph.adapters._identity import config_file_path, load_config
 
     path = config_file_path()
@@ -410,7 +424,7 @@ def _check_config() -> dict[str, object]:
     return {"name": "config", "ok": ok, "detail": f"{path} — {'; '.join(parts)}"}
 
 
-def _check_memgraph() -> dict[str, object]:
+def _check_memgraph() -> _CheckResult:
     from agent_context_graph.adapters._identity import resolve_memgraph_env
 
     env = resolve_memgraph_env()
@@ -434,18 +448,18 @@ def _check_memgraph() -> dict[str, object]:
             driver.close()
 
 
-def _check_cli() -> dict[str, object]:
+def _check_cli() -> _CheckResult:
     path = shutil.which("agent-context-graph") or sys.argv[0]
     return {"name": "agent-context-graph executable", "ok": bool(path), "detail": path or "not found"}
 
 
-def _check_package(package_name: str) -> dict[str, object]:
+def _check_package(package_name: str) -> _CheckResult:
     version = _package_version(package_name)
     ok = version != "unknown"
     return {"name": package_name, "ok": ok, "detail": version if ok else "not installed"}
 
 
-def _check_connector(connector_name: str) -> dict[str, object]:
+def _check_connector(connector_name: str) -> _CheckResult:
     normalized = connector_name.strip().replace("-", "_")
     if normalized == "skills_graph":
         try:
@@ -512,7 +526,7 @@ def _check_connector(connector_name: str) -> dict[str, object]:
         return {"name": f"connector:{connector_name}", "ok": False, "detail": "unsupported connector"}
 
 
-def _check_runtime(runtime: str, connectors: list[str]) -> dict[str, object]:
+def _check_runtime(runtime: str, connectors: list[str]) -> _CheckResult:
     try:
         from agent_context_graph.hooks.runner import create_link
         from agent_context_graph.hooks.runtime_plugin import get_runtime_plugin
@@ -526,7 +540,7 @@ def _check_runtime(runtime: str, connectors: list[str]) -> dict[str, object]:
         return {"name": f"runtime:{runtime}", "ok": False, "detail": f"{type(exc).__name__}: {exc}"}
 
 
-def _print_doctor(payload: dict[str, object]) -> None:
+def _print_doctor(payload: _DoctorPayload) -> None:
     for check in payload["checks"]:
         status = "OK" if check["ok"] else "FAIL"
         print(f"{status} {check['name']}: {check['detail']}")

--- a/context-graph/agent-context-graph/src/agent_context_graph/hooks/runner.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/hooks/runner.py
@@ -13,7 +13,7 @@ import argparse
 import json
 import os
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from agent_context_graph.link import AgentLink
 
@@ -179,7 +179,17 @@ def _add_actions_graph_connector(link: AgentLink, memgraph_env: dict[str, str] |
     link.add_connector(ActionsGraphConnector(graph))
 
 
-def _memgraph_kwargs(memgraph_env: dict[str, str] | None) -> dict[str, str]:
+# A closed key set (never `memgraph`) so `Component(**kwargs)` below can't be
+# read as colliding with that parameter's `Memgraph | None` type, unlike a
+# plain `dict[str, str]`.
+class _MemgraphKwargs(TypedDict, total=False):
+    url: str
+    username: str
+    password: str
+    database: str
+
+
+def _memgraph_kwargs(memgraph_env: dict[str, str] | None) -> _MemgraphKwargs:
     """Convert resolved memgraph env dict to kwargs for graph component constructors."""
     if memgraph_env is None:
         return {}

--- a/context-graph/agent-context-graph/src/agent_context_graph/hooks/runtime_plugin.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/hooks/runtime_plugin.py
@@ -13,10 +13,7 @@ No changes to agent-context-graph itself are needed to add a new runtime.
 from __future__ import annotations
 
 from importlib import metadata
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
 
 _ENTRY_POINT_GROUP = "agent_context_graph.runtimes"
 
@@ -30,14 +27,23 @@ class RuntimeCLIPlugin(Protocol):
     should use ``getattr(plugin, "init", None)`` rather than assume it exists.
     """
 
-    name: str
-    adapter_class: type[Any]
+    # Both read-only: a plain mutable attribute here would require every
+    # plugin's own fields to be writable with these exact types (invariance),
+    # rejecting real plugins that are frozen dataclasses (name) or declare a
+    # narrower adapter_class (type[RuntimeAdapter] instead of type[Any]).
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def adapter_class(self) -> type[Any]: ...
 
     def response_for_payload(self, payload: dict[str, Any]) -> dict[str, Any] | None: ...
 
     def build_hooks_config(self, command: str, *, timeout: int = 30) -> dict[str, Any]: ...
 
-    def init(self, project_dir: Path, connectors: list[str], **kwargs: Any) -> None: ...
+    # Deliberately not a protocol member beyond this point: `init` is optional
+    # (see class docstring) and accessed via `getattr(plugin, "init", None)`,
+    # never through a RuntimeCLIPlugin-typed reference.
 
 
 class UnknownRuntimeError(KeyError):

--- a/context-graph/agent-context-graph/tests/test_claude_code_adapter.py
+++ b/context-graph/agent-context-graph/tests/test_claude_code_adapter.py
@@ -9,7 +9,16 @@ from agent_context_graph.adapters.claude_code import (
     load_payload,
     response_for_payload,
 )
-from agent_context_graph.events import Event, EventType
+from agent_context_graph.events import (
+    AgentEndEvent,
+    AgentStartEvent,
+    Event,
+    EventType,
+    MessageEvent,
+    SessionStartEvent,
+    ToolEndEvent,
+    ToolStartEvent,
+)
 from agent_context_graph.protocols import GraphConnector
 
 
@@ -37,6 +46,7 @@ def test_session_start_payload_emits_session_start_event():
     )
 
     event = rec.events[0]
+    assert isinstance(event, SessionStartEvent)
     assert event.event_type == EventType.SESSION_START
     assert event.source_sdk == "claude-code"
     assert event.session_id == "s1"
@@ -59,6 +69,7 @@ def test_user_prompt_payload_emits_message_event():
     )
 
     event = rec.events[0]
+    assert isinstance(event, MessageEvent)
     assert event.event_type == EventType.MESSAGE
     assert event.role == "user"
     assert event.content == "Use the cypher skill"
@@ -91,9 +102,12 @@ def test_tool_payloads_emit_tool_events():
     )
 
     assert [event.event_type for event in rec.events] == [EventType.TOOL_START, EventType.TOOL_END]
-    assert rec.events[0].tool_name == "Read"
-    assert rec.events[0].tool_input == {"file_path": "/skills/cypher/SKILL.md"}
-    assert rec.events[1].result == "skill body"
+    tool_start, tool_end = rec.events
+    assert isinstance(tool_start, ToolStartEvent)
+    assert isinstance(tool_end, ToolEndEvent)
+    assert tool_start.tool_name == "Read"
+    assert tool_start.tool_input == {"file_path": "/skills/cypher/SKILL.md"}
+    assert tool_end.result == "skill body"
 
 
 def test_failed_tool_payload_emits_error_tool_end():
@@ -114,6 +128,7 @@ def test_failed_tool_payload_emits_error_tool_end():
     )
 
     event = rec.events[0]
+    assert isinstance(event, ToolEndEvent)
     assert event.event_type == EventType.TOOL_END
     assert event.is_error
     assert event.error_message == "Command exited with non-zero status code 1"
@@ -146,8 +161,11 @@ def test_tool_payloads_inside_subagent_carry_agent_name():
         }
     )
 
-    assert rec.events[0].agent_name == "agent-1"
-    assert rec.events[1].agent_name == "agent-1"
+    tool_start, tool_end = rec.events
+    assert isinstance(tool_start, ToolStartEvent)
+    assert isinstance(tool_end, ToolEndEvent)
+    assert tool_start.agent_name == "agent-1"
+    assert tool_end.agent_name == "agent-1"
 
 
 def test_subagent_payloads_emit_agent_events():
@@ -175,8 +193,11 @@ def test_subagent_payloads_emit_agent_events():
     )
 
     assert [event.event_type for event in rec.events] == [EventType.AGENT_START, EventType.AGENT_END]
-    assert rec.events[0].agent_name == "agent-1"
-    assert rec.events[1].output == "Done"
+    agent_start, agent_end = rec.events
+    assert isinstance(agent_start, AgentStartEvent)
+    assert isinstance(agent_end, AgentEndEvent)
+    assert agent_start.agent_name == "agent-1"
+    assert agent_end.output == "Done"
 
 
 def test_stop_payload_emits_session_end_and_json_response():

--- a/context-graph/agent-context-graph/tests/test_codex_adapter.py
+++ b/context-graph/agent-context-graph/tests/test_codex_adapter.py
@@ -4,7 +4,14 @@ import io
 
 from agent_context_graph import AgentLink
 from agent_context_graph.adapters.codex import CodexHooksAdapter, build_hooks_config, load_payload, response_for_payload
-from agent_context_graph.events import Event, EventType
+from agent_context_graph.events import (
+    Event,
+    EventType,
+    MessageEvent,
+    SessionStartEvent,
+    ToolEndEvent,
+    ToolStartEvent,
+)
 from agent_context_graph.protocols import GraphConnector
 
 
@@ -34,6 +41,7 @@ def test_session_start_payload_emits_session_start_event():
 
     assert len(rec.events) == 1
     event = rec.events[0]
+    assert isinstance(event, SessionStartEvent)
     assert event.event_type == EventType.SESSION_START
     assert event.source_sdk == "codex"
     assert event.session_id == "s1"
@@ -58,6 +66,7 @@ def test_user_prompt_payload_emits_message_event():
     )
 
     event = rec.events[0]
+    assert isinstance(event, MessageEvent)
     assert event.event_type == EventType.MESSAGE
     assert event.role == "user"
     assert event.content == "Use the cypher skill"
@@ -90,9 +99,12 @@ def test_tool_payloads_emit_tool_events():
     )
 
     assert [event.event_type for event in rec.events] == [EventType.TOOL_START, EventType.TOOL_END]
-    assert rec.events[0].tool_name == "mcp__skills__get_skill"
-    assert rec.events[0].tool_input == {"name": "cypher-basics"}
-    assert rec.events[1].result == "skill body"
+    tool_start, tool_end = rec.events
+    assert isinstance(tool_start, ToolStartEvent)
+    assert isinstance(tool_end, ToolEndEvent)
+    assert tool_start.tool_name == "mcp__skills__get_skill"
+    assert tool_start.tool_input == {"name": "cypher-basics"}
+    assert tool_end.result == "skill body"
 
 
 def test_post_tool_use_error_result_marks_error():
@@ -111,6 +123,7 @@ def test_post_tool_use_error_result_marks_error():
     )
 
     event = rec.events[0]
+    assert isinstance(event, ToolEndEvent)
     assert event.event_type == EventType.TOOL_END
     assert event.is_error
     assert event.error_message == "nope"

--- a/context-graph/agent-context-graph/tests/test_hook_cli.py
+++ b/context-graph/agent-context-graph/tests/test_hook_cli.py
@@ -374,7 +374,7 @@ def test_init_codex_uses_memgraph_env_only_for_setup_schema(tmp_path, monkeypatc
             captured["database"] = os.environ.get("MEMGRAPH_DATABASE")
 
     fake_skills_graph = ModuleType("skills_graph")
-    fake_skills_graph.SkillGraph = _SkillGraph
+    fake_skills_graph.SkillGraph = _SkillGraph  # ty: ignore[unresolved-attribute] -- fake module double, no static attrs
     monkeypatch.setitem(sys.modules, "skills_graph", fake_skills_graph)
 
     assert (
@@ -421,7 +421,7 @@ def test_init_codex_sets_up_actions_graph_schema(tmp_path, monkeypatch):
             captured["database"] = os.environ.get("MEMGRAPH_DATABASE")
 
     fake_actions_graph = ModuleType("actions_graph")
-    fake_actions_graph.ActionsGraph = _ActionsGraph
+    fake_actions_graph.ActionsGraph = _ActionsGraph  # ty: ignore[unresolved-attribute] -- fake module double, no static attrs
     monkeypatch.setitem(sys.modules, "actions_graph", fake_actions_graph)
 
     assert (

--- a/context-graph/agent-context-graph/tests/test_link.py
+++ b/context-graph/agent-context-graph/tests/test_link.py
@@ -100,9 +100,11 @@ class TestClaudeAdapter:
         )
 
         assert len(rec.events) == 1
-        assert rec.events[0].event_type == EventType.SESSION_START
-        assert rec.events[0].session_id == "s-test"
-        assert rec.events[0].model == "claude-sonnet-4-20250514"
+        event = rec.events[0]
+        assert isinstance(event, SessionStartEvent)
+        assert event.event_type == EventType.SESSION_START
+        assert event.session_id == "s-test"
+        assert event.model == "claude-sonnet-4-20250514"
 
     def test_no_auto_session(self):
         link = AgentLink()
@@ -152,6 +154,7 @@ class TestClaudeAdapter:
 
         assert len(rec.events) == 1
         e = rec.events[0]
+        assert isinstance(e, ToolStartEvent)
         assert e.event_type == EventType.TOOL_START
         assert e.tool_name == "Read"
         assert e.tool_use_id == "tu-1"
@@ -175,6 +178,7 @@ class TestClaudeAdapter:
 
         assert len(rec.events) == 1
         e = rec.events[0]
+        assert isinstance(e, ToolEndEvent)
         assert e.event_type == EventType.TOOL_END
         assert e.result == "file contents"
 
@@ -191,6 +195,7 @@ class TestClaudeAdapter:
 
         assert len(rec.events) == 1
         e = rec.events[0]
+        assert isinstance(e, MessageEvent)
         assert e.event_type == EventType.MESSAGE
         assert e.role == "user"
         assert e.content == "Hello!"

--- a/context-graph/agent-context-graph/tests/test_runner_sessions_graph_connector.py
+++ b/context-graph/agent-context-graph/tests/test_runner_sessions_graph_connector.py
@@ -42,9 +42,9 @@ def fake_sessions_graph(monkeypatch):
             constructed["auto_reconcile"] = auto_reconcile
 
     fake_core = ModuleType("sessions_graph")
-    fake_core.SessionsGraph = _SessionsGraph
+    fake_core.SessionsGraph = _SessionsGraph  # ty: ignore[unresolved-attribute] -- fake module double, no static attrs
     fake_connector = ModuleType("sessions_graph.connector")
-    fake_connector.SessionsGraphConnector = _SessionsGraphConnector
+    fake_connector.SessionsGraphConnector = _SessionsGraphConnector  # ty: ignore[unresolved-attribute]
 
     monkeypatch.setitem(sys.modules, "sessions_graph", fake_core)
     monkeypatch.setitem(sys.modules, "sessions_graph.connector", fake_connector)

--- a/context-graph/agent-context-graph/tests/test_runtime_plugin.py
+++ b/context-graph/agent-context-graph/tests/test_runtime_plugin.py
@@ -38,7 +38,7 @@ def test_codex_plugin_exposes_full_protocol():
     assert plugin.adapter_class is CodexHooksAdapter
     assert plugin.response_for_payload({"hook_event_name": "Stop"}) == {"continue": True}
     assert "SessionStart" in plugin.build_hooks_config("some-command")
-    assert callable(plugin.init)
+    assert callable(getattr(plugin, "init", None))
 
 
 def test_claude_code_plugin_has_no_init():

--- a/context-graph/sessions-graph/src/sessions_graph/reconciliation.py
+++ b/context-graph/sessions-graph/src/sessions_graph/reconciliation.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from actions_graph.models import Action
 
     from .models import Memory
@@ -147,8 +149,8 @@ async def summarize_session_texts(lightrag_wrapper: Any, texts: list[str]) -> st
 
 
 def build_reconciliation_sources(
-    actions: list[Action],
-    memories: list[Memory],
+    actions: Sequence[Action],
+    memories: Sequence[Memory],
 ) -> list[ReconciliationSource]:
     """Build the ordered list of reconcilable text sources for a session.
 

--- a/context-graph/skills-graph/tests/test_connector.py
+++ b/context-graph/skills-graph/tests/test_connector.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,10 +9,13 @@ pytest.importorskip("agent_context_graph", reason="agent-context-graph not insta
 from agent_context_graph.events import ToolEndEvent, ToolStartEvent
 from skills_graph.connector import SkillGraphConnector
 
+if TYPE_CHECKING:
+    from skills_graph import SkillGraph
+
 
 def _connector():
     graph = SimpleNamespace(record_skill_usage=MagicMock())
-    return SkillGraphConnector(graph), graph
+    return SkillGraphConnector(cast("SkillGraph", graph)), graph
 
 
 def test_mcp_tool_name_is_treated_as_skill_tool():

--- a/integrations/langchain-memgraph/langchain_memgraph/__init__.py
+++ b/integrations/langchain-memgraph/langchain_memgraph/__init__.py
@@ -14,7 +14,7 @@ from langchain_memgraph.tools import (
 )
 
 try:
-    __version__ = metadata.version(__package__)
+    __version__ = metadata.version(__package__ or __name__)
 except metadata.PackageNotFoundError:
     # Case where package metadata is not available.
     __version__ = ""

--- a/integrations/langchain-memgraph/langchain_memgraph/chains/graph_qa.py
+++ b/integrations/langchain-memgraph/langchain_memgraph/chains/graph_qa.py
@@ -208,7 +208,11 @@ class MemgraphQAChain(Chain):
         qa_llm = qa_llm or llm
         if use_function_response:
             try:
-                qa_llm.bind_tools({})  # type: ignore[union-attr]
+                # bind_tools isn't declared on BaseLanguageModel (only chat-model subclasses
+                # have it) and qa_llm's real value is guaranteed non-None by the "not qa_llm
+                # and not llm" check above; this is a duck-typed capability probe -- an LLM
+                # that doesn't support it raises NotImplementedError/AttributeError, caught below.
+                qa_llm.bind_tools({})  # ty: ignore[unresolved-attribute]
                 response_prompt = ChatPromptTemplate.from_messages(
                     [
                         SystemMessage(content=function_response_system),
@@ -279,11 +283,11 @@ class MemgraphQAChain(Chain):
             intermediate_steps.append({"context": context})
             if self.use_function_response:
                 function_response = get_function_response(question, context)
-                result = self.qa_chain.invoke(  # type: ignore
+                result = self.qa_chain.invoke(
                     {"question": question, "function_response": function_response},
                 )
             else:
-                result = self.qa_chain.invoke(  # type: ignore
+                result = self.qa_chain.invoke(
                     {"question": question, "context": context},
                     callbacks=callbacks,
                 )

--- a/integrations/langchain-memgraph/langchain_memgraph/graphs/graph_store.py
+++ b/integrations/langchain-memgraph/langchain_memgraph/graphs/graph_store.py
@@ -17,7 +17,7 @@ class GraphStore(Protocol):
         """Return the schema of the Graph database"""
         ...
 
-    def query(self, query: str, params: dict = None) -> list[dict[str, Any]]:
+    def query(self, query: str, params: dict | None = None) -> list[dict[str, Any]]:
         """Query the graph."""
         ...
 

--- a/integrations/langchain-memgraph/langchain_memgraph/graphs/memgraph.py
+++ b/integrations/langchain-memgraph/langchain_memgraph/graphs/memgraph.py
@@ -1,12 +1,15 @@
 import logging
 from hashlib import md5
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from langchain_core.utils import get_from_dict_or_env
 
 from langchain_memgraph.graphs.graph_document import GraphDocument, Node, Relationship
 from langchain_memgraph.graphs.graph_store import GraphStore
 from memgraph_toolbox.api.memgraph import Memgraph
+
+if TYPE_CHECKING:
+    from langchain_core.documents import Document
 
 logger = logging.getLogger(__name__)
 
@@ -352,7 +355,12 @@ class MemgraphLangChain(GraphStore, Memgraph):
 
         except (Neo4jError, ValueError) as e:
             logger.info("SHOW SCHEMA INFO query failed or returned no data; falling back: %s", e)
-            if e.code == "Memgraph.ClientError.MemgraphError.MemgraphError" and "SchemaInfo disabled" in e.message:
+            # Only Neo4jError carries .code/.message; this check is written for that shape
+            # (a bare ValueError here, e.g. from ast.literal_eval, never matches the code below).
+            neo4j_error = cast("Neo4jError", e)
+            if neo4j_error.code == "Memgraph.ClientError.MemgraphError.MemgraphError" and "SchemaInfo disabled" in (
+                neo4j_error.message or ""
+            ):
                 logger.info(
                     "Schema generation with SHOW SCHEMA INFO query failed. "
                     "Set --schema-info-enabled=true to use SHOW SCHEMA INFO query. "
@@ -399,10 +407,13 @@ class MemgraphLangChain(GraphStore, Memgraph):
 
         for document in graph_documents:
             if include_source:
-                if not document.source.metadata.get("id"):
-                    document.source.metadata["id"] = md5(document.source.page_content.encode("utf-8")).hexdigest()
+                # source is only None when a GraphDocument is built without one; callers
+                # that pass include_source=True are expected to supply a source document.
+                source = cast("Document", document.source)
+                if not source.metadata.get("id"):
+                    source.metadata["id"] = md5(source.page_content.encode("utf-8")).hexdigest()
 
-                self.query(INCLUDE_DOCS_QUERY, {"document": document.source.__dict__})
+                self.query(INCLUDE_DOCS_QUERY, {"document": source.__dict__})
 
             self.query(
                 NODE_IMPORT_QUERY,

--- a/integrations/langchain-memgraph/langchain_memgraph/tools.py
+++ b/integrations/langchain-memgraph/langchain_memgraph/tools.py
@@ -1,6 +1,6 @@
 """Memgraph tools."""
 
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.callbacks import (
     CallbackManagerForToolRun,
@@ -37,8 +37,13 @@ class _QueryMemgraphToolInput(BaseModel):
 class RunQueryTool(BaseMemgraphTool, BaseTool):
     """Tool for querying Memgraph."""
 
-    name: str = CypherTool(db=None).get_name()
-    description: str = CypherTool(db=None).get_description()
+    # These toolbox tool classes are instantiated with a placeholder db purely to read
+    # their static name/description as Pydantic field defaults; get_name()/get_description()
+    # never touch self.db, so a real Memgraph connection isn't needed here (one is passed
+    # in _run below, where the db is actually used). cast(..., None) documents that gap for
+    # the type checker without requiring a live connection just to build the class.
+    name: str = CypherTool(db=cast("Memgraph", None)).get_name()
+    description: str = CypherTool(db=cast("Memgraph", None)).get_description()
     args_schema: type[BaseModel] = _QueryMemgraphToolInput
 
     def _run(
@@ -58,8 +63,8 @@ class _SearchSchemaToolInput(BaseModel):
 class RunSearchSchemaTool(BaseMemgraphTool, BaseTool):
     """Tool for searching the graph schema by a regex pattern."""
 
-    name: str = SearchSchemaTool(db=None).get_name()
-    description: str = SearchSchemaTool(db=None).get_description()
+    name: str = SearchSchemaTool(db=cast("Memgraph", None)).get_name()
+    description: str = SearchSchemaTool(db=cast("Memgraph", None)).get_description()
     args_schema: type[BaseModel] = _SearchSchemaToolInput
 
     def _run(
@@ -77,15 +82,15 @@ class _NodeSchemaToolInput(BaseModel):
 class RunNodeSchemaTool(BaseMemgraphTool, BaseTool):
     """Tool for getting the full schema definition of a node."""
 
-    name: str = NodeSchemaTool(db=None).get_name()
-    description: str = NodeSchemaTool(db=None).get_description()
+    name: str = NodeSchemaTool(db=cast("Memgraph", None)).get_name()
+    description: str = NodeSchemaTool(db=cast("Memgraph", None)).get_description()
     args_schema: type[BaseModel] = _NodeSchemaToolInput
 
     def _run(
         self,
         node_labels: list[str],
         run_manager: CallbackManagerForToolRun | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         return NodeSchemaTool(db=self.db).call({"node_labels": node_labels})
 
 
@@ -98,8 +103,8 @@ class _RelationshipSchemaToolInput(BaseModel):
 class RunRelationshipSchemaTool(BaseMemgraphTool, BaseTool):
     """Tool for getting the full schema definition of a relationship."""
 
-    name: str = RelationshipSchemaTool(db=None).get_name()
-    description: str = RelationshipSchemaTool(db=None).get_description()
+    name: str = RelationshipSchemaTool(db=cast("Memgraph", None)).get_name()
+    description: str = RelationshipSchemaTool(db=cast("Memgraph", None)).get_description()
     args_schema: type[BaseModel] = _RelationshipSchemaToolInput
 
     def _run(
@@ -108,7 +113,7 @@ class RunRelationshipSchemaTool(BaseMemgraphTool, BaseTool):
         start_node_labels: list[str],
         end_node_labels: list[str],
         run_manager: CallbackManagerForToolRun | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         return RelationshipSchemaTool(db=self.db).call(
             {
                 "relationship_type": relationship_type,
@@ -125,13 +130,13 @@ class _EnumSchemaToolInput(BaseModel):
 class RunEnumSchemaTool(BaseMemgraphTool, BaseTool):
     """Tool for getting the schema definition of an enum."""
 
-    name: str = EnumSchemaTool(db=None).get_name()
-    description: str = EnumSchemaTool(db=None).get_description()
+    name: str = EnumSchemaTool(db=cast("Memgraph", None)).get_name()
+    description: str = EnumSchemaTool(db=cast("Memgraph", None)).get_description()
     args_schema: type[BaseModel] = _EnumSchemaToolInput
 
     def _run(
         self,
         enum_name: str,
         run_manager: CallbackManagerForToolRun | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         return EnumSchemaTool(db=self.db).call({"enum_name": enum_name})

--- a/integrations/langchain-memgraph/scripts/check_imports.py
+++ b/integrations/langchain-memgraph/scripts/check_imports.py
@@ -1,3 +1,4 @@
+import importlib.util
 import sys
 import traceback
 from importlib.machinery import SourceFileLoader
@@ -7,7 +8,11 @@ if __name__ == "__main__":
     has_failure = False
     for file in files:
         try:
-            SourceFileLoader("x", file).load_module()
+            loader = SourceFileLoader("x", file)
+            spec = importlib.util.spec_from_loader("x", loader)
+            assert spec is not None
+            module = importlib.util.module_from_spec(spec)
+            loader.exec_module(module)
         except Exception:
             has_failure = True
             print(file)

--- a/integrations/langchain-memgraph/tests/integration_tests/test_langgraph.py
+++ b/integrations/langchain-memgraph/tests/integration_tests/test_langgraph.py
@@ -4,7 +4,9 @@ from getpass import getpass
 import pytest
 from dotenv import load_dotenv
 from langchain.chat_models import init_chat_model
-from langgraph.prebuilt import create_react_agent
+from langgraph.prebuilt import (
+    create_react_agent,  # ty: ignore[deprecated] -- migration to langchain.agents.create_agent is a separate, behavior-affecting change
+)
 
 from langchain_memgraph import MemgraphToolkit
 from memgraph_toolbox.api.memgraph import Memgraph
@@ -42,7 +44,7 @@ def memgraph_agent():
     db = Memgraph(url=url, username=username, password=password)
     toolkit = MemgraphToolkit(db=db, llm=llm)
 
-    agent_executor = create_react_agent(
+    agent_executor = create_react_agent(  # ty: ignore[deprecated] -- see import comment above
         llm,
         toolkit.get_tools(),
         prompt="You will get a cypher query, try to execute it on the Memgraph database.",

--- a/integrations/lightrag-memgraph/pyproject.toml
+++ b/integrations/lightrag-memgraph/pyproject.toml
@@ -44,7 +44,6 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "black>=26.3.1",
     "isort>=5.0.0",
-    "mypy>=1.0.0",
 ]
 
 [project.urls]
@@ -71,9 +70,3 @@ target-version = ['py310']
 [tool.isort]
 profile = "black"
 line_length = 88
-
-[tool.mypy]
-python_version = "3.10"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = true

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/__init__.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/__init__.py
@@ -25,7 +25,7 @@ def _patch_anthropic() -> None:
         import os
         from collections.abc import AsyncIterator
         from importlib.metadata import version as get_version
-        from typing import Any
+        from typing import Any, cast
 
         import lightrag.llm.anthropic as _mod
         from anthropic import (
@@ -121,8 +121,14 @@ def _patch_anthropic() -> None:
                 parts.append(content)
             return "".join(parts)
 
-        _wrapped._lightrag_memgraph_patched = True  # type: ignore[attr-defined]
-        _mod.anthropic_complete_if_cache = _wrapped
+        # _wrapped is a plain function object; cast(..., x) is the identity function at runtime,
+        # so this sets/reads the real attribute -- it's just how we spell "let me stash a marker
+        # attribute on a function" past a type checker that doesn't model dynamic attributes on
+        # function objects. Likewise, _wrapped's signature (no image_inputs=) is intentionally
+        # narrower than anthropic_complete_if_cache's -- it's real dynamic monkey-patching of a
+        # third-party module attribute, not something a structural type can express.
+        cast("Any", _wrapped)._lightrag_memgraph_patched = True
+        _mod.anthropic_complete_if_cache = cast("Any", _wrapped)
     except Exception:
         pass
 

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/_connection.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/_connection.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from lightrag.utils import logger
 
@@ -21,6 +21,7 @@ from memgraph_toolbox.api.memgraph import AsyncMemgraph, memgraph_env
 
 if TYPE_CHECKING:
     from neo4j import AsyncDriver, AsyncSession
+    from typing_extensions import LiteralString
 
 # Keyed by event-loop id so tests spinning up a fresh loop per test don't
 # reuse a driver bound to a closed loop.
@@ -71,6 +72,19 @@ def sanitize_index_name(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_]", "_", value)
 
 
+def as_literal_query(text: str) -> LiteralString:
+    """Assert that a dynamically-built Cypher string is safe to pass to ``AsyncSession.run``.
+
+    neo4j types ``run(query=...)`` as ``LiteralString | Query`` to steer callers away from
+    interpolating untrusted input into query text -- ``LiteralString`` can only be produced
+    from literal syntax, so the type checker can't see that a runtime f-string is safe. Every
+    query built in this package only interpolates our own backtick-escaped identifiers
+    (``sanitize_label``/``sanitize_index_name``) or passes values as bound parameters (``$id``
+    etc.), never raw external input concatenated into query text, so the cast is safe here.
+    """
+    return cast("LiteralString", text)
+
+
 def resolve_workspace(workspace: str | None) -> str:
     """Resolve the effective workspace for a storage instance.
 
@@ -84,7 +98,7 @@ def resolve_workspace(workspace: str | None) -> str:
 async def create_index(session: AsyncSession, *, label: str, prop: str, workspace: str) -> None:
     """CREATE INDEX on :`label`(prop), swallowing "already exists" (Memgraph has no IF NOT EXISTS)."""
     try:
-        await (await session.run(f"CREATE INDEX ON :`{label}`({prop})")).consume()
+        await (await session.run(as_literal_query(f"CREATE INDEX ON :`{label}`({prop})"))).consume()
     except Exception as e:  # index may already exist, which is not an error
         logger.warning(f"[{workspace}] Index creation on :`{label}`({prop}) may have failed or already exists: {e}")
 
@@ -106,7 +120,7 @@ class MemgraphCrudMixin:
     async def is_empty(self) -> bool:
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
-            result = await session.run(f"MATCH (n:`{self._label}`) RETURN n LIMIT 1")
+            result = await session.run(as_literal_query(f"MATCH (n:`{self._label}`) RETURN n LIMIT 1"))
             record = await result.single()
             await result.consume()
             return record is None
@@ -118,13 +132,15 @@ class MemgraphCrudMixin:
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"""
-                UNWIND $keys AS k
-                OPTIONAL MATCH (n:`{self._label}` {{id: k}})
-                WITH k, n
-                WHERE n IS NULL
-                RETURN k
-                """,
+                as_literal_query(
+                    f"""
+                    UNWIND $keys AS k
+                    OPTIONAL MATCH (n:`{self._label}` {{id: k}})
+                    WITH k, n
+                    WHERE n IS NULL
+                    RETURN k
+                    """
+                ),
                 keys=list(keys),
             )
             missing = {record["k"] async for record in result}
@@ -138,11 +154,13 @@ class MemgraphCrudMixin:
         async with driver.session(database=get_database()) as session:
             await (
                 await session.run(
-                    f"""
-                    UNWIND $ids AS target_id
-                    MATCH (n:`{self._label}` {{id: target_id}})
-                    DETACH DELETE n
-                    """,
+                    as_literal_query(
+                        f"""
+                        UNWIND $ids AS target_id
+                        MATCH (n:`{self._label}` {{id: target_id}})
+                        DETACH DELETE n
+                        """
+                    ),
                     ids=list(ids),
                 )
             ).consume()
@@ -151,7 +169,7 @@ class MemgraphCrudMixin:
         try:
             driver = await get_driver()
             async with driver.session(database=get_database()) as session:
-                await (await session.run(f"MATCH (n:`{self._label}`) DETACH DELETE n")).consume()
+                await (await session.run(as_literal_query(f"MATCH (n:`{self._label}`) DETACH DELETE n"))).consume()
             logger.info(f"[{self.workspace}] Dropped Memgraph storage for {self.namespace}")
             return {"status": "success", "message": "data dropped"}
         except Exception as e:

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/docstatus_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/docstatus_impl.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
-from typing import Any, final
+from typing import Any, cast, final
 
 from lightrag.base import DocProcessingStatus, DocStatus, DocStatusStorage
 from lightrag.utils import logger
 
 from ._connection import (
     MemgraphCrudMixin,
+    as_literal_query,
     close_driver,
     create_index,
     get_database,
@@ -74,7 +75,7 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"MATCH (n:`{self._label}` {{id: $id}}) RETURN n.data AS data",
+                as_literal_query(f"MATCH (n:`{self._label}` {{id: $id}}) RETURN n.data AS data"),
                 id=id,
             )
             record = await result.single()
@@ -90,11 +91,13 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"""
-                UNWIND $ids AS target_id
-                OPTIONAL MATCH (n:`{self._label}` {{id: target_id}})
-                RETURN target_id AS id, n.data AS data
-                """,
+                as_literal_query(
+                    f"""
+                    UNWIND $ids AS target_id
+                    OPTIONAL MATCH (n:`{self._label}` {{id: target_id}})
+                    RETURN target_id AS id, n.data AS data
+                    """
+                ),
                 ids=list(ids),
             )
             found: dict[str, str] = {}
@@ -102,7 +105,10 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
                 if record["data"] is not None:
                     found[record["id"]] = record["data"]
             await result.consume()
-        return [json.loads(found[i]) if i in found else None for i in ids]
+        # LightRAG's own BaseKVStorage.get_by_ids declares -> list[dict[str, Any]], but its
+        # reference JsonKVStorage impl (and this one, to match) legitimately puts None in the
+        # slot of any id that does not exist -- the upstream annotation itself is imprecise.
+        return cast("list[dict[str, Any]]", [json.loads(found[i]) if i in found else None for i in ids])
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
@@ -123,11 +129,13 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         async with driver.session(database=get_database()) as session:
             await (
                 await session.run(
-                    f"""
-                    UNWIND $entries AS e
-                    MERGE (n:`{self._label}` {{id: e.id}})
-                    SET n.data = e.data, n += e.indexed
-                    """,
+                    as_literal_query(
+                        f"""
+                        UNWIND $entries AS e
+                        MERGE (n:`{self._label}` {{id: e.id}})
+                        SET n.data = e.data, n += e.indexed
+                        """
+                    ),
                     entries=entries,
                 )
             ).consume()
@@ -141,7 +149,9 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         counts = {status.value: 0 for status in DocStatus}
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
-            result = await session.run(f"MATCH (n:`{self._label}`) RETURN n.status AS status, count(n) AS cnt")
+            result = await session.run(
+                as_literal_query(f"MATCH (n:`{self._label}`) RETURN n.status AS status, count(n) AS cnt")
+            )
             async for record in result:
                 if record["status"] in counts:
                     counts[record["status"]] = record["cnt"]
@@ -164,11 +174,13 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"""
-                MATCH (n:`{self._label}`)
-                WHERE n.status IN $statuses
-                RETURN n.id AS id, n.data AS data
-                """,
+                as_literal_query(
+                    f"""
+                    MATCH (n:`{self._label}`)
+                    WHERE n.status IN $statuses
+                    RETURN n.id AS id, n.data AS data
+                    """
+                ),
                 statuses=status_values,
             )
             records = [record async for record in result]
@@ -179,10 +191,12 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"""
-                MATCH (n:`{self._label}` {{track_id: $track_id}})
-                RETURN n.id AS id, n.data AS data
-                """,
+                as_literal_query(
+                    f"""
+                    MATCH (n:`{self._label}` {{track_id: $track_id}})
+                    RETURN n.id AS id, n.data AS data
+                    """
+                ),
                 track_id=track_id,
             )
             records = [record async for record in result]
@@ -237,7 +251,7 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         async def _count() -> int:
             async with driver.session(database=get_database(), default_access_mode="READ") as session:
                 result = await session.run(
-                    f"MATCH (n:`{self._label}`) {where} RETURN count(n) AS total",
+                    as_literal_query(f"MATCH (n:`{self._label}`) {where} RETURN count(n) AS total"),
                     **filter_params,
                 )
                 record = await result.single()
@@ -247,12 +261,14 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         async def _page() -> list:
             async with driver.session(database=get_database(), default_access_mode="READ") as session:
                 result = await session.run(
-                    f"""
-                    MATCH (n:`{self._label}`) {where}
-                    RETURN n.id AS id, n.data AS data
-                    ORDER BY {sort_expr} {order}
-                    SKIP $skip LIMIT $limit
-                    """,
+                    as_literal_query(
+                        f"""
+                        MATCH (n:`{self._label}`) {where}
+                        RETURN n.id AS id, n.data AS data
+                        ORDER BY {sort_expr} {order}
+                        SKIP $skip LIMIT $limit
+                        """
+                    ),
                     **params,
                 )
                 records = [record async for record in result]
@@ -277,7 +293,7 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"MATCH (n:`{self._label}` {{file_path: $file_path}}) RETURN n.data AS data LIMIT 1",
+                as_literal_query(f"MATCH (n:`{self._label}` {{file_path: $file_path}}) RETURN n.data AS data LIMIT 1"),
                 file_path=file_path,
             )
             record = await result.single()
@@ -293,7 +309,9 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"MATCH (n:`{self._label}` {{file_path: $basename}}) RETURN n.id AS id, n.data AS data LIMIT 1",
+                as_literal_query(
+                    f"MATCH (n:`{self._label}` {{file_path: $basename}}) RETURN n.id AS id, n.data AS data LIMIT 1"
+                ),
                 basename=basename,
             )
             record = await result.single()
@@ -309,7 +327,9 @@ class MemgraphDocStatusStorage(MemgraphCrudMixin, DocStatusStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"MATCH (n:`{self._label}` {{content_hash: $content_hash}}) RETURN n.id AS id, n.data AS data LIMIT 1",
+                as_literal_query(
+                    f"MATCH (n:`{self._label}` {{content_hash: $content_hash}}) RETURN n.id AS id, n.data AS data LIMIT 1"
+                ),
                 content_hash=content_hash,
             )
             record = await result.single()

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/kv_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/kv_impl.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, final
+from typing import Any, cast, final
 
 from lightrag.base import BaseKVStorage
 from lightrag.utils import logger
 
 from ._connection import (
     MemgraphCrudMixin,
+    as_literal_query,
     close_driver,
     create_index,
     get_database,
@@ -66,7 +67,7 @@ class MemgraphKVStorage(MemgraphCrudMixin, BaseKVStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"MATCH (n:`{self._label}` {{id: $id}}) RETURN n.data AS data",
+                as_literal_query(f"MATCH (n:`{self._label}` {{id: $id}}) RETURN n.data AS data"),
                 id=id,
             )
             record = await result.single()
@@ -80,11 +81,13 @@ class MemgraphKVStorage(MemgraphCrudMixin, BaseKVStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"""
-                UNWIND $ids AS target_id
-                OPTIONAL MATCH (n:`{self._label}` {{id: target_id}})
-                RETURN target_id AS id, n.data AS data
-                """,
+                as_literal_query(
+                    f"""
+                    UNWIND $ids AS target_id
+                    OPTIONAL MATCH (n:`{self._label}` {{id: target_id}})
+                    RETURN target_id AS id, n.data AS data
+                    """
+                ),
                 ids=list(ids),
             )
             found: dict[str, str] = {}
@@ -92,7 +95,10 @@ class MemgraphKVStorage(MemgraphCrudMixin, BaseKVStorage):
                 if record["data"] is not None:
                     found[record["id"]] = record["data"]
             await result.consume()
-        return [self._decode(i, found.get(i)) for i in ids]
+        # LightRAG's own BaseKVStorage.get_by_ids declares -> list[dict[str, Any]], but its
+        # reference JsonKVStorage impl (and this one, to match) legitimately puts None in the
+        # slot of any id that doesn't exist -- the upstream annotation itself is imprecise.
+        return cast("list[dict[str, Any]]", [self._decode(i, found.get(i)) for i in ids])
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
@@ -126,13 +132,15 @@ class MemgraphKVStorage(MemgraphCrudMixin, BaseKVStorage):
         async with driver.session(database=get_database()) as session:
             await (
                 await session.run(
-                    f"""
-                    UNWIND $entries AS e
-                    MERGE (n:`{self._label}` {{id: e.id}})
-                    ON CREATE SET n.data = e.new_data, n.created_at = e.ts
-                    ON MATCH SET n.data = e.update_data
-                    SET n.updated_at = e.ts
-                    """,
+                    as_literal_query(
+                        f"""
+                        UNWIND $entries AS e
+                        MERGE (n:`{self._label}` {{id: e.id}})
+                        ON CREATE SET n.data = e.new_data, n.created_at = e.ts
+                        ON MATCH SET n.data = e.update_data
+                        SET n.updated_at = e.ts
+                        """
+                    ),
                     entries=entries,
                 )
             ).consume()

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
@@ -19,6 +19,7 @@ from lightrag.base import BaseVectorStorage
 from lightrag.utils import compute_mdhash_id, logger
 
 from ._connection import (
+    as_literal_query,
     close_driver,
     create_index,
     get_database,
@@ -130,12 +131,14 @@ class MemgraphVectorStorage(BaseVectorStorage):
             await self._ensure_vector_index(session)
             await (
                 await session.run(
-                    f"""
-                    UNWIND $entries AS e
-                    MERGE (n:`{self._label}` {{id: e.id}})
-                    ON CREATE SET n.created_at = e.ts
-                    SET n += e.props, n.embedding = e.embedding, n.updated_at = e.ts
-                    """,
+                    as_literal_query(
+                        f"""
+                        UNWIND $entries AS e
+                        MERGE (n:`{self._label}` {{id: e.id}})
+                        ON CREATE SET n.created_at = e.ts
+                        SET n += e.props, n.embedding = e.embedding, n.updated_at = e.ts
+                        """
+                    ),
                     entries=entries,
                 )
             ).consume()
@@ -176,15 +179,17 @@ class MemgraphVectorStorage(BaseVectorStorage):
                 # dropping it.
                 # Index name is a sanitized string literal (not accepted as a query param).
                 result = await session.run(
-                    f"""
-                    CALL vector_search.search("{self._index_name}", $top_k, $embedding)
-                    YIELD node, similarity
-                    WITH collect({{node: node, similarity: similarity}}) AS cand_pairs
-                    UNWIND cand_pairs AS cp
-                    OPTIONAL MATCH (live:`{self._label}`) WHERE live = cp.node
-                    RETURN live.id AS id, cp.similarity AS similarity,
-                           CASE WHEN live IS NULL THEN NULL ELSE properties(live) END AS props
-                    """,
+                    as_literal_query(
+                        f"""
+                        CALL vector_search.search("{self._index_name}", $top_k, $embedding)
+                        YIELD node, similarity
+                        WITH collect({{node: node, similarity: similarity}}) AS cand_pairs
+                        UNWIND cand_pairs AS cp
+                        OPTIONAL MATCH (live:`{self._label}`) WHERE live = cp.node
+                        RETURN live.id AS id, cp.similarity AS similarity,
+                               CASE WHEN live IS NULL THEN NULL ELSE properties(live) END AS props
+                        """
+                    ),
                     top_k=int(top_k),
                     embedding=embedding,
                 )
@@ -225,7 +230,7 @@ class MemgraphVectorStorage(BaseVectorStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"MATCH (n:`{self._label}` {{id: $id}}) RETURN properties(n) AS props",
+                as_literal_query(f"MATCH (n:`{self._label}` {{id: $id}}) RETURN properties(n) AS props"),
                 id=id,
             )
             record = await result.single()
@@ -243,11 +248,13 @@ class MemgraphVectorStorage(BaseVectorStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"""
-                MATCH (n:`{self._label}`)
-                WHERE n.id IN $ids
-                RETURN n.id AS id, properties(n) AS props
-                """,
+                as_literal_query(
+                    f"""
+                    MATCH (n:`{self._label}`)
+                    WHERE n.id IN $ids
+                    RETURN n.id AS id, properties(n) AS props
+                    """
+                ),
                 ids=list(ids),
             )
             records = [record async for record in result]
@@ -266,11 +273,13 @@ class MemgraphVectorStorage(BaseVectorStorage):
         driver = await get_driver()
         async with driver.session(database=get_database(), default_access_mode="READ") as session:
             result = await session.run(
-                f"""
-                MATCH (n:`{self._label}`)
-                WHERE n.id IN $ids AND n.embedding IS NOT NULL
-                RETURN n.id AS id, n.embedding AS embedding
-                """,
+                as_literal_query(
+                    f"""
+                    MATCH (n:`{self._label}`)
+                    WHERE n.id IN $ids AND n.embedding IS NOT NULL
+                    RETURN n.id AS id, n.embedding AS embedding
+                    """
+                ),
                 ids=list(ids),
             )
             vectors = {record["id"]: list(record["embedding"]) async for record in result}
@@ -291,12 +300,14 @@ class MemgraphVectorStorage(BaseVectorStorage):
         async with driver.session(database=get_database()) as session:
             await (
                 await session.run(
-                    f"""
-                    MATCH (n:`{self._label}`)
-                    {where_clause}
-                    SET n.embedding = NULL
-                    DETACH DELETE n
-                    """,
+                    as_literal_query(
+                        f"""
+                        MATCH (n:`{self._label}`)
+                        {where_clause}
+                        SET n.embedding = NULL
+                        DETACH DELETE n
+                        """
+                    ),
                     **params,
                 )
             ).consume()
@@ -323,7 +334,7 @@ class MemgraphVectorStorage(BaseVectorStorage):
             driver = await get_driver()
             async with driver.session(database=get_database()) as session:
                 try:
-                    await (await session.run(f"DROP VECTOR INDEX {self._index_name}")).consume()
+                    await (await session.run(as_literal_query(f"DROP VECTOR INDEX {self._index_name}"))).consume()
                 except Exception as e:
                     logger.debug(f"[{self.workspace}] Dropping vector index {self._index_name} skipped: {e}")
             self._index_ready = False

--- a/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
+++ b/integrations/lightrag-memgraph/src/lightrag_memgraph/vector_impl.py
@@ -141,7 +141,7 @@ class MemgraphVectorStorage(BaseVectorStorage):
             ).consume()
         logger.debug(f"[{self.workspace}] Upserted {len(entries)} vectors to {self.namespace}")
 
-    async def query(self, query: str, top_k: int, query_embedding: list[float] = None) -> list[dict[str, Any]]:
+    async def query(self, query: str, top_k: int, query_embedding: list[float] | None = None) -> list[dict[str, Any]]:
         """Vector-search this namespace and return up to ``top_k`` live results.
 
         By design, Memgraph's native vector index operates at ``READ_UNCOMMITTED``

--- a/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
+++ b/integrations/lightrag-memgraph/tests/test_integration_memgraph.py
@@ -35,6 +35,7 @@ from lightrag.utils import EmbeddingFunc
 
 from lightrag_memgraph import MemgraphLightRAGWrapper
 from lightrag_memgraph._connection import (
+    as_literal_query,
     close_driver,
     get_database,
     get_driver,
@@ -493,7 +494,8 @@ async def test_vector_query_logs_and_excludes_stale_candidates(
         # DETACH DELETE leaves a stale entry in the native vector index.
         driver = await get_driver()
         async with driver.session(database=get_database()) as session:
-            await (await session.run(f"MATCH (n:`{store._label}` {{id: 'v-cat'}}) DETACH DELETE n")).consume()
+            query = as_literal_query(f"MATCH (n:`{store._label}` {{id: 'v-cat'}}) DETACH DELETE n")
+            await (await session.run(query)).consume()
 
         # lightrag's logger has propagate=False, so caplog.at_level (which only
         # relies on root-logger propagation) never sees its records; attach the
@@ -612,9 +614,11 @@ async def test_wrapper_defaults_embedding_func_to_working_memgraph_sentence_embe
         # underlying callable, unwrapping the EmbeddingFunc nesting), so identity
         # doesn't survive the round trip -- the declared model/dim and, most
         # importantly, actual behaviour do.
-        assert rag.embedding_func.model_name == memgraph_sentence_embed.model_name
-        assert rag.embedding_func.embedding_dim == DEFAULT_EMBEDDING_DIM
-        vectors = await rag.embedding_func(["hello world", "graph databases are fast"])
+        embedding_func = rag.embedding_func
+        assert embedding_func is not None
+        assert embedding_func.model_name == memgraph_sentence_embed.model_name
+        assert embedding_func.embedding_dim == DEFAULT_EMBEDDING_DIM
+        vectors = await embedding_func(["hello world", "graph databases are fast"])
         assert vectors.shape == (2, DEFAULT_EMBEDDING_DIM)
     finally:
         if wrapper.rag is not None:

--- a/integrations/mcp-memgraph/src/mcp_memgraph/servers/memgraph_experimental.py
+++ b/integrations/mcp-memgraph/src/mcp_memgraph/servers/memgraph_experimental.py
@@ -9,7 +9,7 @@ This server provides autonomous adapting GraphRAG capabilities that:
 
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from fastmcp import Context, FastMCP
 from starlette.responses import JSONResponse
@@ -248,7 +248,10 @@ Reason: Vector search operation
         if isinstance(response, str):
             response_text = response.strip()
         elif hasattr(response, "text"):
-            response_text = response.text.strip()
+            # SamplingResult.text is `str | None`; a missing text block is left to
+            # raise here (as before this was type-annotated) and be caught by the
+            # except clauses below, which already handle a failed/absent response.
+            response_text = cast("str", response.text).strip()
         else:
             # Try to get content from response object
             response_text = str(response).strip()
@@ -378,7 +381,10 @@ Respond with ONLY the Cypher query, no explanation or markdown.
         if isinstance(response, str):
             query_text = response.strip()
         elif hasattr(response, "text"):
-            query_text = response.text.strip()
+            # SamplingResult.text is `str | None`; a missing text block is left to
+            # raise here (as before this was type-annotated) and be caught by the
+            # except clause below, which falls back to a manually generated query.
+            query_text = cast("str", response.text).strip()
         else:
             query_text = str(response).strip()
 

--- a/integrations/mcp-memgraph/tests/test_server.py
+++ b/integrations/mcp-memgraph/tests/test_server.py
@@ -63,11 +63,11 @@ async def test_mcp_client():
     client = MCPClient()
     try:
         await client.connect_to_server(server_script_path)
+        assert client.session is not None, "Session should be initialized"
         response = await client.session.list_tools()
         tools = response.tools
         print("\nConnected to server with tools:", [tool.name for tool in tools])
 
-        assert client.session is not None, "Session should be initialized"
         assert client.stdio is not None, "Stdio transport should be initialized"
         assert client.write is not None, "Write transport should be initialized"
 
@@ -255,6 +255,7 @@ async def test_tools_and_resources():
     client = MCPClient()
     try:
         await client.connect_to_server(server_script_path)
+        assert client.session is not None, "Session should be initialized"
 
         # TODO(@antejavor): Add this dynamically.
         expected_tools = [

--- a/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
@@ -1,6 +1,6 @@
 import os
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 from neo4j import AsyncGraphDatabase, GraphDatabase
 
@@ -160,8 +160,12 @@ class Memgraph:
         if params is None:
             params = {}
         try:
+            # neo4j's driver stubs require query_: LiteralString | Query, a hint aimed at
+            # discouraging unparameterized query construction. This is a generic passthrough
+            # executor that legitimately accepts caller-built Cypher text (injection is
+            # already guarded by `params`), which a `str` can never satisfy statically.
             records, _, _ = self.driver.execute_query(
-                query,
+                cast("Any", query),
                 parameters_=params,
                 database_=self.database,
             )
@@ -172,7 +176,7 @@ class Memgraph:
 
         # fallback to allow implicit transactions
         with self.driver.session(database=self.database) as session:
-            return serialize_records(session.run(query, params))
+            return serialize_records(session.run(cast("Any", query), params))
 
     def close(self) -> None:
         """
@@ -258,8 +262,12 @@ class AsyncMemgraph:
         if params is None:
             params = {}
         try:
+            # See the matching comment in Memgraph.query: query_ is typed LiteralString |
+            # Query in the driver stubs, but this is a generic passthrough executor that
+            # legitimately accepts caller-built Cypher text -- a `str` can never satisfy
+            # LiteralString statically, regardless of how it was validated at runtime.
             records, _, _ = await self.driver.execute_query(
-                query,
+                cast("Any", query),
                 parameters_=params,
                 database_=self.database,
             )
@@ -270,7 +278,7 @@ class AsyncMemgraph:
 
         # fallback to allow implicit transactions
         async with self.driver.session(database=self.database) as session:
-            result = await session.run(query, params)
+            result = await session.run(cast("Any", query), params)
             records = [record async for record in result]
             return serialize_records(records)
 

--- a/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/api/memgraph.py
@@ -87,10 +87,10 @@ class Memgraph:
 
     def __init__(
         self,
-        url: str = None,
-        username: str = None,
-        password: str = None,
-        database: str = None,
+        url: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        database: str | None = None,
         driver_config: dict | None = None,
         user_agent: str | None = None,
     ):
@@ -140,7 +140,7 @@ class Memgraph:
                 f"Could not connect to Memgraph database. Authentication failed for user '{username}'"
             ) from e
 
-    def query(self, query: str, params: dict = None) -> list[dict[str, Any]]:
+    def query(self, query: str, params: dict | None = None) -> list[dict[str, Any]]:
         """
         Execute a Cypher query and return type-preserving result rows.
 
@@ -193,10 +193,10 @@ class AsyncMemgraph:
 
     def __init__(
         self,
-        url: str = None,
-        username: str = None,
-        password: str = None,
-        database: str = None,
+        url: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        database: str | None = None,
         driver_config: dict | None = None,
         user_agent: str | None = None,
     ):
@@ -238,7 +238,7 @@ class AsyncMemgraph:
         """
         await self.driver.verify_connectivity()
 
-    async def query(self, query: str, params: dict = None) -> list[dict[str, Any]]:
+    async def query(self, query: str, params: dict | None = None) -> list[dict[str, Any]]:
         """
         Execute a Cypher query and return type-preserving result rows.
 

--- a/memgraph-toolbox/src/memgraph_toolbox/api/tool.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/api/tool.py
@@ -17,7 +17,7 @@ class BaseTool(ABC):
         self.input_schema = input_schema
 
     @abstractmethod
-    def call(self, arguments: dict[str, Any]) -> list[Any]:
+    def call(self, arguments: dict[str, Any]) -> list[Any] | dict[str, Any]:
         """
         Execute the tool with the provided arguments.
 
@@ -25,7 +25,9 @@ class BaseTool(ABC):
             arguments (dict): A dictionary of arguments as defined by the input schema.
 
         Returns:
-            List containing one or more output values.
+            Either a list containing one or more output values, or -- for tools whose
+            "found" result is naturally a single object (e.g. schema lookups) -- a bare
+            dict.
         """
         pass
 

--- a/memgraph-toolbox/src/memgraph_toolbox/client/mcp_prompt.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/client/mcp_prompt.py
@@ -19,9 +19,9 @@ logger = logging.getLogger(__name__)
 async def prompt_with_tools(
     prompt: str,
     tool_selection_model_name: str = "openai/gpt-4o",
-    tool_selection_system_messages: list[dict[str, str]] = None,
+    tool_selection_system_messages: list[dict[str, str]] | None = None,
     response_model_name: str = "openai/gpt-4o",
-    response_system_messages: list[dict[str, str]] = None,
+    response_system_messages: list[dict[str, str]] | None = None,
     mcp_server_params: StdioServerParameters | None = None,
 ):
     """

--- a/memgraph-toolbox/src/memgraph_toolbox/client/mcp_prompt.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/client/mcp_prompt.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sys
+from typing import cast
 
 try:
     from litellm import acompletion, experimental_mcp_client
@@ -113,10 +114,13 @@ async def prompt_with_tools(
                     result = await session.call_tool(name=tc["function"]["name"], arguments=arguments)
                     if hasattr(result, "content") and result.content:
                         if isinstance(result.content, list):
-                            content_text = []
+                            content_text: list[str] = []
                             for content_item in result.content:
                                 if hasattr(content_item, "text"):
-                                    content_text.append(content_item.text)
+                                    # hasattr narrows to an attribute typed `object`; of the
+                                    # mcp ContentBlock union members only TextContent has
+                                    # `.text`, and it's declared `str` there.
+                                    content_text.append(cast("str", content_item.text))
                                 elif isinstance(content_item, str):
                                     content_text.append(content_item)
                                 else:

--- a/memgraph-toolbox/src/memgraph_toolbox/evals/coherence.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/evals/coherence.py
@@ -111,7 +111,10 @@ class CoherenceEmbeddingsBasedMetric(BaseMetric):
             Array of embeddings with shape (n_sentences, embedding_dim)
         """
         # TODO(gitbuda): This should use the utils.embeddings because GPU could be used.
-        return self.model.encode(sentences)
+        # convert_to_numpy is already the model's default; pinning it explicitly picks the
+        # np.ndarray-returning overload instead of leaving overload resolution to fall
+        # through to a Tensor-returning one.
+        return self.model.encode(sentences, convert_to_numpy=True)
 
     def _compute_cosine_similarity(self, embeddings: np.ndarray) -> list[float]:
         """Compute cosine similarity between consecutive embeddings.
@@ -221,7 +224,9 @@ class CoherenceEmbeddingsBasedMetric(BaseMetric):
         Returns:
             True if score meets threshold, False otherwise
         """
-        return self.success
+        # self.success is bool | None (None until measure() has run); treat "never measured"
+        # as "not successful" rather than lying about the return type or leaking None.
+        return self.success or False
 
     @property
     def __name__(self) -> str:

--- a/memgraph-toolbox/src/memgraph_toolbox/tools/schema.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/tools/schema.py
@@ -33,7 +33,7 @@ class NodeSchemaTool(BaseTool):
         )
         self.db = db
 
-    def call(self, arguments: dict[str, Any]) -> list[dict[str, Any]]:
+    def call(self, arguments: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]]:
         try:
             node_labels = arguments["node_labels"]
             schema = _get_schema(self.db)
@@ -96,7 +96,7 @@ class RelationshipSchemaTool(BaseTool):
         )
         self.db = db
 
-    def call(self, arguments: dict[str, Any]) -> list[dict[str, Any]]:
+    def call(self, arguments: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]]:
         try:
             edge_type = arguments["relationship_type"]
             start_node_labels = arguments["start_node_labels"]
@@ -138,7 +138,7 @@ class EnumSchemaTool(BaseTool):
         )
         self.db = db
 
-    def call(self, arguments: dict[str, Any]) -> list[dict[str, Any]]:
+    def call(self, arguments: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]]:
         try:
             enum_name = arguments["enum_name"]
             schema = _get_schema(self.db)

--- a/memgraph-toolbox/src/memgraph_toolbox/utils/serialization.py
+++ b/memgraph-toolbox/src/memgraph_toolbox/utils/serialization.py
@@ -2,6 +2,7 @@
 Serialization utilities for Neo4j date/time types.
 """
 
+from collections.abc import Iterable
 from typing import Any
 
 from neo4j.graph import Node, Path, Relationship
@@ -145,11 +146,15 @@ def serialize_value(value: Any) -> Any:
     return serialize_neo4j_types(value)
 
 
-def serialize_records(records: list[Any]) -> list[dict]:
+def serialize_records(records: Iterable[Any]) -> list[dict]:
     """Serialize raw neo4j records into type-preserving rows (one dict per row).
 
     Each row keeps its ``RETURN`` column names; each value is serialized with
     :func:`serialize_value`, so nodes/edges/paths retain their identity instead
     of collapsing to bare property maps.
+
+    Accepts anything iterable of records (a plain ``list``, or a neo4j
+    ``Result``/``AsyncResult`` consumed lazily) -- the body only ever iterates
+    once and calls ``.items()`` per record, it never needs list operations.
     """
     return [{key: serialize_value(value) for key, value in record.items()} for record in records]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ members = [
 [tool.ty.environment]
 python-version = "3.10"
 
+[tool.ty.src]
+# Notebook cells reference variables from earlier cells -- same reasoning as
+# the ruff F821 per-file-ignore for *.ipynb below; a static checker can't
+# model notebook cell execution order.
+exclude = ["**/*.ipynb"]
+
 [tool.ruff]
 target-version = "py310"
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ members = [
     "context-graph/sessions-graph",
 ]
 
+[tool.ty.environment]
+python-version = "3.10"
+
 [tool.ruff]
 target-version = "py310"
 line-length = 120
@@ -79,7 +82,6 @@ ignore = [
     "N812",    # lowercase imported as non-lowercase — allows aliasing conventions like `import x as X`
     "N815",    # mixed-case variable in class scope — graph/DB field names follow external conventions
     "RUF001",  # ambiguous unicode character in string — false positives on intentional unicode content
-    "RUF013",  # implicit Optional — affects public API signatures, defer to a dedicated typing cleanup
 ]
 
 [tool.ruff.lint.isort]

--- a/unstructured2graph/src/unstructured2graph/__init__.py
+++ b/unstructured2graph/src/unstructured2graph/__init__.py
@@ -31,7 +31,7 @@ from .memgraph import (
 from .ontology import DEFAULT_ONTOLOGY, DEFAULT_ONTOLOGY_PATH, EntityType, Ontology, load_ontology
 
 try:
-    __version__ = metadata.version(__package__)
+    __version__ = metadata.version(__package__ or __name__)
 except metadata.PackageNotFoundError:
     # Case where package metadata is not available.
     __version__ = ""

--- a/unstructured2graph/src/unstructured2graph/loaders.py
+++ b/unstructured2graph/src/unstructured2graph/loaders.py
@@ -5,7 +5,7 @@ import statistics
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from unstructured.chunking.title import chunk_by_title
 from unstructured.partition.auto import partition
@@ -43,7 +43,7 @@ class ChunkedDocument:
 def parse_source(
     source: str | Path,
     partition_kwargs: dict[str, Any] | None = None,
-) -> list[str]:
+) -> list[Chunk]:
     """
     Parse a source file or URL using the unstructured library. The unstructured
     library supports many types of data sources and various parsing options.
@@ -155,7 +155,9 @@ def _resolve_entity_workspace(
     if only_chunks or entity_workspace is not None:
         return entity_workspace
     try:
-        return lightrag_wrapper.get_lightrag().chunk_entity_relation_graph.workspace
+        # only_chunks is False here, so callers (from_texts/from_unstructured)
+        # have already raised ValueError if lightrag_wrapper were None.
+        return cast("MemgraphLightRAGWrapper", lightrag_wrapper).get_lightrag().chunk_entity_relation_graph.workspace
     except Exception as e:
         logger.warning(f"Could not auto-derive LightRAG entity workspace, falling back to 'base': {e}")
         return "base"
@@ -232,14 +234,20 @@ async def _ingest_chunks(
             link_nodes_in_order(memgraph, "Chunk", "hash", relationships, "NEXT")
 
     if not only_chunks:
+        # Both casts are safe here per this function's documented precondition:
+        # callers already raised ValueError for a None lightrag_wrapper, and
+        # already resolved entity_workspace (see _resolve_entity_workspace)
+        # before calling _ingest_chunks with only_chunks=False.
+        wrapper = cast("MemgraphLightRAGWrapper", lightrag_wrapper)
+        resolved_workspace = cast("str", entity_workspace)
         for chunk in chunks:
-            await lightrag_wrapper.ainsert(input=chunk.text, file_paths=[chunk.hash])
-        connect_chunks_to_entities(memgraph, "Chunk", entity_workspace)
+            await wrapper.ainsert(input=chunk.text, file_paths=[chunk.hash])
+        connect_chunks_to_entities(memgraph, "Chunk", resolved_workspace)
         if enforce_ontology:
             ontology = load_ontology(ontology_path) if ontology_path else DEFAULT_ONTOLOGY
-            promote_entity_types_to_labels(memgraph, entity_workspace, ontology)
+            promote_entity_types_to_labels(memgraph, resolved_workspace, ontology)
         elif promote_labels:
-            promote_all_entity_types_to_labels(memgraph, entity_workspace)
+            promote_all_entity_types_to_labels(memgraph, resolved_workspace)
 
     return chunks
 

--- a/unstructured2graph/src/unstructured2graph/loaders.py
+++ b/unstructured2graph/src/unstructured2graph/loaders.py
@@ -3,6 +3,7 @@ import logging
 import os
 import statistics
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -108,7 +109,7 @@ def parse_text(
 
 
 def make_chunks(
-    sources: list[str | Path],
+    sources: Sequence[str | Path],
     partition_kwargs: dict[str, Any] | None = None,
 ) -> list[ChunkedDocument]:
     """
@@ -335,7 +336,7 @@ async def from_texts(
 
 
 async def from_unstructured(
-    sources: list[str | Path],
+    sources: Sequence[str | Path],
     memgraph: Memgraph,
     lightrag_wrapper: MemgraphLightRAGWrapper | None = None,
     only_chunks: bool = False,

--- a/uv.lock
+++ b/uv.lock
@@ -3283,7 +3283,6 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "isort" },
-    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -3295,7 +3294,6 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "lightrag-hku", specifier = "==1.5.4" },
     { name = "memgraph-toolbox", editable = "memgraph-toolbox" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.22.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -4342,51 +4340,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/f9/8e360bdfc3c44e267e7e046f0e0b9922766da92da26959a6963f597e6bb5/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4fd8189ee293a09f30f4931408f40c28ccd42d9de4f66595f8814879339378bc", size = 161811, upload-time = "2025-11-14T09:51:01.289Z" },
     { url = "https://files.pythonhosted.org/packages/f9/31/97649680595b1096803d877ababb9a67c07f4378f177ec885eea28b9db6d/murmurhash-1.0.15-cp314-cp314t-win_amd64.whl", hash = "sha256:66395b1388f7daa5103db92debe06842ae3be4c0749ef6db68b444518666cdcc", size = 29817, upload-time = "2025-11-14T09:51:02.493Z" },
     { url = "https://files.pythonhosted.org/packages/76/66/4fce8755f25d77324401886c00017c556be7ca3039575b94037aff905385/murmurhash-1.0.15-cp314-cp314t-win_arm64.whl", hash = "sha256:c22e56c6a0b70598a66e456de5272f76088bc623688da84ef403148a6d41851d", size = 26219, upload-time = "2025-11-14T09:51:03.563Z" },
-]
-
-[[package]]
-name = "mypy"
-version = "1.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/6f/657961a0743cff32e6c0611b63ff1c1970a0b482ace35b069203bf705187/mypy-1.18.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eab0cf6294dafe397c261a75f96dc2c31bffe3b944faa24db5def4e2b0f77c", size = 12807973, upload-time = "2025-09-19T00:10:35.282Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e9/420822d4f661f13ca8900f5fa239b40ee3be8b62b32f3357df9a3045a08b/mypy-1.18.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a780ca61fc239e4865968ebc5240bb3bf610ef59ac398de9a7421b54e4a207e", size = 11896527, upload-time = "2025-09-19T00:10:55.791Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/73/a05b2bbaa7005f4642fcfe40fb73f2b4fb6bb44229bd585b5878e9a87ef8/mypy-1.18.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448acd386266989ef11662ce3c8011fd2a7b632e0ec7d61a98edd8e27472225b", size = 12507004, upload-time = "2025-09-19T00:11:05.411Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/01/f6e4b9f0d031c11ccbd6f17da26564f3a0f3c4155af344006434b0a05a9d/mypy-1.18.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9e171c465ad3901dc652643ee4bffa8e9fef4d7d0eece23b428908c77a76a66", size = 13245947, upload-time = "2025-09-19T00:10:46.923Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/97/19727e7499bfa1ae0773d06afd30ac66a58ed7437d940c70548634b24185/mypy-1.18.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:592ec214750bc00741af1f80cbf96b5013d81486b7bb24cb052382c19e40b428", size = 13499217, upload-time = "2025-09-19T00:09:39.472Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/4f/90dc8c15c1441bf31cf0f9918bb077e452618708199e530f4cbd5cede6ff/mypy-1.18.2-cp310-cp310-win_amd64.whl", hash = "sha256:7fb95f97199ea11769ebe3638c29b550b5221e997c63b14ef93d2e971606ebed", size = 9766753, upload-time = "2025-09-19T00:10:49.161Z" },
-    { url = "https://files.pythonhosted.org/packages/88/87/cafd3ae563f88f94eec33f35ff722d043e09832ea8530ef149ec1efbaf08/mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:807d9315ab9d464125aa9fcf6d84fde6e1dc67da0b6f80e7405506b8ac72bc7f", size = 12731198, upload-time = "2025-09-19T00:09:44.857Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e0/1e96c3d4266a06d4b0197ace5356d67d937d8358e2ee3ffac71faa843724/mypy-1.18.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bb00de1778caf4db739c6e83919c1d85a448f71979b6a0edd774ea8399341", size = 11817879, upload-time = "2025-09-19T00:09:47.131Z" },
-    { url = "https://files.pythonhosted.org/packages/72/ef/0c9ba89eb03453e76bdac5a78b08260a848c7bfc5d6603634774d9cd9525/mypy-1.18.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1379451880512ffce14505493bd9fe469e0697543717298242574882cf8cdb8d", size = 12427292, upload-time = "2025-09-19T00:10:22.472Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/52/ec4a061dd599eb8179d5411d99775bec2a20542505988f40fc2fee781068/mypy-1.18.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1331eb7fd110d60c24999893320967594ff84c38ac6d19e0a76c5fd809a84c86", size = 13163750, upload-time = "2025-09-19T00:09:51.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5f/2cf2ceb3b36372d51568f2208c021870fe7834cf3186b653ac6446511839/mypy-1.18.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ca30b50a51e7ba93b00422e486cbb124f1c56a535e20eff7b2d6ab72b3b2e37", size = 13351827, upload-time = "2025-09-19T00:09:58.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/7d/2697b930179e7277529eaaec1513f8de622818696857f689e4a5432e5e27/mypy-1.18.2-cp311-cp311-win_amd64.whl", hash = "sha256:664dc726e67fa54e14536f6e1224bcfce1d9e5ac02426d2326e2bb4e081d1ce8", size = 9757983, upload-time = "2025-09-19T00:10:09.071Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273, upload-time = "2025-09-19T00:10:58.321Z" },
-    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910, upload-time = "2025-09-19T00:10:20.043Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585, upload-time = "2025-09-19T00:10:33.005Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562, upload-time = "2025-09-19T00:10:11.51Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296, upload-time = "2025-09-19T00:10:06.568Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828, upload-time = "2025-09-19T00:10:28.203Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/04/7f462e6fbba87a72bc8097b93f6842499c428a6ff0c81dd46948d175afe8/mypy-1.18.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:07b8b0f580ca6d289e69209ec9d3911b4a26e5abfde32228a288eb79df129fcc", size = 12898728, upload-time = "2025-09-19T00:10:01.33Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5b/61ed4efb64f1871b41fd0b82d29a64640f3516078f6c7905b68ab1ad8b13/mypy-1.18.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ed4482847168439651d3feee5833ccedbf6657e964572706a2adb1f7fa4dfe2e", size = 11910758, upload-time = "2025-09-19T00:10:42.607Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/46/d297d4b683cc89a6e4108c4250a6a6b717f5fa96e1a30a7944a6da44da35/mypy-1.18.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3ad2afadd1e9fea5cf99a45a822346971ede8685cc581ed9cd4d42eaf940986", size = 12475342, upload-time = "2025-09-19T00:11:00.371Z" },
-    { url = "https://files.pythonhosted.org/packages/83/45/4798f4d00df13eae3bfdf726c9244bcb495ab5bd588c0eed93a2f2dd67f3/mypy-1.18.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a431a6f1ef14cf8c144c6b14793a23ec4eae3db28277c358136e79d7d062f62d", size = 13338709, upload-time = "2025-09-19T00:11:03.358Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/09/479f7358d9625172521a87a9271ddd2441e1dab16a09708f056e97007207/mypy-1.18.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7ab28cc197f1dd77a67e1c6f35cd1f8e8b73ed2217e4fc005f9e6a504e46e7ba", size = 13529806, upload-time = "2025-09-19T00:10:26.073Z" },
-    { url = "https://files.pythonhosted.org/packages/71/cf/ac0f2c7e9d0ea3c75cd99dff7aec1c9df4a1376537cb90e4c882267ee7e9/mypy-1.18.2-cp313-cp313-win_amd64.whl", hash = "sha256:0e2785a84b34a72ba55fb5daf079a1003a34c05b22238da94fcae2bbe46f3544", size = 9833262, upload-time = "2025-09-19T00:10:40.035Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0c/7d5300883da16f0063ae53996358758b2a2df2a09c72a5061fa79a1f5006/mypy-1.18.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:62f0e1e988ad41c2a110edde6c398383a889d95b36b3e60bcf155f5164c4fdce", size = 12893775, upload-time = "2025-09-19T00:10:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/50/df/2cffbf25737bdb236f60c973edf62e3e7b4ee1c25b6878629e88e2cde967/mypy-1.18.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8795a039bab805ff0c1dfdb8cd3344642c2b99b8e439d057aba30850b8d3423d", size = 11936852, upload-time = "2025-09-19T00:10:51.631Z" },
-    { url = "https://files.pythonhosted.org/packages/be/50/34059de13dd269227fb4a03be1faee6e2a4b04a2051c82ac0a0b5a773c9a/mypy-1.18.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ca1e64b24a700ab5ce10133f7ccd956a04715463d30498e64ea8715236f9c9c", size = 12480242, upload-time = "2025-09-19T00:11:07.955Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/040983fad5132d85914c874a2836252bbc57832065548885b5bb5b0d4359/mypy-1.18.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d924eef3795cc89fecf6bedc6ed32b33ac13e8321344f6ddbf8ee89f706c05cb", size = 13326683, upload-time = "2025-09-19T00:09:55.572Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/ba/89b2901dd77414dd7a8c8729985832a5735053be15b744c18e4586e506ef/mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075", size = 13514749, upload-time = "2025-09-19T00:10:44.827Z" },
-    { url = "https://files.pythonhosted.org/packages/25/bc/cc98767cffd6b2928ba680f3e5bc969c4152bf7c2d83f92f5a504b92b0eb/mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf", size = 9982959, upload-time = "2025-09-19T00:10:37.344Z" },
-    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes out the core ask in #313: standardizes and enforces Astral's `ty` type checker across the whole `uv` workspace. `uvx ty check .` now reports **"All checks passed!"** repo-wide, and `ruff check .` / `ruff format --check .` remain clean.

- Fixed all 17 repo-wide implicit-Optional (`RUF013`) violations and dropped the now-obsolete ruff ignore.
- Added `[tool.ty]` config (target Python version, notebook exclusion matching the existing ruff `F821` precedent for `*.ipynb`).
- Removed `lightrag-memgraph`'s dormant, never-wired-in `mypy` dev-dependency and config.
- Fixed every `ty` diagnostic across all 10 workspace packages (260 → 0), including the specific `**kwargs`-splat pattern originally flagged in #313 (confirmed real, not a false positive) and one real cross-package regression caught during review (memgraph-toolbox's corrected tool-return-type surfaced a stale type in langchain-memgraph's wrapper).
- Investigated the `ActionsGraph.__init__` diagnostic named in #313 and fixed it via a closed `TypedDict`, same pattern applied everywhere else this exact `**kwargs`-splat-vs-typed-parameter shape occurred.

Work was parallelized across per-package background agents, then independently re-verified: every package's diff was reviewed, `ty check`/`ruff` re-run independently, and every package's test suite was actually executed against a disposable, isolated Memgraph instance (not any shared/CI container). One pre-existing test failure was found in `lightrag-memgraph` (`test_vector_query_logs_and_excludes_stale_candidates`) and proven — via diff against `main` — to be unrelated to this PR (the function body is byte-identical); left as-is, out of scope here.

## Test plan

- [x] `uvx ty check .` — all checks passed
- [x] `ruff check .` / `ruff format --check .` — all checks passed
- [x] Every package's test suite run against an isolated Memgraph instance: `agent-context-graph` 111 passed, `mcp-memgraph` 45 passed, `memgraph-toolbox` 52 passed, `actions-graph` 53 passed, `langchain-memgraph` 36 passed, `lightrag-memgraph` 41 passed (+1 pre-existing unrelated failure), `skills-graph` 64 passed/1 skipped (no LLM key), `sessions-graph` 54 passed/1 skipped, `unstructured2graph` 62 passed/6 skipped, `sql2graph` 3 passed
- [ ] CI wiring (a per-package typecheck job) intentionally **not** included here — tracked as remaining scope in #313, since it's a separate, lower-risk follow-up once this baseline is merged