### PR TITLE
agent-context-graph: use stable Codex hooks feature flag

### DIFF
--- a/context-graph/agent-context-graph/src/agent_context_graph/adapters/codex.py
+++ b/context-graph/agent-context-graph/src/agent_context_graph/adapters/codex.py
@@ -218,7 +218,7 @@ def init(project_dir: Path, connectors: list[str], **kwargs: Any) -> None:
         hook_command = shlex.join(command_parts)
 
     codex_dir.mkdir(parents=True, exist_ok=True)
-    config_path.write_text("[features]\ncodex_hooks = true\n", encoding="utf-8")
+    config_path.write_text("[features]\nhooks = true\n", encoding="utf-8")
     hooks_path.write_text(
         json.dumps({"hooks": build_hooks_config(hook_command, timeout=timeout)}, indent=2) + "\n",
         encoding="utf-8",

--- a/context-graph/agent-context-graph/tests/test_hook_cli.py
+++ b/context-graph/agent-context-graph/tests/test_hook_cli.py
@@ -292,7 +292,7 @@ def test_top_level_cli_setup_aliases_codex_init(tmp_path, monkeypatch):
 
     assert top_level_main(["setup", "codex", "--project-dir", str(tmp_path)]) == 0
 
-    assert (tmp_path / ".codex" / "config.toml").read_text() == "[features]\ncodex_hooks = true\n"
+    assert (tmp_path / ".codex" / "config.toml").read_text() == "[features]\nhooks = true\n"
 
 
 def test_generic_cli_requires_runtime(capsys):
@@ -318,7 +318,7 @@ def test_init_codex_writes_private_config(tmp_path, capsys):
         == 0
     )
 
-    assert (tmp_path / ".codex" / "config.toml").read_text() == "[features]\ncodex_hooks = true\n"
+    assert (tmp_path / ".codex" / "config.toml").read_text() == "[features]\nhooks = true\n"
     hooks = json.loads((tmp_path / ".codex" / "hooks.json").read_text())
     command = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
     assert command == "/venv/bin/agent-context-graph hook run codex --connector skills-graph"
@@ -477,4 +477,4 @@ def test_init_codex_force_overwrites(tmp_path):
 
     assert main(["init", "codex", "--project-dir", str(tmp_path), "--force"]) == 0
 
-    assert (codex_dir / "config.toml").read_text() == "[features]\ncodex_hooks = true\n"
+    assert (codex_dir / "config.toml").read_text() == "[features]\nhooks = true\n"


### PR DESCRIPTION
## Summary
- replace deprecated `[features].codex_hooks` with stable `[features].hooks`
- update Codex hook initialization regression tests

## Validation
- `uv run --package agent-context-graph --extra test pytest context-graph/agent-context-graph/tests/test_hook_cli.py` (23 passed)