### PR TITLE
ci: wire ty into lint.yaml as a blocking typecheck job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,3 +29,31 @@ jobs:
 
       - name: Ruff format check
         run: ruff format --check .
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: python -m pip install uv
+
+      - name: Install ty
+        run: uv tool install ty==0.0.75
+
+      - name: Sync workspace
+        # ty resolves imports through installed packages (unlike ruff, which is
+        # purely syntactic), and cross-package imports span the whole workspace
+        # (e.g. agent-context-graph optionally imports skills-graph/actions-graph/
+        # sessions-graph) -- a single full sync, not a per-package one, is what
+        # lets ty see all of it and avoid spurious unresolved-import diagnostics.
+        run: uv sync --all-packages --all-extras
+
+      - name: Type check
+        run: ty check .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,19 +115,22 @@ own real Claude Code session — see `./scripts/dev-memgraph.sh --help`.
 ## Type checking
 
 This repo standardizes on [`ty`](https://docs.astral.sh/ty/) (Astral's type
-checker — same vendor as `uv`/`ruff`), not `mypy` or `pyright`. **Not yet
-enforced in CI** — tracked in
-[#313](https://github.com/memgraph/ai-toolkit/issues/313); annotate as you
-touch code in the meantime rather than waiting for enforcement to land.
-`ty` needs a package's own installed dependencies to resolve imports (like
-`pytest`, unlike `ruff`), so check one package at a time:
+checker — same vendor as `uv`/`ruff`), not `mypy` or `pyright`. **Enforced in
+CI**, blocking: `.github/workflows/lint.yaml`'s `typecheck` job. `ty` resolves
+imports through installed packages (unlike `ruff`, which is purely
+syntactic), and cross-package imports span the whole workspace (e.g.
+`agent-context-graph` optionally imports `skills-graph`/`actions-graph`/
+`sessions-graph`), so CI syncs the full workspace before checking:
+```bash
+uv sync --all-packages --all-extras
+ty check .
+```
+For a quick local check of just what you touched, without a full sync, you
+can still point `ty` at one package's own venv — but expect spurious
+unresolved-import diagnostics for anything that imports across packages:
 ```bash
 uvx ty check <package>/src --python .venv
 ```
-`integrations/lightrag-memgraph/pyproject.toml` still carries a dormant,
-never-wired-in `mypy` dev dependency and `[tool.mypy]` block predating this
-decision — don't treat it as a second standard; it's slated for removal in
-#313.
 
 ## Testing policy: prefer real Memgraph over mocks
 


### PR DESCRIPTION
## Summary

Closes #313.

- Adds a `typecheck` job to `.github/workflows/lint.yaml` (already named "Lint and type check", never actually running one) — a separate job from `lint` so ruff's fast feedback isn't gated behind the much heavier full-workspace sync `ty` needs.
- `ty` resolves imports through installed packages, unlike ruff's purely syntactic checks, and cross-package imports span the whole workspace (`agent-context-graph` optionally imports `skills-graph`/`actions-graph`/`sessions-graph`) — so the job runs one `uv sync --all-packages --all-extras` before checking, rather than per-package syncs that would produce spurious unresolved-import diagnostics.
- Pins `ty==0.0.75`, matching `ruff`'s own exact-pin convention in the same file — `ty` is still pre-1.0 and evolves fast; pinning locks in the exact version #314's fixes were verified against.
- Updates `AGENTS.md`'s Type checking section: drops the "not yet enforced" framing and the now-stale note about `lightrag-memgraph`'s dormant `mypy` config (removed in #314), documents the full-sync command CI actually runs.

## Test plan

- [x] Verified locally end-to-end exactly as CI will run it: `uv tool install ty==0.0.75` → `uv sync --all-packages --all-extras` → `ty check .` → all checks passed
- [x] `.github/workflows/lint.yaml` validated as parseable YAML (also passes the repo's own pre-commit `check-yaml` hook)
- [ ] CI itself, on this PR